### PR TITLE
keeps our own stack-trace in `JETInterpreter.stackframes` field

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -229,17 +229,17 @@ is_constant_propagated(frame::InferenceState) = CC.any(frame.result.overridden_b
 istoplevel(linfo::MethodInstance) = linfo.def == __toplevel__
 istoplevel(sv::InferenceState)    = istoplevel(sv.linfo)
 
-prewalk_inf_frame(@nospecialize(f), ::Nothing) = return
-function prewalk_inf_frame(@nospecialize(f), frame::InferenceState)
-    ret = f(frame)
-    prewalk_inf_frame(f, frame.parent)
+function prewalk_inf_frame(@nospecialize(f), stackframes::Vector{InferenceState}, index = length(stackframes))
+    iszero(index) && return
+    ret = f(@inbounds stackframes[index])
+    prewalk_inf_frame(f, stackframes, index-1)
     return ret
 end
 
-postwalk_inf_frame(@nospecialize(f), ::Nothing) = return
-function postwalk_inf_frame(@nospecialize(f), frame::InferenceState)
-    postwalk_inf_frame(f, frame.parent)
-    return f(frame)
+function postwalk_inf_frame(@nospecialize(f), stackframes::Vector{InferenceState}, index = length(stackframes))
+    iszero(index) && return
+    postwalk_inf_frame(f, stackframes, index-1)
+    return f(@inbounds stackframes[index])
 end
 
 # NOTE: these methods assume `frame` is not inlined

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -370,12 +370,12 @@ function abstract_call_method_with_const_args(interp::$(JETInterpreter), @nospec
         inf_result = inf_result::InferenceResult
         if !isa(inf_result.result, InferenceState)
             # corresponds to report throw away logic in `_typeinf(interp::JETInterpreter, frame::InferenceState)`
-            $(filter!)(r->$(!is_lineage)(r.lineage, sv, inf_result.linfo), interp.reports)
+            $(filter!)(r->$(!is_lineage)(r.lineage, interp.stackframes, inf_result.linfo), interp.reports)
 
             local_cache = $(get)(interp.cache, argtypes, nothing)
             if isa(local_cache, $(Vector{InferenceErrorReportCache}))
                 $(foreach)(local_cache) do cached
-                    $(restore_cached_report!)(cached, interp, sv)
+                    $(restore_cached_report!)(cached, interp)
                 end
             end
         end

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -28,6 +28,8 @@ struct JETInterpreter <: AbstractInterpreter
     # for sequential assignment of virtual global variables
     id::Symbol
 
+    stackframes::Vector{InferenceState}
+
     # reports found so far
     reports::Vector{InferenceErrorReport}
 
@@ -53,6 +55,7 @@ struct JETInterpreter <: AbstractInterpreter
                             compress            = false,
                             discard_trees       = false,
                             id                  = gensym(:JETInterpreterID),
+                            stackframes         = InferenceState[],
                             reports             = InferenceErrorReport[],
                             uncaught_exceptions = UncaughtExceptionReport[],
                             native_remarks      = NativeRemark[],
@@ -69,6 +72,7 @@ struct JETInterpreter <: AbstractInterpreter
                    discard_trees,
                    LocalCache(),
                    id,
+                   stackframes,
                    reports,
                    uncaught_exceptions,
                    native_remarks,


### PR DESCRIPTION
this PR  keeps our own stack-frames so that we don't need to rely on
`(frame::InferenceState).parent` for stack-trace traversal;
the previous ".parent" method works for most cases, but it sometimes
doesn't work, e.g. a method for inner constructor is not tracked in
the "parent" chain so the caching within there will just fail.

note that there is minor computational cost to keep the stack-trace as
described below:
```julia
jυλια> @nfreshexec @profile_call rand(Bool) # on base branch
(time = 3.8745424096, bytes = 4.852278638e8, gctime = 0.09731429080000001)

shell> git checkout avi/ourownstackframe
Switched to branch 'avi/ourownstackframe'
Your branch is up to date with 'origin/avi/ourownstackframe'.

jυλια> @nfreshexec @profile_call rand(Bool) # on this branch
(time = 3.9033724398000005, bytes = 4.86873047e8, gctime = 0.09761718259999999)
```

