### PR TITLE
register callbacks to invalidate JET caches

### DIFF
--- a/patches/abstract_call_gf_by_type.diff
+++ b/patches/abstract_call_gf_by_type.diff
@@ -1,9 +1,9 @@
 diff --git a/patches/abstract_call_gf_by_type.jl b/patches/abstract_call_gf_by_type.jl
-index e3e1e2b..384419d 100644
+index d99f5f3..96cfa7e 100644
 --- a/patches/abstract_call_gf_by_type.jl
 +++ b/patches/abstract_call_gf_by_type.jl
 @@ -1,6 +1,6 @@
- # https://github.com/JuliaLang/julia/blob/b166d0d15f616f4a025ac5905a115399cc932ddc/base/compiler/abstractinterpretation.jl#L20-L184
+ # https://github.com/JuliaLang/julia/blob/5e048f3e537387fd388a5360ce6163c8f7c61ccf/base/compiler/abstractinterpretation.jl#L31-L196
  
 -function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState,
 +function abstract_call_gf_by_type(interp::$(JETInterpreter), @nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState,
@@ -95,3 +95,15 @@ index e3e1e2b..384419d 100644
          # if there's a possibility we could constant-propagate a better result
          # (hopefully without doing too much work), try to do that now
          # TODO: it feels like this could be better integrated into abstract_call_method / typeinf_edge
+@@ -151,7 +182,10 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
+         # and avoid keeping track of a more complex result type.
+         rettype = Any
+     end
+-    if !(rettype === Any) # adding a new method couldn't refine (widen) this type
++    #=== abstract_call_gf_by_type patch point 5 start ===#
++    # a new method may refine analysis, so we always add backedges
++    if true # !(rettype === Any) # adding a new method couldn't refine (widen) this type
++    #=== abstract_call_gf_by_type patch point 5 end ===#
+         for edge in edges
+             add_backedge!(edge::MethodInstance, sv)
+         end

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -17,7 +17,6 @@ import .CC:
     OptimizationParams,
     get_world_counter,
     get_inference_cache,
-    code_cache,
     lock_mi_inference,
     unlock_mi_inference,
     add_remark!,
@@ -25,7 +24,7 @@ import .CC:
     may_compress,
     may_discard_trees,
     # jetcache.jl
-    # WorldView,
+    code_cache,
     # tfuncs.jl
     builtin_tfunction,
     return_type_tfunc,
@@ -67,6 +66,7 @@ import .CC:
     InternalCodeCache,
     CodeInstance,
     WorldRange,
+    WorldView,
     MethodInstance,
     Bottom,
     NOT_FOUND,

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -24,6 +24,8 @@ import .CC:
     may_optimize,
     may_compress,
     may_discard_trees,
+    # jetcache.jl
+    # WorldView,
     # tfuncs.jl
     builtin_tfunction,
     return_type_tfunc,
@@ -247,6 +249,7 @@ get_result(frame::InferenceState) = frame.result.result
 
 include("reports.jl")
 include("abstractinterpreterinterface.jl")
+include("jetcache.jl")
 include("tfuncs.jl")
 include("abstractinterpretation.jl")
 include("typeinfer.jl")

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -82,10 +82,6 @@ CC.OptimizationParams(interp::JETInterpreter) = OptimizationParams(interp.native
 CC.get_world_counter(interp::JETInterpreter) = get_world_counter(interp.native)
 CC.get_inference_cache(interp::JETInterpreter) = get_inference_cache(interp.native)
 
-# for global code cache we just bypass to the native one, and in a case cache is hit, we
-# restore reports associated with it within the typeinf_edge overload
-CC.code_cache(interp::JETInterpreter) = code_cache(interp.native)
-
 # JET only works for runtime inference
 CC.lock_mi_inference(::JETInterpreter, ::MethodInstance) = nothing
 CC.unlock_mi_inference(::JETInterpreter, ::MethodInstance) = nothing

--- a/src/jetcache.jl
+++ b/src/jetcache.jl
@@ -1,52 +1,65 @@
-# # global cache
-# # ------------
-#
-# CC.code_cache(interp::JETInterpreter) = JETCache(interp, code_cache(interp.native))
-#
-# struct JETCache{NativeCache}
-#     interp::JETInterpreter
-#     native::NativeCache
-#     JETCache(interp::JETInterpreter, native::NativeCache) where {NativeCache} =
-#         new{NativeCache}(interp, native)
-# end
-# CC.WorldView(tpc::JETCache, wr::WorldRange) = JETCache(tpc.interp, WorldView(tpc.native, wr))
-# CC.WorldView(tpc::JETCache, args...) = WorldView(tpc, WorldRange(args...))
-#
-# CC.haskey(tpc::JETCache, mi::MethodInstance) = CC.haskey(tpc.native, mi)
-#
-# const ANALYZED_LINFOS   = IdSet{MethodInstance}()         # keeps `MethodInstances` analyzed by JET
-# const ERRONEOUS_LINFOS = IdDict{MethodInstance,Symbol}() # keeps `MethodInstances` analyzed as "erroneous" by JET
-#
-# function CC.get(tpc::JETCache, mi::MethodInstance, default)
-#     # if we haven't analyzed this linfo, just invalidate native code cache and force analysis by JET
-#     if mi ∉ ANALYZED_LINFOS
-#         push!(ANALYZED_LINFOS, mi)
-#         return default
-#     end
-#
-#     ret = CC.get(tpc.native, mi, default)
-#
-#     # cache isn't really found
-#     if ret === default
-#         return ret
-#     end
-#
-#     # cache hit, now we need to invalidate the cache lookup if this `mi` has been profiled
-#     # as erroneous by JET analysis; otherwise the error reports that can occur from this
-#     # frame will just be ignored
-#     force_inference = false
-#
-#     if haskey(ERRONEOUS_LINFOS, mi)
-#         # don't force re-inference for frames from the same inference process;
-#         # FIXME: this is critical for profiling performance, but seems to lead to lots of false positives ...
-#         if ERRONEOUS_LINFOS[mi] !== get_id(tpc.interp)
-#             force_inference = true
-#         end
-#     end
-#
-#     return force_inference ? default : ret
-# end
-#
-# CC.getindex(tpc::JETCache, mi::MethodInstance) = CC.getindex(tpc.native, mi)
-#
-# CC.setindex!(tpc::JETCache, ci::CodeInstance, mi::MethodInstance) = CC.setindex!(tpc.native, ci, mi)
+# XXX: additional backedges for JET analysis
+# currently invalidation of JET cache just relies on invalidation of native code cache, i.e.
+# it happens only when there is a backedge from erroneous frame, which is not always true
+# e.g. native interpreter doesn't add backedge when the return type is `Any`, but invalidation
+# may still change the result of JET analysis
+# so we may need to add additional backedges for frames from which some errors are reported
+
+# we just overload `cache_result!` and so we don't need to set up our own cache
+CC.code_cache(interp::JETInterpreter) = code_cache(interp.native)
+
+# TODO better to use `overload_cache_result!!` hack ?
+function CC.cache_result!(interp::JETInterpreter, result::InferenceResult, valid_worlds::WorldRange)
+    linfo = result.linfo
+
+    # check if the existing linfo metadata is also sufficient to describe the current inference result
+    # to decide if it is worth caching this
+    already_inferred = CC.already_inferred_quick_test(interp, linfo) # always false
+    if !already_inferred && CC.haskey(WorldView(code_cache(interp), valid_worlds), linfo)
+        already_inferred = true
+    end
+
+    # TODO: also don't store inferred code if we've previously decided to interpret this function
+    if !already_inferred
+        inferred_result = CC.transform_result_for_cache(interp, linfo, result.src)
+        CC.setindex!(code_cache(interp), CodeInstance(result, inferred_result, valid_worlds), linfo)
+    end
+    unlock_mi_inference(interp, linfo)
+
+    # this function is called from `_typeinf(interp::AbstractInterpreter, frame::InferenceState)`
+    # and so at this point `linfo` is not registered in `ANALYZED_LINFOS`
+    # (unless inference happens multiple times for this frame)
+    if linfo ∉ ANALYZED_LINFOS
+        add_jet_callback!(linfo)
+    end
+
+    return nothing
+end
+
+function add_jet_callback!(linfo)
+    if !isdefined(linfo, :callbacks)
+        linfo.callbacks = Any[invalidate_jet_cache!]
+    else
+        if !any(cb->cb!==invalidate_jet_cache!, linfo.callbacks)
+            push!(linfo.callbacks, invalidate_jet_cache!)
+        end
+    end
+end
+
+function invalidate_jet_cache!(replaced, max_world)
+    invalidate_jet_cache!(replaced, max_world, 0)
+    return nothing
+end
+
+function invalidate_jet_cache!(replaced, max_world, depth)
+    replaced ∉ ANALYZED_LINFOS && return
+    delete!(ANALYZED_LINFOS, replaced)
+    delete!(JET_GLOBAL_CACHE, replaced)
+
+    if isdefined(replaced, :backedges)
+        for mi in replaced.backedges
+            invalidate_jet_cache!(mi, max_world, depth+1)
+        end
+    end
+    return nothing
+end

--- a/src/jetcache.jl
+++ b/src/jetcache.jl
@@ -1,0 +1,52 @@
+# # global cache
+# # ------------
+#
+# CC.code_cache(interp::JETInterpreter) = JETCache(interp, code_cache(interp.native))
+#
+# struct JETCache{NativeCache}
+#     interp::JETInterpreter
+#     native::NativeCache
+#     JETCache(interp::JETInterpreter, native::NativeCache) where {NativeCache} =
+#         new{NativeCache}(interp, native)
+# end
+# CC.WorldView(tpc::JETCache, wr::WorldRange) = JETCache(tpc.interp, WorldView(tpc.native, wr))
+# CC.WorldView(tpc::JETCache, args...) = WorldView(tpc, WorldRange(args...))
+#
+# CC.haskey(tpc::JETCache, mi::MethodInstance) = CC.haskey(tpc.native, mi)
+#
+# const ANALYZED_LINFOS   = IdSet{MethodInstance}()         # keeps `MethodInstances` analyzed by JET
+# const ERRONEOUS_LINFOS = IdDict{MethodInstance,Symbol}() # keeps `MethodInstances` analyzed as "erroneous" by JET
+#
+# function CC.get(tpc::JETCache, mi::MethodInstance, default)
+#     # if we haven't analyzed this linfo, just invalidate native code cache and force analysis by JET
+#     if mi ∉ ANALYZED_LINFOS
+#         push!(ANALYZED_LINFOS, mi)
+#         return default
+#     end
+#
+#     ret = CC.get(tpc.native, mi, default)
+#
+#     # cache isn't really found
+#     if ret === default
+#         return ret
+#     end
+#
+#     # cache hit, now we need to invalidate the cache lookup if this `mi` has been profiled
+#     # as erroneous by JET analysis; otherwise the error reports that can occur from this
+#     # frame will just be ignored
+#     force_inference = false
+#
+#     if haskey(ERRONEOUS_LINFOS, mi)
+#         # don't force re-inference for frames from the same inference process;
+#         # FIXME: this is critical for profiling performance, but seems to lead to lots of false positives ...
+#         if ERRONEOUS_LINFOS[mi] !== get_id(tpc.interp)
+#             force_inference = true
+#         end
+#     end
+#
+#     return force_inference ? default : ret
+# end
+#
+# CC.getindex(tpc::JETCache, mi::MethodInstance) = CC.getindex(tpc.native, mi)
+#
+# CC.setindex!(tpc::JETCache, ci::CodeInstance, mi::MethodInstance) = CC.setindex!(tpc.native, ci, mi)


### PR DESCRIPTION
now we can dynamically update JET analysis result after method
invalidation.

this seems to add certain amount of overhead by invalidating many frames,
but correct analysis result is much more important than this performance
regression, I think
> julia -i benchmark/benchmark_utils.jl
```julia
jυλια> N_BENCHMARK_TIMES = 10
10

jυλια> # first time analysis benchmark
       @nbenchmark_freshexec begin
           using JET
           @profile_call identity(nothing) # warm up
       end begin
           @profile_call println(:(f(args))) # first time analysis
       end
(time = 3.7400115921, bytes = 4.934496184e8, gctime = 0.10036386589999999)

jυλια> # second time analysis (after invalidation) benchmark
       @nbenchmark_freshexec begin
           using JET
           @profile_call println(:(f(args))) # warm up & first time analysis

           # should invoke deeper-level invalidation
           @eval Base begin
               function show_sym(io::IO, sym; allow_macroname = false)
                   if is_valid_identifier(sym)
                       print(io, sym)
                   elseif allow_macroname && (sym_str = string(sym);
                   startswith(sym_str, '@'))
                       print(io, '@')
                       show_sym(io, Symbol(sym_str[2:end]))
                   else
                       print(io, "var", repr(string(sym)))
                   end
               end
           end
       end begin
           @profile_call println(:(f(args))) # second time analysis after invalidation
       end
(time = 1.77370692, bytes = 1.89515294e8, gctime = 0.0467443214)

shell> git checkout avi/invalidate
Switched to branch 'avi/invalidate'
Your branch is up to date with 'origin/avi/invalidate'.

jυλια> # first time analysis benchmark
       @nbenchmark_freshexec begin
           using JET
           @profile_call identity(nothing) # warm up
       end begin
           @profile_call println(:(f(args))) # first time analysis
       end
(time = 3.7337413293000004, bytes = 4.937713754e8, gctime = 0.10048820720000003)

jυλια> # second time analysis (after invalidation) benchmark
       @nbenchmark_freshexec begin
           using JET
           @profile_call println(:(f(args))) # warm up & first time analysis

           # should invoke deeper-level invalidation
           @eval Base begin
               function show_sym(io::IO, sym; allow_macroname = false)
                   if is_valid_identifier(sym)
                       print(io, sym)
                   elseif allow_macroname && (sym_str = string(sym);
                   startswith(sym_str, '@'))
                       print(io, '@')
                       show_sym(io, Symbol(sym_str[2:end]))
                   else
                       print(io, "var", repr(string(sym)))
                   end
               end
           end
       end begin
           @profile_call println(:(f(args))) # second time analysis after invalidation
       end
(time = 2.0696888118, bytes = 2.60689625e8, gctime = 0.059430796400000006)
```
