### PR TITLE
watch w/ Revise

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 LoweredCodeUtils = "1.2.4"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 LoweredCodeUtils = "1.2.4"
+Revise = "3.1.14"
 julia = "1.6"
 
 [extras]

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -134,8 +134,6 @@ import JuliaInterpreter:
     is_return,
     is_quotenode_egal
 
-using FileWatching, Requires
-
 using InteractiveUtils
 
 # common


### PR DESCRIPTION
- `profile_and_watch_file` is now fully integrated with Revise.ji,
  which allows us to update/reflect changes in `Base`/stdlibs/packages
  that are not directly `include`d in `virtual_process!`ed files.
- Revise will automatically take care of those `using`ed in
  `virtual_process!`ed files (because JET.jl is currently just re-using
  Juila's `using` _as is_), but extra tweak is needed to reflect changes
  in `Base`/stdlibs
- if we want to reflect changes in e.g. `Base`, we will do
  `profile_and_watch_file("file_using_base.jl"; modules = Base)`,
  where the `modules` keyword option will be passed onto
  `Revise.entr(; modules)`

---

this PR is functional, but still in WIP
- [x] clean code in general
- [ ] turn errors from Revise into JET.jl toplevel error reports
- [ ] maybe add test for watch mode