### PR TITLE
re-enable optimization step for `JETInterpreter`

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -41,7 +41,6 @@ import .CC:
     # typeinfer.jl
     typeinf,
     _typeinf,
-    maybe_compress_codeinfo,
     # optimize.jl
     OptimizationState,
     optimize

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -444,18 +444,6 @@ function CC.abstract_eval_special_value(interp::JETInterpreter, @nospecialize(e)
             # undefined variable just works because we will invalidate the cache for this frame
             # anyway
         end
-    elseif isa(e, Slot)
-        # report local `UndefVarError`
-        # NOTE: this slot is only annotated as `Bottom` when it is really undefined,
-        # and so this approach includes false negatives
-        if ret === Bottom
-            slot = slot_id(e)
-            if slot in locals(interp)
-                # `locals(interp)` keeps explicitly declared local variables (i.e. those defined with `NewvarNode`)
-                # (otherwise there may be implicitly declared local variables that can be annotated as `Bottom`)
-                report!(interp, LocalUndefVarErrorReport(interp, sv, get_slotname(sv, slot)))
-            end
-        end
     end
 
     return ret

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -36,9 +36,6 @@ mutable struct JETInterpreter <: AbstractInterpreter
     # keeps track of the current inference frame (needed for report cache reconstruction)
     current_frame::Union{Nothing,InferenceState}
 
-    # stashes explicitly declared local variables (FILO, i.e. the last element is for the current frame)
-    locals_stack::Vector{Set{Int}}
-
     # debugging
     depth::Int
 
@@ -64,7 +61,6 @@ mutable struct JETInterpreter <: AbstractInterpreter
                    concretized,
                    analysis_params,
                    nothing,
-                   Set{Symbol}[],
                    0,
                    )
     end
@@ -157,18 +153,3 @@ end
 function stash_uncaught_exception!(interp::JETInterpreter, report::UncaughtExceptionReport)
     push!(interp.uncaught_exceptions, report)
 end
-
-locals(interp::JETInterpreter) = last(interp.locals_stack)
-
-function setup_locals!(interp::JETInterpreter, frame::InferenceState)
-    locals = Set{Int}()
-    # slotnames = frame.src.slotnames
-    for node in frame.src.code
-        if isa(node, NewvarNode)
-            push!(locals, slot_id(node.slot))
-        end
-    end
-    push!(interp.locals_stack, locals)
-end
-
-remove_locals!(interp::JETInterpreter, frame::InferenceState) = pop!(interp.locals_stack)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,19 +1,13 @@
-# NOTE: optimization step for `JETInterpreter`
-# currently `may_optimize(::JETInterpreter)` always returns `false`,
-# as such we even don't need the definitions below, but I'd define them to minimize codegen time
-
 function CC.OptimizationState(linfo::MethodInstance, params::OptimizationParams, interp::JETInterpreter)
     return OptimizationState(linfo, params, interp.native)
 end
 
 function CC.optimize(interp::JETInterpreter, opt::OptimizationState, params::OptimizationParams, result)
-    return nothing # do nothing
-
-    # # NOTE: to keep the previous implementations as a future reference
-    # # `JETInterpreter` shouldn't recur into the optimization step via `@invoke` macro,
-    # # but rather it should just go through `NativeInterpreter`'s optimization pass
-    # # this is necessary because `CC.get(wvc::WorldView{JETCache}, mi::MethodInstance, default)`
-    # # can be called from optimization pass otherwise, and it may cause errors because our report
-    # # construction is only valid before optimization pass
-    # return optimize(interp.native, opt, params, result)
+    # NOTE: to keep the previous implementations as a future reference
+    # `JETInterpreter` shouldn't recur into the optimization step via `@invoke` macro,
+    # but rather it should just go through `NativeInterpreter`'s optimization pass
+    # this is necessary because `CC.get(wvc::WorldView{JETCache}, mi::MethodInstance, default)`
+    # can be called from optimization pass otherwise, and it may cause errors because our report
+    # construction is only valid before optimization pass
+    return optimize(interp.native, opt, params, result)
 end

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -314,7 +314,7 @@ extract_type_decls(x) = @isexpr(x, :(::)) ? last(x.args) : Any
 
 @reportdef GlobalUndefVarErrorReport(interp, sv, mod::Module, name::Symbol)
 
-@reportdef LocalUndefVarErrorReport(interp, sv, name::Symbol)
+@reportdef LocalUndefVarErrorReport(interp, sv, name::Symbol) track_from_frame = true
 
 @reportdef NonBooleanCondErrorReport(interp, sv, @nospecialize(t::Type))
 

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -111,6 +111,19 @@ end
             first(interp.reports) isa LocalUndefVarErrorReport &&
             first(interp.reports).name === :bar
     end
+
+    let
+        interp, frame = profile_call((Int,)) do a
+            function inner(n)
+                if n > 0
+                   a = n
+                end
+            end
+            inner(rand(Int))
+            return a
+        end
+        @test isempty(interp.reports)
+    end
 end
 
 @testset "report undefined (global) variables" begin


### PR DESCRIPTION
The optimization for `JETInterpreter` was disabled by #93 for minor
speed up, but it turns out there are following regressions:
1. error report accuracy regression
2. invalid code cache

1. error report accuracy regression

The following piece of code will yield a false positive error
```julia
julia> function foo(a)
           function bar(n)
               if n > 0
                   a = n
               end
           end
           bar(rand(Int))
           return a
       end
foo (generic function with 1 method)

julia> using JET; report_call(foo, (Int,))
═════ 1 possible error found ═════
┌ @ REPL[1]:8 a
│ local variable a is not defined
└─────────────
Any
```

While it would be definitely possible to improve our local under var
detection logic and fix this, but I think to the previous approach
(just ask the optimization step to reveal local under vars) is more
reliable and the performance cost is negligible
(What I really need to fix is explored in #90).

2. invalid code cache

The current hack to forcibly cache unoptimized `CodeInstance` can lead
to segmentation fault (while MRE no longer happens on the current
master), or less performant self-profiling. As far as JET relies on
native code cache logic to restore reports, that should be removed
anyway.