### PR TITLE
fixes #109, mimic the native implementation of local cache

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -101,7 +101,10 @@ import .CC:
     _methods_by_ftype,
     specialize_method,
     add_backedge!,
-    compute_basic_blocks
+    compute_basic_blocks,
+    matching_cache_argtypes,
+    is_argtype_match,
+    tuple_tfunc
 
 import Base:
     parse_input_line,
@@ -372,18 +375,9 @@ const _JET_CONFIGURATIONS = Dict{Symbol,Symbol}()
 # utils
 # -----
 
-is_constant_propagated(frame::InferenceState) = CC.any(frame.result.overridden_by_const)
-
-# # XXX: should sync with the `haveconst` check within `abstract_call_method_with_const_args` ?
-# is_constant_propagated(frame::InferenceState) = is_constant_propagated(frame.result)
-# function is_constant_propagated(result::InferenceResult)
-#     for a in result.argtypes
-#         if CC.has_nontrivial_const_info(a) && CC.const_prop_profitable(a)
-#             return true
-#         end
-#     end
-#     return false
-# end
+function is_constant_propagated(frame::InferenceState)
+    return !frame.cached && CC.any(frame.result.overridden_by_const)
+end
 
 istoplevel(linfo::MethodInstance) = linfo.def == __toplevel__
 istoplevel(sv::InferenceState)    = istoplevel(sv.linfo)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -6,7 +6,7 @@ function CC.optimize(interp::JETInterpreter, opt::OptimizationState, params::Opt
     # NOTE: don't recurse with `@invoke`
     # `JETInterpreter` shouldn't recur into the optimization step via `@invoke` macro,
     # but rather it should just go through `NativeInterpreter`'s optimization pass
-    # this is necessary because `CC.get(wvc::WorldView{JETCache}, mi::MethodInstance, default)`
+    # this is necessary because `CC.get(wvc::WorldView{JETGlobalCache}, mi::MethodInstance, default)`
     # can be called from optimization pass otherwise, and it may cause errors because our report
     # construction is only valid on inference frames before the optimizer runs on it
     return optimize(interp.native, opt, params, result)

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -98,10 +98,10 @@ struct InferenceErrorReportCache
     spec_args::NTuple{N,Any} where N
 end
 
-function cache_report!(report::T, cache) where {T<:InferenceErrorReport}
+function cache_report!(cache, report::T) where {T<:InferenceErrorReport}
     st = copy(report.st)
     new = InferenceErrorReportCache(T, st, report.msg, report.sig, spec_args(report))
-    push!(cache, new)
+    return push!(cache, new)
 end
 
 function restore_cached_report!(cache::InferenceErrorReportCache,

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -149,24 +149,23 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
         if iscp
             argtypes = frame.result.argtypes
             cache = interp.cache
-
-            @assert !haskey(cache, argtypes) "invalid local caching $argtypes"
-            local_cache = cache[argtypes] = InferenceErrorReportCache[]
-
+            @assert jet_cache_lookup(linfo, argtypes, cache) === nothing "invalid local caching $linfo, $argtypes"
+            local_cache = InferenceErrorReportCache[]
             for report in this_caches
                 # # TODO make this hold
                 # @assert first(report.st).linfo === linfo "invalid local caching"
                 cache_report!(local_cache, report)
             end
+            push!(cache, AnalysisResult(linfo, argtypes, local_cache))
         elseif frame.cached # only cache when `NativeInterpreter` does
             @assert !haskey(JET_GLOBAL_CACHE, linfo) || isentry "invalid global caching $linfo"
-            global_cache = JET_GLOBAL_CACHE[linfo] = InferenceErrorReportCache[]
-
+            global_cache = InferenceErrorReportCache[]
             for report in this_caches
                 # # TODO make this hold
                 # @assert first(report.st).linfo === linfo "invalid global caching"
                 cache_report!(global_cache, report)
             end
+            JET_GLOBAL_CACHE[linfo] = global_cache
         end
     end
 

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -156,7 +156,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
             for report in this_caches
                 # # TODO make this hold
                 # @assert first(report.st).linfo === linfo "invalid local caching"
-                cache_report!(report, local_cache)
+                cache_report!(local_cache, report)
             end
         elseif frame.cached # only cache when `NativeInterpreter` does
             @assert !haskey(JET_GLOBAL_CACHE, linfo) || isentry "invalid global caching $linfo"
@@ -165,7 +165,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
             for report in this_caches
                 # # TODO make this hold
                 # @assert first(report.st).linfo === linfo "invalid global caching"
-                cache_report!(report, global_cache)
+                cache_report!(global_cache, report)
             end
         end
     end

--- a/test/test_jetcache.jl
+++ b/test/test_jetcache.jl
@@ -143,7 +143,9 @@ end
 
         @test !isempty(interp.reports)
         @test !isempty(interp.cache)
-        @test haskey(interp.cache, Any[CC.Const(getproperty),m.Foo{Int},CC.Const(:baz)])
+        @test any(interp.cache) do analysis_result
+            analysis_result.argtypes==Any[CC.Const(getproperty),m.Foo{Int},CC.Const(:baz)]
+        end
     end
 
     let
@@ -162,7 +164,11 @@ end
         # there should be local cache for each errorneous constant analysis
         @test !isempty(interp.reports)
         @test !isempty(interp.cache)
-        @test haskey(interp.cache, Any[CC.Const(m.getter),m.Foo{Int},CC.Const(:baz)])
-        @test haskey(interp.cache, Any[CC.Const(m.getter),m.Foo{Int},CC.Const(:qux)])
+        @test any(interp.cache) do analysis_result
+            analysis_result.argtypes==Any[CC.Const(m.getter),m.Foo{Int},CC.Const(:baz)]
+        end
+        @test any(interp.cache) do analysis_result
+            analysis_result.argtypes==Any[CC.Const(m.getter),m.Foo{Int},CC.Const(:qux)]
+        end
     end
 end


### PR DESCRIPTION
- this PR creates `AnalysisResult` struct, which should work similarly to 
  how `InferenceResult` does (but it's not integrated with the JET's global
  cache for now)
- with `AnalysisResult`, we can implement local cache in a same way as
  `NativeInterpreter` implements its local cache, and we will use
  `Vector` as a store of the local cache and this should fix #109 as a
  consequence
- as a positive side effect, now our local cache almost syncs with the
  `NativeInterpreter`'s local cache and this fixes the previous
  "over-filtering" of non-constant analysis