### PR TITLE
enable constant propagation for union split signatures

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -101,10 +101,13 @@ import .CC:
     _methods_by_ftype,
     specialize_method,
     add_backedge!,
+    add_mt_backedge!,
     compute_basic_blocks,
     matching_cache_argtypes,
     is_argtype_match,
-    tuple_tfunc
+    tuple_tfunc,
+    uniontypes,
+    call_result_unused
 
 import Base:
     parse_input_line,

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -418,7 +418,7 @@ function is_const_prop_profitable_arg(@nospecialize(arg))
             is_const_prop_profitable_arg(b) && return true
         end
     end
-    isa(arg, PartialOpaque) && return true
+    $(isdefined(CC, :PartialOpaque) && :(isa(arg, PartialOpaque) && return true))
     isa(arg, Const) || return true
     val = arg.val
     # don't consider mutable values or Strings useful constants
@@ -428,7 +428,8 @@ end
 function is_allconst(argtypes::Vector{Any})
     for a in argtypes
         a = widenconditional(a)
-        if !isa(a, Const) && !isconstType(a) && !isa(a, PartialStruct) && !isa(a, PartialOpaque)
+        if !isa(a, Const) && !isconstType(a) && !isa(a, PartialStruct) &&
+           $(isdefined(CC, :PartialOpaque) ? :(!isa(a, PartialOpaque)) : true)
             return false
         end
     end
@@ -436,7 +437,7 @@ function is_allconst(argtypes::Vector{Any})
 end
 
 function force_const_prop(interp::AbstractInterpreter, @nospecialize(f), method::Method)
-    return method.aggressive_constprop ||
+    return $(hasfield(Method, :aggressive_constprop) ? :(method.aggressive_constprop) : false) ||
            InferenceParams(interp).aggressive_constant_propagation ||
            istopfunction(f, :getproperty) ||
            istopfunction(f, :setproperty!)


### PR DESCRIPTION
This commit adopts the unmerged PR JuliaLang/julia#39305,
and we will enable constant propagation for each union-split signature.

It should improve the analysis accuracy at the cost of possible
performance reduction (the nanosoldier benchmark should reveal it, but
currently the machine is down and the original PR is pending now because
of the reason).

Failures of constant propagation can sometimes lead to lots of false
positive error reports, which really spoils JET.jl's usability and
reliability. ~~In particular, more correct constant analysis filtering
introduced in #110 reveals lots of hidden false positive errors
(e.g. see `@report_call rand(Bool)`), which are not easy to be "fixed".
I believe JET should eliminate them even if we have to wait more for an
analysis to finish, otherwise JET'd be an noisy and unusable analyzer.~~
It turns out that was because of the wrong implementation of the filtering.

Once the PR is merged, we can remove the hacky overloading of
`abstract_call_gf_by_type`, but the code can also be used as a new
"legacy code" for older versions of Julia.