### PR TITLE
fix #114, add special cased analysis pass for task parallelism

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -108,8 +108,7 @@ import .CC:
     compute_basic_blocks,
     matching_cache_argtypes,
     is_argtype_match,
-    tuple_tfunc,
-    abstract_eval_global
+    tuple_tfunc
 
 import Base:
     parse_input_line,

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -103,6 +103,18 @@ const _CONCRETIZED  = BitVector()
 const _TOPLEVELMOD  = @__MODULE__
 const _GLOBAL_SLOTS = Dict{Int,Symbol}()
 
+# constructor to do additional JET analysis in the middle of parent (non-toplevel) interpretation
+function JETInterpreter(interp::JETInterpreter)
+    return JETInterpreter(get_world_counter(interp);
+                          current_frame   = interp.current_frame,
+                          cache           = interp.cache,
+                          analysis_params = AnalysisParams(interp),
+                          inf_params      = InferenceParams(interp),
+                          opt_params      = OptimizationParams(interp),
+                          depth           = interp.depth,
+                          )
+end
+
 function Base.show(io::IO, interp::JETInterpreter)
     rn = length(interp.reports)
     en = length(interp.uncaught_exceptions)

--- a/test/interactive_utils.jl
+++ b/test/interactive_utils.jl
@@ -36,7 +36,9 @@ macro def(ex)
     @assert isexpr(ex, :block)
     return quote let
         vmod = $(gen_virtual_module)()
-        Core.eval(vmod, $(QuoteNode(ex)))
+        for x in $(ex.args)
+            Core.eval(vmod, x)
+        end
         vmod # return virtual module
     end end
 end

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -682,3 +682,113 @@ end
     @test !isempty(interp.reports)
     @test !any(r->isa(r, InvalidInvokeErrorReport), interp.reports)
 end
+
+@testset "additional analysis pass for task parallelism code" begin
+    # general case with `schedule(::Task)` pattern
+    interp, frame = profile_call() do
+        t = Task() do
+            sum("julia")
+        end
+        schedule(t)
+        fetch(t)
+    end
+    test_sum_over_string(interp)
+
+    # handle `Threads.@spawn` (https://github.com/aviatesk/JET.jl/issues/114)
+    interp, frame = profile_call() do
+        fetch(Threads.@spawn 1 + "foo")
+    end
+    @test length(interp.reports) == 1
+    let r = first(interp.reports)
+        @test isa(r, NoMethodErrorReport)
+        @test r.atype === Tuple{typeof(+), Int, String}
+    end
+
+    # handle `Threads.@threads`
+    interp, frame = profile_call((Int,)) do n
+        a = String[]
+        Threads.@threads for i in 1:n
+            push!(a, i)
+        end
+        return a
+    end
+    @test !isempty(interp.reports)
+    @test any(interp.reports) do r
+        isa(r, NoMethodErrorReport) &&
+        r.atype === Tuple{typeof(convert), Type{String}, Int}
+    end
+
+    # multiple tasks in the same frame
+    interp, frame = profile_call() do
+        t1 = Threads.@spawn 1 + "foo"
+        t2 = Threads.@spawn "foo" + 1
+        fetch(t1), fetch(t2)
+    end
+    @test length(interp.reports) == 2
+    let r = interp.reports[1]
+        @test isa(r, NoMethodErrorReport)
+        @test r.atype === Tuple{typeof(+), Int, String}
+    end
+    let r = interp.reports[2]
+        @test isa(r, NoMethodErrorReport)
+        @test r.atype === Tuple{typeof(+), String, Int}
+    end
+
+    # nested tasks
+    interp, frame = profile_call() do
+        t0 = Task() do
+            t = Threads.@spawn sum("julia")
+            fetch(t)
+        end
+        schedule(t0)
+        fetch(t0)
+    end
+    test_sum_over_string(interp)
+
+    # don't fail into infinite loop (rather, don't spoil inference termination)
+    m = @def begin
+        # adapated from https://julialang.org/blog/2019/07/multithreading/
+        import Base.Threads.@spawn
+
+        # sort the elements of `v` in place, from indices `lo` to `hi` inclusive
+        function psort!(v, lo::Int=1, hi::Int=length(v))
+            if lo >= hi                       # 1 or 0 elements; nothing to do
+                return v
+            end
+            if hi - lo < 100000               # below some cutoff, run in serial
+                sort!(view(v, lo:hi), alg = MergeSort)
+                return v
+            end
+
+            mid = (lo+hi)>>>1                 # find the midpoint
+
+            half = @spawn psort!(v, lo, mid)  # task to sort the lower half; will run
+            psort!(v, mid+1, hi)              # in parallel with the current call sorting
+                                              # the upper half
+            wait(half)                        # wait for the lower half to finish
+
+            temp = v[lo:mid]                  # workspace for merging
+
+            i, k, j = 1, lo, mid+1            # merge the two sorted sub-arrays
+            @inbounds while k < j <= hi
+                if v[j] < temp[i]
+                    v[k] = v[j]
+                    j += 1
+                else
+                    v[k] = temp[i]
+                    i += 1
+                end
+                k += 1
+            end
+            @inbounds while k < j
+                v[k] = temp[i]
+                k += 1
+                i += 1
+            end
+
+            return v
+        end
+    end
+    interp, frame = profile_call(m.psort!, (Vector{Int},))
+    @test true
+end


### PR DESCRIPTION
In Julia's task parallelism implementation, parallel code is represented
as closure and it's wrapped in `Task` object.
`NativeInterpreter` doesn't run type inference nor optimization on the
body of those closures when compiling code that creates parallel tasks,
but JET will try to run additional analysis pass by recurring into the
closures.

NOTE JET won't do anything other than doing JET analysis, e.g. won't
annotate return type of wrapped code block in order to not confuse
the original `AbstractInterpreter` routine.