### PR TITLE
configurable concretization strategy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -129,7 +129,7 @@ SUITE["invalidation"] = @jetbenchmarkable (@analyze_call println(QuoteNode(nothi
 end
 SUITE["self profiling"] = @jetbenchmarkable(
     analyze_call(JET.virtual_process!,
-                 (AbstractString, AbstractString, Module, Symbol, JET.JETInterpreter),
+                 (AbstractString, AbstractString, Module, Symbol, JET.JETInterpreter, JET.ToplevelConfig),
                  ),
     setup = begin
         using JET

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -6,12 +6,20 @@ arguments (or optional parameters for macros).
 For example, if you want to analyze `your_awesome_file.jl` with turning on `strict_condition_check` configuration and
 also logs inference process into `stdout`, your can do:
 ```julia
-report_file("your_awesome_file.jl"; strict_condition_check = true, inference_logger = stdout)
+report_file("your_awesome_file.jl";
+            strict_condition_check = true,
+            inference_logger = stdout)
 ```
 
 !!! note
-    Please ignore the names of documented objects below, like `JETAnalysisParams`.
+    Please ignore the names of documented objects below, like "`JET.ToplevelConfig`".
     They are just remnants of documentation internals, and you will never directly interact with them.
+
+## Configurations for Top-level Analysis
+
+```@docs
+JET.ToplevelConfig
+```
 
 
 ## Configurations for Abstract Interpretation

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -136,6 +136,8 @@ import JuliaInterpreter:
     is_return,
     is_quotenode_egal
 
+import MacroTools: @capture
+
 using InteractiveUtils
 
 # common
@@ -484,6 +486,7 @@ function collect_reports(actualmod, text, filename; jetconfigs...)
                            virtualmod,
                            Symbol(actualmod),
                            interp,
+                           ToplevelConfig(; jetconfigs...),
                            )
 
     return res.included_files,

--- a/src/print.jl
+++ b/src/print.jl
@@ -120,6 +120,7 @@ const RIGHT_ROOF = " ═════"
 const HEADER_COLOR = :reverse
 const ERROR_SIG_COLOR = :bold
 const TYPE_ANNOTATION_COLOR = :light_cyan
+const HINT_COLOR = :light_green
 
 pluralize(n::Integer, one::AbstractString, more::AbstractString = string(one, 's')) =
     string(n, ' ', isone(n) ? one : more)
@@ -206,6 +207,16 @@ function print_report(io, report::RecursiveIncludeErrorReport)
 end
 # TODO: add context information, i.e. during macroexpansion, defining something
 print_report(io, report::ActualErrorWrapped) = showerror(io, report.err, report.st)
+function print_report(io, report::MissingConcretization)
+    printstyled(io, "HINT: "; bold = true, color = HINT_COLOR)
+    printlnstyled(io, """
+    the following error happened mostly because of the missing JET analysis configurations,
+    and this could be fixed with the `concretization_patterns` configuration.
+    Check [TODO URI] for the details.
+    ---"""; color = HINT_COLOR)
+
+    showerror(io, report.err, report.st)
+end
 
 # inference
 # ---------

--- a/src/print.jl
+++ b/src/print.jl
@@ -212,7 +212,7 @@ function print_report(io, report::MissingConcretization)
     printlnstyled(io, """
     the following error happened mostly because of the missing JET analysis configurations,
     and this could be fixed with the `concretization_patterns` configuration.
-    Check [TODO URI] for the details.
+    Check https://aviatesk.github.io/JET.jl/dev/config/#JET.ToplevelConfig for the details.
     ---"""; color = HINT_COLOR)
 
     showerror(io, report.err, report.st)

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -48,6 +48,14 @@ struct ActualErrorWrapped <: ToplevelErrorReport
     end
 end
 
+# wraps an error that might happen because of inappropriate top-level code abstraction
+struct MissingConcretization <: ToplevelErrorReport
+    err
+    st::Vector{Base.StackTraces.StackFrame}
+    file::String
+    line::Int
+end
+
 # inference
 # ---------
 

--- a/src/virtualprocess.jl
+++ b/src/virtualprocess.jl
@@ -1,6 +1,4 @@
 """
-    ToplevelConfig
-
 Configurations for top-level analysis.
 These configurations will be active for all the top-level entries explained in [Analysis entry points](@ref).
 
@@ -8,14 +6,15 @@ These configurations will be active for all the top-level entries explained in [
 - `concretization_patterns::Vector{Expr} = Expr[]` \\
   Specifies a customized top-level code concretization strategy.
 
-  When analyzing a top-level code, JET first splits the entire code and then iterate a simulation
-    process on each code block, in order to process the top-level code sequentially as Julia runtime does.
-  However, with this approach, JET can't track the inter-code-block level dependencies, and
-    so a partial interpretation of top-level definitions will fail if it needs an access to
+  When analyzing a top-level code, JET first splits the entire code and then iterate a virtual
+    top-level code execution process on each code block, in order to simulate Julia's sequential
+    top-level code execution.
+  However, with this approach, JET can't track the "inter-code-block" level dependencies, and
+    so a partial interpretation of top-level definitions can fail if it needs an access to
     global variables defined in other code blocks that are not actually interpreted ("concretized")
     but just abstract-interpreted ("abstracted").
 
-  For example, the issue happens when your macro accesses a global variable during its expansion, e.g.:
+  For example, the issue happens when your macro accesses to a global variable during its expansion, e.g.:
   > test/fixtures/concretization_patterns.jl
   $(let
       text = read(normpath(@__DIR__, "..", "test", "fixtures", "concretization_patterns.jl"), String)

--- a/test/fixtures/concretization_patterns.jl
+++ b/test/fixtures/concretization_patterns.jl
@@ -1,0 +1,13 @@
+# JET doesn't conretize this by default, but just analyze its type
+const GLOBAL_CODE_STORE = Dict()
+
+macro with_code_record(a)
+    GLOBAL_CODE_STORE[__source__] = a # record the code location in the global store
+    esc(a)
+end
+
+# here JET will try to actually expand `@with_code_record`,
+# but since `GLOBAL_CODE_STORE` didn't get concretized (i.e. instantiated), JET analysis fails at this point
+@with_code_record foo(a) = identity(a)
+
+foo(10) # top-level callsite, abstracted away

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -11,7 +11,7 @@
             end
             """
 
-        res = analyze_text(s; filename = @__FILE__)
+        res = analyze_text(s, @__FILE__)
         print_reports(io, res.toplevel_error_reports)
         let s = String(take!(io))
             @test occursin("1 toplevel error found", s)
@@ -19,7 +19,7 @@
             @test occursin("syntax: unexpected \"end\"", s)
         end
 
-        res = analyze_text(s; filename = "foo")
+        res = analyze_text(s, "foo")
         print_reports(io, res.toplevel_error_reports)
         let s = String(take!(io))
             @test occursin("1 toplevel error found", s)


### PR DESCRIPTION
This PR will implement a configuration which allows users to customize
JET's concretization strategy.

`virtual_process!`'s concretization strategy can fail if a toplevel
definition needs an access to (non-concretized) global variable (see
[this document](https://aviatesk.github.io/JET.jl/previews/PR127/internals/#JET.virtual_process!)), and this PR will provide a way to circumvent it.

The new JET configuration `concretization_patterns::Vector{Expr}` will
specify the patterns of statements that should be concretized anyway.
For example, when [self-analyzing JET](https://github.com/aviatesk/JET.jl/pull/101), we need to concretize
```julia
const EGAL_TYPES = Set{Symbol}((:Type, :Symbol, :MethodInstance))
const _JET_CONFIGURATIONS = Dict{Symbol,Symbol}()
```
because they're accessed within the expansions of `@withmixedhash` and 
`@jetconfigurable` macros.
JET won't concretize them by default, but now we can force their
concretization with the configuration:
```julia
concretization_patterns = [:(EGAL_TYPES = x_),
                           :(_JET_CONFIGURATIONS = x_),
                           ]
```

The expression pattern matching uses [MacroTools.jl](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/),
and is done on lowered representation, and thus the configurations above are not like:
```julia
concretization_patterns = [:(const EGAL_TYPES = x_),
                           :(const _JET_CONFIGURATIONS = x_),
                           ]
```
I've to admit that it might be a bit user-unfriendly, but it has several benefits over the pattern
matching with surface level AST. Especially, in lowered representation,
a function definition signature (`f(args...)`) can be clearly
distinguished from the call expression while within at surface AST level
we should care about the scope of the expression, etc.