### PR TITLE
fix #142, global variable woe, again

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -387,9 +387,6 @@ function is_constant_propagated(frame::InferenceState)
     return !frame.cached && CC.any(frame.result.overridden_by_const)
 end
 
-@inline istoplevel(linfo::MethodInstance) = linfo.def === __virtual_toplevel__
-@inline istoplevel(sv::InferenceState)    = istoplevel(sv.linfo)
-
 prewalk_inf_frame(@nospecialize(f), ::Nothing) = return
 function prewalk_inf_frame(@nospecialize(f), frame::InferenceState)
     ret = f(frame)
@@ -621,7 +618,7 @@ function analyze_toplevel!(interp::JETInterpreter, src::CodeInfo)
     mi.specTypes = Tuple{}
 
     transform_abstract_global_symbols!(interp, src)
-    mi.def = __virtual_toplevel__ # set to the dummy module
+    mi.def = interp.toplevelmod
 
     result = InferenceResult(mi);
     # toplevel frame doesn't need to be cached (and so it won't be optimized)

--- a/src/legacy/abstractinterpretation
+++ b/src/legacy/abstractinterpretation
@@ -129,7 +129,7 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
         method = match.method
         sig = match.spec_types
         #=== abstract_call_gf_by_type patch point 2 start ===#
-        if istoplevel && !isdispatchtuple(sig) && !$istoplevel(sv) # keep going for "our" toplevel frame
+        if istoplevel && !isdispatchtuple(sig) && !$istoplevel(interp, sv) # keep going for "our" toplevel frame
         #=== abstract_call_gf_by_type patch point 2 end ===#
             # only infer concrete call sites in top-level expressions
             add_remark!(interp, sv, "Refusing to infer non-concrete call site in top-level expression")

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -105,7 +105,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
             sym, _ = stmt.args
 
             # slots in toplevel frame may be a abstract global slot
-            istoplevel(frame) && is_global_slot(interp, sym) && continue
+            istoplevel(interp, frame) && is_global_slot(interp, sym) && continue
 
             next_idx = idx + 1
             if checkbounds(Bool, stmts, next_idx) && is_unreachable(@inbounds stmts[next_idx])
@@ -255,7 +255,7 @@ function is_throw_call_expr(interp::JETInterpreter, frame::InferenceState, @nosp
     if isa(e, Expr)
         if e.head === :call
             f = e.args[1]
-            if istoplevel(frame) && isa(f, Symbol)
+            if istoplevel(interp, frame) && isa(f, Symbol)
                 f = GlobalRef(interp.toplevelmod, f)
             end
             if isa(f, GlobalRef)

--- a/test/interactive_utils.jl
+++ b/test/interactive_utils.jl
@@ -91,6 +91,12 @@ is_concrete(mod, sym) = isdefined(mod, sym) && !isa(getfield(mod, sym), Abstract
 is_abstract(mod, sym) = isdefined(mod, sym) && isa(getfield(mod, sym), AbstractGlobal)
 isa_abstract(x, @nospecialize(typ)) = isa(x, AbstractGlobal) && x.t ⊑ typ
 
+# JET will try to concretize global variable when its type is a constant at analysis time,
+# but the starategy is a bit complicated right now and may change in the future
+# these utilities allow robust testing to check if a object is successfully analyzed by JET whichever it's concretized or abstracted
+is_analyzed(mod, sym) = isdefined(mod, sym) # essentially, `is_concrete(mod, sym) || is_abstract(mod, sym)`
+isa_analyzed(x, @nospecialize(typ)) = isa_abstract(x, typ) || isa(x, typ)
+
 # fresh execution/benchmark tools
 include(normpath(@__DIR__, "..", "benchmark", "JETBenchmarkUtils.jl"))
 using .JETBenchmarkUtils

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -27,3 +27,5 @@ end
 test_sum_over_string(res::JET.VirtualProcessResult) =
     test_sum_over_string(res.inference_error_reports)
 test_sum_over_string(interp::JETInterpreter) = test_sum_over_string(interp.reports)
+
+return

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -235,8 +235,7 @@ end
             sum(s)
         end
 
-        @test is_abstract(vmod, :s)
-        @test isa_abstract(vmod.s, String)
+        @test is_concrete(vmod, :s)
         test_sum_over_string(res)
     end
 
@@ -294,8 +293,9 @@ end
                 foo(globalvar) # no method matching error should be reported
             end
 
-            @test is_abstract(vmod, :globalvar)
-            @test isa_abstract(vmod.globalvar, Int)
+            @test is_concrete(vmod, :globalvar)
+            @test is_analyzed(vmod, :globalvar)
+            @test isa_analyzed(vmod.globalvar, Int)
             @test length(res.inference_error_reports) === 2
             let er = first(res.inference_error_reports)
                 @test er isa NoMethodErrorReport &&
@@ -305,30 +305,6 @@ end
                 @test er isa NoMethodErrorReport &&
                 !er.unionsplit
             end
-        end
-    end
-
-    @testset "invalidate code cache" begin
-        let
-            res = @analyze_toplevel begin
-                foo(::Integer) = "good call, pal"
-                bar() = a
-
-                a = 1
-                foo(bar()) # no method error should NOT be reported
-
-                a = '1'
-                foo(bar()) # no method error should be reported
-
-                a = 1
-                foo(bar()) # no method error should NOT be reported
-            end
-            @test length(res.inference_error_reports) === 1
-            er = first(res.inference_error_reports)
-            @test er isa NoMethodErrorReport &&
-                first(er.st).file === Symbol(@__FILE__) &&
-                first(er.st).line === (@__LINE__) - 9 &&
-                er.atype <: Tuple{Any,Char}
         end
     end
 end


### PR DESCRIPTION
1. trying to propagate types of a global variable when in a toplevel 
frame
2. don't propagate type of abstract global variables when in a local 
frame

With 2., JET analysis is now more consistent how Julia's native type
inference works, and we can eliminate the hacky logic to invalidate
a dummy cache associated with the previously analyzed abstract global's
type.