### PR TITLE
self-profiling results at 0ae4d76

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -354,13 +354,14 @@ macro jetconfigurable(funcdef)
     @assert @isexpr(funcdef, :(=)) || @isexpr(funcdef, :function) "function definition should be given"
 
     defsig = funcdef.args[1]
-    thisname = first(defsig.args)
-    i = findfirst(a->@isexpr(a, :parameters), defsig.args)
+    args = defsig.args::Vector{Any}
+    thisname = first(args)
+    i = findfirst(a->@isexpr(a, :parameters), args)
     if isnothing(i)
         @warn "no JET configurations are defined for `$thisname`"
-        insert!(defsig.args, 2, Expr(:parameters, :(jetconfigs...)))
+        insert!(args, 2, Expr(:parameters, :(jetconfigs...)))
     else
-        kwargs = defsig.args[i]
+        kwargs = args[i]
         found = false
         for kwarg in kwargs.args
             if @isexpr(kwarg, :...)

--- a/src/print.jl
+++ b/src/print.jl
@@ -9,7 +9,7 @@ If the entry renders the collected error points, the configurations below will b
 - `print_toplevel_success::Bool = false` \\
   If `true`, prints a message when there is no toplevel errors found.
 ---
-- `print_inference_sucess::Bool = true` \\
+- `print_inference_success::Bool = true` \\
   If `true`, print a message when there is no errors found in abstract interpretation based analysis pass.
 ---
 - `annotate_types::Bool = false` \\
@@ -86,16 +86,16 @@ If the entry renders the collected error points, the configurations below will b
 """
 struct PrintConfig
     print_toplevel_success::Bool
-    print_inference_sucess::Bool
+    print_inference_success::Bool
     annotate_types::Bool
     fullpath::Bool
     @jetconfigurable PrintConfig(; print_toplevel_success::Bool = false,
-                                   print_inference_sucess::Bool = true,
+                                   print_inference_success::Bool = true,
                                    annotate_types::Bool         = false,
                                    fullpath::Bool               = false,
                                    ) =
         return new(print_toplevel_success,
-                   print_inference_sucess,
+                   print_inference_success,
                    annotate_types,
                    fullpath,
                    )
@@ -163,7 +163,7 @@ function print_reports(io::IO,
     config = PrintConfig(; jetconfigs...)
 
     if isempty(reports)
-        if config.print_toplevel_sucess
+        if config.print_toplevel_success
             printlnstyled(io, "No toplevel errors !"; color = NOERROR_COLOR)
         end
         return false
@@ -231,7 +231,7 @@ function print_reports(io::IO,
     reports = unique(get_identity_key, reports)
 
     if isempty(reports)
-        if config.print_inference_sucess
+        if config.print_inference_success
             printlnstyled(io, "No errors !"; color = NOERROR_COLOR)
         end
         return false

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -80,7 +80,7 @@ end
 function Base.show(io::IO, report::T) where {T<:InferenceErrorReport}
     print(io, T.name.name, '(')
     for a in report.sig
-        _print_signature(io, a; annotate_types = true, bold = true)
+        _print_signature(io, a, (; annotate_types = true); bold = true)
     end
     print(io, ')')
 end

--- a/src/tfuncs.jl
+++ b/src/tfuncs.jl
@@ -97,7 +97,8 @@ function istoplevel_globalref(interp::JETInterpreter, sv::InferenceState)
     def = sv.linfo.def
     def.name === :getproperty || return false
     def.sig === Tuple{typeof(getproperty), Module, Symbol} || return false
-    return istoplevel(interp, sv.parent)
+    parent = sv.parent
+    return !isnothing(parent) && istoplevel(interp, parent)
 end
 
 # `return_type_tfunc` internally uses `abstract_call` to model `return_type` function and


### PR DESCRIPTION
Out of those 50 errors below, this PR fixes these three cases:
```
┌ @ src/print.jl:166 Base.getproperty(config, :print_toplevel_sucess)
│┌ @ Base.jl:33 Base.getfield(x, f)
││ type JET.PrintConfig has no field print_toplevel_sucess
│└──────────────
```
```
@ src/JET.jl:362 JET.insert!(Base.getproperty(defsig::Any, 
:args::Symbol)::Any, 2, JET.Expr(:parameters::Symbol, $(Expr(:copyast, 
:($(QuoteNode(:(jetconfigs...))))))::Expr)::Expr)
│┌ @ bitarray.jl:887 Base._insert_int!(B::BitVector, 
Base.Int(i::Int64)::Int64, item::Expr)
││┌ @ bitarray.jl:892 Base.convert(Base.Bool, item::Expr)
│││ no matching method found for call signature: Base.convert(Base.Bool, 
item::Expr)
││└───────────────────
```
```
┌ @ src/reports.jl:83 
Core.kwfunc(JET._print_signature)::JET.var"#_print_signature##kw"(Core.apply_type(Core.NamedTuple, 
(:annotate_types, :bold)::Tuple{Symbol, 
Symbol})::Type{NamedTuple{(:annotate_types, :bold), T} where 
T<:Tuple}(Core.tuple(true, true)::Tuple{Bool, 
Bool})::NamedTuple{(:annotate_types, :bold), Tuple{Bool, Bool}}, 
JET._print_signature, io::IO, a::Any)
│ no matching method found for call signature: 
Core.kwfunc(JET._print_signature)::JET.var"#_print_signature##kw"(Core.apply_type(Core.NamedTuple, 
(:annotate_types, :bold)::Tuple{Symbol, 
Symbol})::Type{NamedTuple{(:annotate_types, :bold), T} where 
T<:Tuple}(Core.tuple(true, true)::Tuple{Bool, 
Bool})::NamedTuple{(:annotate_types, :bold), Tuple{Bool, Bool}}, 
JET._print_signature, io::IO, a::Any)
└─────────────────────
```


> `./jet src/JET.jl`

```
[toplevel-info] entered into src/JET.jl
[toplevel-info] entered into src/reports.jl
[toplevel-info]  exited from src/reports.jl (took 2.025 sec)
[toplevel-info] entered into src/abstractinterpreterinterface.jl
[toplevel-info]  exited from src/abstractinterpreterinterface.jl (took 
1.0 sec)
[toplevel-info] entered into src/jetcache.jl
[toplevel-info]  exited from src/jetcache.jl (took 0.022 sec)
[toplevel-info] entered into src/tfuncs.jl
[toplevel-info]  exited from src/tfuncs.jl (took 0.312 sec)
[toplevel-info] entered into src/abstractinterpretation.jl
[toplevel-info]  exited from src/abstractinterpretation.jl (took 0.396 
sec)
[toplevel-info] entered into src/typeinfer.jl
[toplevel-info]  exited from src/typeinfer.jl (took 0.093 sec)
[toplevel-info] entered into src/optimize.jl
[toplevel-info]  exited from src/optimize.jl (took 0.001 sec)
[toplevel-info] entered into src/print.jl
[toplevel-info]  exited from src/print.jl (took 0.114 sec)
[toplevel-info] entered into src/virtualprocess.jl
[toplevel-info]  exited from src/virtualprocess.jl (took 1.129 sec)
[toplevel-info] entered into src/watch.jl
[toplevel-info]  exited from src/watch.jl (took 0.148 sec)
[toplevel-info]  exited from src/JET.jl (took 13.467 sec)
═════ 50 possible errors found ═════
┌ @ src/abstractinterpreterinterface.jl:312 
JET.JETInterpreter(Core.kwfunc(JET.NativeInterpreter)(Core.apply_type(Core.NamedTuple, 
(:inf_params, :opt_params))(Core.tuple(inf_params, opt_params)), 
JET.NativeInterpreter, world), Base.getindex(JET.InferenceErrorReport), 
Base.getindex(JET.UncaughtExceptionReport), Core.apply_type(JET.Set, 
JET.InferenceErrorReport)(), current_frame, cache, analysis_params, 
false, concretized, toplevelmod, toplevelmods, global_slots, logger, 
depth)
│┌ @ src/abstractinterpreterinterface.jl:290 
Base.convert(Core.fieldtype(JET.JETInterpreter, 6), 
Core.getfield(Core.tuple(Core.tuple(native), args...), 6, false))
││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/LinearAlgebra/src/factorization.jl:58 
_(f)
│││ no matching method found for call signature: 
_::Type{Vector{JET.AnalysisResult}}(f::LinearAlgebra.Factorization)
││└─────────────────────────────────────────────────────────────────────────────────────────────────
│┌ @ src/abstractinterpreterinterface.jl:290 
Base.convert(Core.fieldtype(JET.JETInterpreter, 9), 
Core.getfield(Core.tuple(Core.tuple(native), args...), 9, false))
││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/LinearAlgebra/src/factorization.jl:58 
_(f)
│││┌ @ bitarray.jl:575 Base.gen_bitarrayN(Core.apply_type(Base.BitArray, 
_), Base.IteratorSize(itr), itr)
││││┌ @ bitarray.jl:604 Base.gen_bitarray(itsz, itr)
│││││┌ @ bitarray.jl:598 Base.length(itr)
││││││ no matching method found for call signature: 
Base.length(itr::LinearAlgebra.Factorization)
│││││└───────────────────
┌ @ src/jetcache.jl:99 JET.cache_lookup(linfo, given_argtypes, 
Base.getproperty(cache, :cache))
│┌ @ compiler/inferenceresult.jl:155 
Core.Compiler.is_argtype_match(Core.Compiler.getindex(given_argtypes, 
i), Core.Compiler.getindex(cache_argtypes, i), 
Core.Compiler.getindex(cache_overridden_by_const, i))
││┌ @ compiler/inferenceresult.jl:7 
Core.Compiler.is_lattice_equal(given_argtype, cache_argtype)
│││┌ @ compiler/typelattice.jl:265 
Core.Compiler.is_lattice_equal(Core.Compiler.getproperty(a, :env), 
Core.Compiler.getproperty(b, :env))
││││┌ @ compiler/typelattice.jl:267 Core.Compiler.⊑(a, b)
│││││┌ @ compiler/typelattice.jl:166 Core.Compiler.issubconditional(a, 
b)
││││││ for any of the union split cases, no matching method found for 
call signature: 
Core.Compiler.issubconditional(a::Union{Core.Compiler.Conditional, 
Core.InterConditional}, b::Union{Core.Compiler.Conditional, 
Core.InterConditional})
│││││└───────────────────────────────
┌ @ src/tfuncs.jl:124 JET.return_type_tfunc(Base.getproperty(interp, 
:native), argtypes, sv)
│┌ @ compiler/tfuncs.jl:1616 Core.Compiler.abstract_call(interp, 
Core.Compiler.nothing, argtypes_vec, sv, -1)
││┌ @ compiler/abstractinterpretation.jl:1285 
Core.Compiler.abstract_call_gf_by_type(interp, Core.Compiler.nothing, 
fargs, argtypes, Core.Compiler.argtypes_to_type(argtypes), sv, 
max_methods)
│││┌ @ compiler/abstractinterpretation.jl:213 
Core.Compiler.union!(Core.Compiler.getproperty(sv, :pclimitations), 
Core.Compiler.getproperty(rettype, :causes))
││││┌ @ abstractset.jl:91 Core.Compiler.push!(s, x)
│││││┌ @ idset.jl:20 
Core.Compiler.setindex!(Core.Compiler.getproperty(s, :dict), 
Core.Compiler.nothing, x)
││││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key)
│││││││ variable Core.Compiler.limitrepr is not defined: 
Core.Compiler.limitrepr(key::Any)
││││││└────────────────
│││┌ @ compiler/abstractinterpretation.jl:179 
Core.Compiler.tmerge(rettype, this_rt)
││││┌ @ compiler/typelimits.jl:384 Core.Compiler.nfields_tfunc(typea)
│││││┌ @ compiler/tfuncs.jl:415 
Core.Compiler.nfields_tfunc(Core.Compiler.getproperty(x, :a))
││││││┌ @ compiler/tfuncs.jl:417 Core.Compiler.tmerge(na, 
Core.Compiler.nfields_tfunc(Core.Compiler.getproperty(x, :b)))
│││││││┌ @ compiler/typelimits.jl:394 
Core.Compiler.getfield_tfunc(typea, Core.Compiler.Const(i))
││││││││┌ @ compiler/tfuncs.jl:837 Core.Compiler.getfield_tfunc(_ts, 
name)
│││││││││┌ @ compiler/tfuncs.jl:837 Core.Compiler.getfield_tfunc(_ts, 
name)
││││││││││┌ @ compiler/tfuncs.jl:850 
Core.Compiler.==(Core.Compiler.length(ftypes), 1)
│││││││││││┌ @ promotion.jl:359 Core.Compiler.promote(x, y)
││││││││││││┌ @ promotion.jl:292 
Core.Compiler.not_sametype(Core.tuple(x, y), Core.tuple(px, py))
│││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39, input)
│││││││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 2))
││││││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Int64)::Type{Int64})
││││││││││││││││└────────────────────
│││││││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 1))
││││││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Number)::Type{var"#s459"} 
where var"#s459"<:Number)
││││││││││││││││└────────────────────
││││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
│││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Number, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││└────────────────────
││││││┌ @ iddict.jl:87 
Core.Compiler.string(Core.Compiler.limitrepr(key), " is not a valid key 
for type ", _)
│││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a 
valid key for type ", _::Type{Core.Compiler.InferenceState})
││││││└────────────────
┌ @ src/abstractinterpretation.jl:222 
JET.abstract_call_method(newinterp, Base.getproperty(mm, :method), 
Base.getproperty(mm, :spec_types), Base.getproperty(mm, :sparams), 
false, sv)
│┌ @ src/abstractinterpretation.jl:245 Base.getproperty(method, 
:is_for_opaque_closure)
││┌ @ compiler/abstractinterpretation.jl:472 
Core.Compiler.typeinf_edge(interp, method, Core.getfield(sig, 
:contents), sparams, sv)
│││┌ @ compiler/typeinfer.jl:816 Core.Compiler.InferenceState(result, 
true, interp)
││││┌ @ compiler/inferencestate.jl:156 
Core.Compiler.validate_code_in_debug_mode(Core.Compiler.getproperty(result, 
:linfo), src, "lowered")
│││││┌ @ compiler/validation.jl:62 Core.Compiler.validate_code(linfo, 
src)
││││││┌ @ compiler/validation.jl:220 
Core.Compiler.validate_code!(Core.tuple(Core.apply_type(Core.Compiler.Vector, 
Core.Compiler.InvalidCodeError)()), args...)
│││││││┌ @ compiler/validation.jl:209 Core.Compiler.!=(n_sig_params, 
mnargs)
││││││││┌ @ operators.jl:264 Core.Compiler.==(x, y)
│││││││││┌ @ promotion.jl:359 Core.Compiler.promote(x, y)
││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x, 
y), Core.tuple(px, py))
│││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
│││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Number, Int32})::Tuple{Any, Any}, ", ", " and ")
││││││││││││└────────────────────
│││┌ @ compiler/typeinfer.jl:825 Core.Compiler.typeinf(interp, frame)
││││┌ @ compiler/typeinfer.jl:205 Core.Compiler._typeinf(interp, frame)
│││││┌ @ src/typeinfer.jl:98 Base.getproperty(frame, :src)
││││││┌ @ compiler/typeinfer.jl:255 Core.Compiler.optimize(interp, opt, 
Core.Compiler.OptimizationParams(interp), result_type)
│││││││┌ @ src/optimize.jl:12 JET.optimize(Base.getproperty(interp, 
:native), opt, params, result)
││││││││┌ @ compiler/optimize.jl:296 
Core.Compiler.run_passes(Core.Compiler.getproperty(opt, :src), nargs, 
opt)
│││││││││┌ @ compiler/ssair/driver.jl:125 Core.Compiler.slot2reg(ir, ci, 
nargs, sv)
││││││││││┌ @ compiler/ssair/driver.jl:116 
Core.Compiler.construct_domtree(Core.Compiler.getproperty(Core.Compiler.getproperty(ir, 
:cfg), :blocks))
│││││││││││┌ @ compiler/ssair/domtree.jl:204 
Core.Compiler.update_domtree!(blocks, Core.Compiler.DomTree(), true, 0)
││││││││││││┌ @ compiler/ssair/domtree.jl:210 
Core.Compiler.DFS!(Core.Compiler.getproperty(domtree, :dfs_tree), 
blocks)
│││││││││││││┌ @ compiler/ssair/domtree.jl:113 Core.Compiler.copy!(D, 
Core.Compiler.DFSTree(Core.Compiler.length(blocks)))
││││││││││││││┌ @ compiler/ssair/domtree.jl:102 
Core.Compiler.copy!(Core.Compiler.getproperty(dst, :to_pre), 
Core.Compiler.getproperty(src, :to_pre))
│││││││││││││││┌ @ abstractarray.jl:826 Core.Compiler.eachindex(dst, 
src)
││││││││││││││││┌ @ abstractarray.jl:305 
Core.Compiler.eachindex(Core.Compiler.IndexStyle(A, B), A, B)
│││││││││││││││││┌ @ abstractarray.jl:316 
Core.Compiler.broadcasted(Core.Compiler.eachindex, B)
││││││││││││││││││ variable Core.Compiler.broadcasted is not defined: 
Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B::Tuple{Vector{Int64}})
│││││││││││││││││└────────────────────────
│││││││││┌ @ compiler/ssair/driver.jl:129 
Core.Compiler.ssa_inlining_pass!(ir, Core.Compiler.getproperty(ir, 
:linetable), Core.Compiler.getproperty(sv, :inlining), 
Core.Compiler.getproperty(ci, :propagate_inbounds))
││││││││││┌ @ compiler/ssair/inlining.jl:75 
Core.Compiler.batch_inline!(todo, ir, linetable, propagate_inbounds)
│││││││││││┌ @ compiler/ssair/inlining.jl:573 
Core.Compiler.ir_inline_unionsplit!(compact, idx, argexprs, linetable, 
item, boundscheck, Core.Compiler.getproperty(state, :todo_bbs))
││││││││││││┌ @ compiler/ssair/inlining.jl:470 
Core.Compiler.setindex!(argexprs′, 
Core.Compiler.insert_node_here!(compact, 
Core.Compiler.NewInstruction(Core.Compiler.PiNode(Core.Compiler.getindex(argexprs′, 
i), m), m, line)), i)
│││││││││││││┌ @ abstractarray.jl:1267 
Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A), A, v), 
Core.Compiler.to_indices(A, I)...)
││││││││││││││┌ @ abstractarray.jl:1282 Core.Compiler.string("setindex! 
for ", Core.Compiler.typeof(A), " with types ", Core.Compiler.typeof(I), 
" is not supported")
│││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("setindex! for ", 
Core.Compiler.typeof(A::Vector{Any})::Type{Vector{Any}}, " with types ", 
Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s459"} where 
var"#s459"<:Tuple{Any}, " is not supported")
││││││││││││││└─────────────────────────
││││││││││┌ @ compiler/ssair/driver.jl:118 
Core.Compiler.construct_ssa!(ci, ir, domtree, defuse_insts, nargs, 
Core.Compiler.getproperty(sv, :slottypes))
│││││││││││┌ @ compiler/ssair/slot2ssa.jl:906 
Core.Compiler.domsort_ssa!(ir, domtree)
││││││││││││┌ @ compiler/ssair/slot2ssa.jl:400 
Core.Compiler.sort(Core.Compiler.filter(#331, cs))
│││││││││││││┌ @ sort.jl:794 
Core.Compiler.Sort.#sort#9(Core.Compiler.pairs(Core.NamedTuple()), 
#self#, v)
││││││││││││││┌ @ sort.jl:794 
Core.Compiler.Sort.sort!(Core.Compiler.Sort.copymutable(v))
│││││││││││││││┌ @ sort.jl:735 
Core.Compiler.Sort.#sort!#8(Core.Compiler.Sort.defalg(v), 
Core.Compiler.Sort.isless, Core.Compiler.Sort.identity, 
Core.Compiler.Sort.nothing, Core.Compiler.Sort.Forward, #self#, v)
││││││││││││││││┌ @ sort.jl:743 Core.Compiler.Sort.sort_int_range!(v, 
rangelen, min, _21)
│││││││││││││││││┌ @ sort.jl:759 Core.Compiler.Sort.firstindex(x)
││││││││││││││││││ variable Core.Compiler.Sort.firstindex is not 
defined: Core.Compiler.Sort.firstindex(x::Vector{Int64})
│││││││││││││││││└───────────────
│││││││││││││││││┌ @ sort.jl:764 Core.Compiler.setindex!(x, val, j)
││││││││││││││││││┌ @ abstractarray.jl:1267 Core.Compiler.to_indices(A, 
I)
│││││││││││││││││││┌ @ indices.jl:330 Core.Compiler.to_indices(A, (), I)
││││││││││││││││││││┌ @ indices.jl:333 Core.Compiler.to_index(A, 
Core.Compiler.getindex(I, 1))
│││││││││││││││││││││┌ @ indices.jl:277 Core.Compiler.to_index(i)
││││││││││││││││││││││┌ @ indices.jl:293 Core.Compiler.string("invalid 
index: ", i, " of type Bool")
│││││││││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("invalid index: ", i::Bool, " of type Bool")
││││││││││││││││││││││└──────────────────
│││││││┌ @ compiler/validation.jl:215 
Core.Compiler.validate_code!(errors, c, is_top_level)
││││││││┌ @ compiler/validation.jl:124 Core.Compiler.in(nargs, 
narg_bounds)
│││││││││┌ @ range.jl:1239 Core.Compiler._in_range(x, r)
││││││││││┌ @ range.jl:1235 
Core.Compiler.+(Core.Compiler.round(Core.Compiler.Integer, 
Core.Compiler./(Core.Compiler.-(x, Core.Compiler.first(r)), 
Core.Compiler.step(r))), 1)
│││││││││││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a, b), 
Core.tuple(aT, bT))
││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
│││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Integer, Int64})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││└────────────────────
││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39, input)
│││││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 2))
││││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Int32)::Type{Int32})
││││││││││││││└────────────────────
│││││││││││││││││┌ @ abstractarray.jl:316 
Core.Compiler.materialize(Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B))
││││││││││││││││││ variable Core.Compiler.materialize is not defined: 
Core.Compiler.materialize(Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B::Tuple{Vector{Int64}})::Any)
│││││││││││││││││└────────────────────────
││││││││││┌ @ range.jl:1235 Core.Compiler.-(x, Core.Compiler.first(r))
│││││││││││┌ @ promotion.jl:322 Core.Compiler.promote(x, y)
││││││││││││┌ @ promotion.jl:292 
Core.Compiler.not_sametype(Core.tuple(x, y), Core.tuple(px, py))
│││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
│││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Int64, Number})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││└────────────────────
│││││││││││┌ @ compiler/ssair/inlining.jl:571 
Core.Compiler.ir_inline_item!(compact, idx, argexprs, linetable, item, 
boundscheck, Core.Compiler.getproperty(state, :todo_bbs))
││││││││││││┌ @ compiler/ssair/inlining.jl:319 
Core.Compiler.:(nargs_def, Core.Compiler.lastindex(argexprs))
│││││││││││││┌ @ range.jl:3 Core.Compiler.promote(a, b)
││││││││││││││┌ @ promotion.jl:292 
Core.Compiler.not_sametype(Core.tuple(x, y), Core.tuple(px, py))
│││││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
│││││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Real, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││││└────────────────────
││││││││┌ @ compiler/validation.jl:122 Core.Compiler.==(narg_bounds, 
Core.Compiler.:(-1, -1))
│││││││││┌ @ range.jl:959 
Core.Compiler.&(Core.Compiler._has_length_one(s), 
Core.Compiler.==(Core.Compiler.first(r), Core.Compiler.first(s)))
││││││││││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a, b), 
Core.tuple(aT, bT))
│││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39, input)
│││││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 1))
││││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Bool)::Type{Bool})
││││││││││││││└────────────────────
││││┌ @ compiler/typeinfer.jl:206 
Core.Compiler.Timings.exit_current_timer(frame)
│││││┌ @ compiler/typeinfer.jl:164 Core.Compiler.Timings.backtrace()
││││││┌ @ error.jl:113 Core.Compiler._reformat_bt(Core.typeassert(bt1, 
Core.apply_type(Core.Compiler.Vector, Core.apply_type(Core.Compiler.Ptr, 
Core.Compiler.Cvoid))), Core.typeassert(bt2, 
Core.apply_type(Core.Compiler.Vector, Core.Compiler.Any)))
│││││││┌ @ error.jl:93 Core.Compiler.string("Unexpected extended 
backtrace entry tag ", tag, " at bt[", i, "]")
││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("Unexpected extended backtrace entry tag ", 
tag::UInt64, " at bt[", i::Int64, "]")
│││││││└───────────────
│││┌ @ compiler/typeinfer.jl:815 Core.Compiler.InferenceResult(mi)
││││┌ @ compiler/types.jl:33 #self#(linfo, Core.Compiler.nothing, false)
│││││┌ @ compiler/types.jl:33 
Core.Compiler.matching_cache_argtypes(linfo, given_argtypes, 
va_override)
││││││┌ @ compiler/inferenceresult.jl:141 
Core.Compiler.falses(Core.Compiler.length(cache_argtypes))
│││││││┌ @ bitarray.jl:403 Core.Compiler.falses(dims)
││││││││┌ @ bitarray.jl:405 Core.Compiler.BitArray(Core.Compiler.undef, 
dims)
│││││││││┌ @ bitarray.jl:71 Core.apply_type(Core.Compiler.BitArray, 
_)(Core.tuple(Core.Compiler.undef), Core.Compiler.map(Core.Compiler.Int, 
dims)...)
││││││││││┌ @ bitarray.jl:32 Core.Compiler.string("dimension size must 
be ≥ 0, got ", d, " for dimension ", i)
│││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("dimension size must be ≥ 0, got ", d::Int64, " for 
dimension ", i::Int64)
││││││││││└──────────────────
││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
│││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Bool, Integer})::Tuple{Any, Any}, ", ", " and ")
││││││││││││└────────────────────
│││││││││││││││││┌ @ abstractarray.jl:316 
Core.Compiler.throw_eachindex_mismatch_indices(Core.tuple(Core.Compiler.IndexLinear(), 
Core.Compiler.eachindex(A)), 
Core.Compiler.materialize(Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B))...)
││││││││││││││││││┌ @ abstractarray.jl:260 Core.Compiler.join(inds, ", 
", " and ")
│││││││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(inds::Tuple{Core.Compiler.OneTo{Int64}, Vararg{Any}}, 
", ", " and ")
││││││││││││││││││└────────────────────────
│││││││││││┌ @ compiler/ssair/inlining.jl:521 
Core.Compiler.cfg_inline_unionsplit!(ir, idx, Core.typeassert(item, 
Core.Compiler.UnionSplit), state)
││││││││││││┌ @ compiler/ssair/inlining.jl:215 
Core.Compiler.inline_into_block!(state, block)
│││││││││││││┌ @ compiler/ssair/inlining.jl:112 
Core.Compiler.append!(Core.Compiler.getproperty(state, :new_cfg_blocks), 
Core.Compiler.map(Core.Compiler.copy, 
Core.Compiler.getindex(Core.Compiler.getproperty(Core.Compiler.getproperty(state, 
:cfg), :blocks), new_range)))
││││││││││││││┌ @ array.jl:978 Core.Compiler.copyto!(a, 
Core.Compiler.+(Core.Compiler.-(Core.Compiler.length(a), n), 1), items, 
Core.Compiler.first(itemindices), n)
│││││││││││││││┌ @ array.jl:299 Core.Compiler._copyto_impl!(dest, doffs, 
src, soffs, n)
││││││││││││││││┌ @ array.jl:313 Core.Compiler.unsafe_copyto!(dest, 
doffs, src, soffs, n)
│││││││││││││││││┌ @ array.jl:289 Core.Compiler._unsafe_copyto!(dest, 
doffs, src, soffs, n)
││││││││││││││││││┌ @ array.jl:235 Core.Compiler.getindex(src, 
Core.Compiler.-(Core.Compiler.+(soffs, i), 1))
│││││││││││││││││││┌ @ array.jl:802 
Core.Compiler.arrayref($(Expr(:boundscheck)), A, i1)
││││││││││││││││││││ invalid builtin function call: 
Core.Compiler.arrayref($(Expr(:boundscheck)), A::Vector{Union{}}, 
i1::Int64)
│││││││││││││││││││└────────────────
││││││││││││││││││┌ @ abstractarray.jl:1267 
Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A), A, v), 
Core.Compiler.to_indices(A, I)...)
│││││││││││││││││││┌ @ abstractarray.jl:1282 
Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A), " with 
types ", Core.Compiler.typeof(I), " is not supported")
││││││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("setindex! for ", 
Core.Compiler.typeof(A::Vector{Int64})::Type{Vector{Int64}}, " with 
types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s459"} where 
var"#s459"<:Tuple{Any}, " is not supported")
│││││││││││││││││││└─────────────────────────
││││││││││││││││││┌ @ abstractarray.jl:260 Core.Compiler.string("all 
inputs to eachindex must have the same indices, got ", 
Core.Compiler.join(inds, ", ", " and "))
│││││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("all inputs to eachindex must have the same 
indices, got ", 
Core.Compiler.join(inds::Tuple{Core.Compiler.OneTo{Int64}, Vararg{Any}}, 
", ", " and ")::Any)
││││││││││││││││││└────────────────────────
│││││││││││││┌ @ compiler/ssair/inlining.jl:111 
Core.Compiler.setindex!(Core.Compiler.getproperty(state, :bb_rename), 
Core.Compiler.:(Core.Compiler.+(l, 1), Core.Compiler.+(l, 
Core.Compiler.length(new_range))), new_range)
││││││││││││││┌ @ array.jl:847 Core.Compiler.setindex_shape_check(X, 
Core.Compiler.length(I))
│││││││││││││││┌ @ indices.jl:245 
Core.Compiler.throw_setindex_mismatch(X, Core.tuple(i))
││││││││││││││││┌ @ indices.jl:191 Core.Compiler.string("tried to assign 
", Core.Compiler.length(X), " elements to ", Core.Compiler.getindex(I, 
1), " destinations")
│││││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string("tried to assign ", 
Core.Compiler.length(X::Core.Compiler.UnitRange{Int64})::Int64, " 
elements to ", Core.Compiler.getindex(I::Tuple{Int64}, 1)::Int64, " 
destinations")
││││││││││││││││└──────────────────
││││┌ @ compiler/inferencestate.jl:157 
Core.Compiler.InferenceState(result, src, cached, interp)
│││││┌ @ compiler/inferencestate.jl:63 
Core.Compiler.sptypes_from_meth_instance(Core.typeassert(linfo, 
Core.Compiler.MethodInstance))
││││││┌ @ compiler/inferencestate.jl:189 Core.Compiler.:(1, 
Core.Compiler.length(sigtypes))
│││││││┌ @ range.jl:3 Core.Compiler.promote(a, b)
││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x, 
y), Core.tuple(px, py))
│││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39, input)
│││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 2))
││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Real)::Type{var"#s459"} 
where var"#s459"<:Real)
││││││││││││└────────────────────
│││││││││││││┌ @ tuple.jl:214 f(Core.Compiler.getindex(t, 2))
││││││││││││││┌ @ promotion.jl:316 
Core.Compiler.string(Core.Compiler.typeof(x))
│││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.typeof(x::Integer)::Type{var"#s459"} 
where var"#s459"<:Integer)
││││││││││││││└────────────────────
│││││││││││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a, b), 
Core.tuple(aT, bT))
││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x)
│││││││││││││┌ @ promotion.jl:315 
Core.Compiler.join(Core.Compiler.map(#39, input), ", ", " and ")
││││││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Int64, Integer})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││└────────────────────
│││││││││┌ @ compiler/ssair/driver.jl:133 
Core.Compiler.getfield_elim_pass!(ir)
││││││││││┌ @ compiler/ssair/passes.jl:638 Core.Compiler.union!(mid, 
intermediaries)
│││││││││││┌ @ abstractset.jl:91 Core.Compiler.push!(s, x)
││││││││││││┌ @ idset.jl:20 
Core.Compiler.setindex!(Core.Compiler.getproperty(s, :dict), 
Core.Compiler.nothing, x)
│││││││││││││┌ @ iddict.jl:87 
Core.Compiler.string(Core.Compiler.limitrepr(key), " is not a valid key 
for type ", _)
││││││││││││││ variable Core.Compiler.string is not defined: 
Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a 
valid key for type ", _::Type{Int64})
│││││││││││││└────────────────
││││││││││││┌ @ compiler/ssair/domtree.jl:218 
Core.Compiler.compute_domtree_nodes!(domtree)
│││││││││││││┌ @ compiler/ssair/domtree.jl:224 
Core.Compiler.copy!(Core.Compiler.getproperty(domtree, :nodes), _6)
││││││││││││││┌ @ abstractarray.jl:826 Core.Compiler.eachindex(dst, src)
│││││││││││││││┌ @ abstractarray.jl:305 
Core.Compiler.eachindex(Core.Compiler.IndexStyle(A, B), A, B)
││││││││││││││││┌ @ abstractarray.jl:316 
Core.Compiler.broadcasted(Core.Compiler.eachindex, B)
│││││││││││││││││ variable Core.Compiler.broadcasted is not defined: 
Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B::Tuple{Vector{Core.Compiler.DomTreeNode}})
││││││││││││││││└────────────────────────
││││││││││││││││┌ @ abstractarray.jl:316 
Core.Compiler.materialize(Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B))
│││││││││││││││││ variable Core.Compiler.materialize is not defined: 
Core.Compiler.materialize(Core.Compiler.broadcasted(Core.Compiler.eachindex, 
B::Tuple{Vector{Core.Compiler.DomTreeNode}})::Any)
││││││││││││││││└────────────────────────
│││││││││┌ @ compiler/ssair/driver.jl:142 Core.Compiler.verify_ir(ir)
││││││││││┌ @ compiler/ssair/verify.jl:67 #self#(ir, true)
│││││││││││┌ @ compiler/ssair/verify.jl:114 
Core.Compiler.!=(Core.Compiler.getproperty(block, :succs), 
Core.Compiler.vect(Core.Compiler.getindex(Core.Compiler.getproperty(terminator, 
:args), 1), Core.Compiler.+(idx, 1)))
││││││││││││┌ @ operators.jl:264 Core.Compiler.!(Core.Compiler.==(x, y))
│││││││││││││ for any of the union split cases, no matching method found 
for call signature: Core.Compiler.!(Core.Compiler.==(x::Vector{Int64}, 
y::Vector{_A} where _A)::Union{Core.Compiler.Missing, Bool})
││││││││││││└────────────────────
│││││││││││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key)
││││││││││││││ variable Core.Compiler.limitrepr is not defined: 
Core.Compiler.limitrepr(key::Any)
│││││││││││││└────────────────
││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39, 
input), ", ", " and ")
│││││││││││ variable Core.Compiler.join is not defined: 
Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", 
input::Tuple{Int64, Real})::Tuple{Any, Any}, ", ", " and ")
││││││││││└────────────────────
┌ @ src/virtualprocess.jl:177 #self#(s, filename, virtualmod, 
actualmodsym, interp, config, JET.gen_virtual_process_result())
│┌ @ src/virtualprocess.jl:193 JET.virtual_process!(toplevelex, 
filename, virtualmod, actualmodsym, interp, config, res)
││┌ @ src/virtualprocess.jl:333 JET.partially_interpret!(interp′, 
virtualmod, src)
│││┌ @ src/virtualprocess.jl:440 JET.select_statements(src, 
Base.getproperty(interp, :config))
││││┌ @ 
/Users/aviatesk/.julia/packages/MacroTools/gME9C/src/match/macro.jl:72 
MacroTools.trymatch(pat, stmt)
│││││┌ @ 
/Users/aviatesk/.julia/packages/MacroTools/gME9C/src/match/match.jl:112 
MacroTools.match(pat, ex)
││││││┌ @ 
/Users/aviatesk/.julia/packages/MacroTools/gME9C/src/match/match.jl:107 
MacroTools.match(pat, ex, MacroTools.Dict())
│││││││┌ @ 
/Users/aviatesk/.julia/packages/MacroTools/gME9C/src/match/match.jl:100 
MacroTools.bname(pat)
││││││││┌ @ 
/Users/aviatesk/.julia/packages/MacroTools/gME9C/src/match/match.jl:27 
Base.getproperty(Base.getproperty(MacroTools.Base, 
:match)(r"^@?(.*?)_+(_str)?$", MacroTools.string(s)), :captures)
│││││││││┌ @ Base.jl:33 Base.getfield(x, f)
││││││││││ type Nothing has no field captures
│││││││││└──────────────
┌ @ src/virtualprocess.jl:217 JET.MissingConcretization(err, st, 
Core.getfield(#self#, :filename), 
Base.getproperty(Core.typeassert(Core.getfield(Core.getfield(#self#, 
:lnn), :contents), JET.LineNumberNode), :line))
│┌ @ src/reports.jl:53 
Base.convert(Core.fieldtype(JET.MissingConcretization, 2), st)
││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/LinearAlgebra/src/factorization.jl:58 
_(f)
│││ no matching method found for call signature: 
_::Type{Vector{Base.StackTraces.StackFrame}}(f::LinearAlgebra.Factorization)
││└─────────────────────────────────────────────────────────────────────────────────────────────────
┌ @ src/virtualprocess.jl:455 JET.CodeEdges(src)
│┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:371 
LoweredCodeUtils.CodeEdges(Base.collect(Base.Generator(#23, 
LoweredCodeUtils.:(1, n))), Base.collect(Base.Generator(#24, 
LoweredCodeUtils.:(1, n))), Core.apply_type(LoweredCodeUtils.Dict, 
Core.apply_type(LoweredCodeUtils.Union, LoweredCodeUtils.GlobalRef, 
LoweredCodeUtils.Symbol), LoweredCodeUtils.Variable)())
││┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:367 
Base.convert(Core.fieldtype(LoweredCodeUtils.CodeEdges, 1), preds)
│││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/LinearAlgebra/src/factorization.jl:58 
_(f)
││││ no matching method found for call signature: 
_::Type{Vector{Vector{Int64}}}(f::LinearAlgebra.Factorization)
│││└─────────────────────────────────────────────────────────────────────────────────────────────────
┌ @ src/virtualprocess.jl:516 JET.lines_required!(concretize, src, 
edges)
│┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:593 
LoweredCodeUtils.#lines_required!#32(Base.pairs(Core.NamedTuple()), 
#self#, isrequired, src, edges)
││┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:594 
LoweredCodeUtils.lines_required!(isrequired, objs, src, edges)
│││┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:604 
LoweredCodeUtils.#lines_required!#33(false, #self#, isrequired, objs, 
src, edges)
││││┌ @ 
/Users/aviatesk/julia/packages/LoweredCodeUtils/src/codeedges.jl:653 
LoweredCodeUtils.any(LoweredCodeUtils.view(isrequired, 
Base.getproperty(uses, :succs)))
│││││┌ @ reducedim.jl:894 Base.#any#733(Base.:, #self#, a)
││││││┌ @ reducedim.jl:894 Base._any(a, dims)
│││││││┌ @ reducedim.jl:896 Base._any(Base.identity, a, Base.:)
││││││││┌ @ reduce.jl:1094 Base.iterate(itr)
│││││││││┌ @ abstractarray.jl:1094 #self#(A, 
Core.tuple(Base.eachindex(A)))
││││││││││┌ @ multidimensional.jl:580 Base.indexed_iterate(_3, 2, _4)
│││││││││││┌ @ tuple.jl:86 Base.getfield(t, i)
││││││││││││ invalid builtin function call: Base.getfield(t::Tuple{Any}, 
i::Int64)
│││││││││││└───────────────
│││││││││┌ @ multidimensional.jl:576 Base.IteratorsMD.first(iter)
││││││││││┌ @ abstractarray.jl:368 Base.getindex(a, 
Base.first(Base.eachindex(a)))
│││││││││││┌ @ subarray.jl:276 
Base.getindex(Core.tuple(Base.getproperty(V, :parent)), 
Base.reindex(Base.getproperty(V, :indices), I)...)
││││││││││││┌ @ reshapedarray.jl:234 
Base._unsafe_getindex(Core.tuple(A), indices...)
│││││││││││││┌ @ reshapedarray.jl:245 Base.ind2sub_rs(axp, 
Base.getproperty(A, :mi), i)
││││││││││││││┌ @ reshapedarray.jl:218 Base._ind2sub_rs(ax, strds, 
Base.-(i, 1))
│││││││││││││││┌ @ reshapedarray.jl:221 Base.divrem(ind, 
Base.getindex(strds, 1))
││││││││││││││││┌ @ div.jl:148 Base.divrem(x, y, Base.RoundToZero)
│││││││││││││││││┌ @ div.jl:152 Base.div(a, b)
││││││││││││││││││┌ @ div.jl:37 Base.div(a, b, Base.RoundToZero)
│││││││││││││││││││ no matching method found for call signature: 
Base.div(a::Any, 
b::Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}, 
Base.RoundToZero)
││││││││││││││││││└─────────────
┌ @ src/watch.jl:67 JET._report_and_watch_file(args...)
│┌ @ src/watch.jl:86 
JET.#_report_and_watch_file#80(Core.tuple(JET.IOContext(io, 
JET.=>(JET.LOGGER_LEVEL_KEY, JET.INFO_LOGGER_LEVEL)), 
Base.pairs(Core.NamedTuple()), #self#, io, filename), args...)
││┌ @ src/watch.jl:95 Base.getproperty(JET.Revise, :entr)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:entr::Symbol)
││└───────────────────
││┌ @ src/watch.jl:113 Base.getproperty(JET.Revise, 
:ReviseEvalException)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:ReviseEvalException::Symbol)
││└────────────────────
││┌ @ src/watch.jl:128 Base.getproperty(JET.Revise, 
:ReviseEvalException)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:ReviseEvalException::Symbol)
││└────────────────────
┌ @ src/watch.jl:67 
Core.kwfunc(JET._report_and_watch_file)(Core.tuple(Base.merge(Base.NamedTuple(), 
kwargs), JET._report_and_watch_file), args...)
│┌ @ src/watch.jl:86 
JET.#_report_and_watch_file#80(Core.tuple(toplevel_logger, 
jetconfigs..., _3, io, filename), args...)
││┌ @ src/watch.jl:95 Base.getproperty(JET.Revise, :entr)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:entr::Symbol)
││└───────────────────
││┌ @ src/watch.jl:113 Base.getproperty(JET.Revise, 
:ReviseEvalException)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:ReviseEvalException::Symbol)
││└────────────────────
││┌ @ src/watch.jl:128 Base.getproperty(JET.Revise, 
:ReviseEvalException)
│││ variable JET.Revise is not defined: Base.getproperty(JET.Revise, 
:ReviseEvalException::Symbol)
││└────────────────────
┌ @ src/JET.jl:780 Base.getproperty(JET.InteractiveUtils, 
:gen_call_with_extracted_types_and_kwargs)(__module__, :analyze_call, 
ex0)
│┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/InteractiveUtils/src/macros.jl:195 
InteractiveUtils.gen_call_with_extracted_types(__module__, fcn, arg, 
kws)
││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/InteractiveUtils/src/macros.jl:40 
InteractiveUtils.findlast(#34, 
Base.getproperty(Base.getindex(Base.getproperty(ex0, :args), 1), :args))
│││┌ @ array.jl:2104 Base.findprev(testf, A, Base.last(Base.keys(A)))
││││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/SparseArrays/src/abstractsparse.jl:100 
SparseArrays._sparse_findprevnz(v, SparseArrays.prevind(v, j))
│││││┌ @ 
/Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/SparseArrays/src/abstractsparse.jl:77 
SparseArrays.searchsortedlast(I, i)
││││││┌ @ sort.jl:327 Base.Sort.#searchsortedlast#5(Base.Sort.isless, 
Base.Sort.identity, Base.Sort.nothing, Base.Sort.Forward, #self#, v, x)
│││││││┌ @ sort.jl:327 Base.Sort.searchsortedlast(v, x, 
Base.Sort.ord(lt, by, rev, order))
││││││││┌ @ sort.jl:325 Base.Sort.searchsortedlast(v, x, 
Base.Sort.first(inds), Base.Sort.last(inds), o)
│││││││││┌ @ sort.jl:201 Base.Sort.lt(o, x, Base.getindex(v, m))
││││││││││┌ @ ordering.jl:109 Base.Order.isless(a, b)
│││││││││││┌ @ multidimensional.jl:127 Base.IteratorsMD._isless(0, 
Base.getproperty(I1, :I), Base.getproperty(I2, :I))
││││││││││││┌ @ multidimensional.jl:130 Base.IteratorsMD._isless(newret, 
Base.front(I1), Base.front(I2))
│││││││││││││ for any of the union split cases, no matching method found 
for call signature: Base.IteratorsMD._isless(newret::Int64, 
Base.front::typeof(Base.front)(I1::Tuple{Vararg{Int64, N}} where 
N)::Union{Tuple{}, Tuple{Int64, Vararg{Int64}}}, 
Base.front::typeof(Base.front)(I2::Tuple{Vararg{Int64, N}} where 
N)::Union{Tuple{}, Tuple{Int64, Vararg{Int64}}})
││││││││││││└───────────────────────────
││││││││││││┌ @ multidimensional.jl:130 Base.IteratorsMD._isless(newret, 
Base.front(I1), Base.front(I2))
│││││││││││││┌ @ multidimensional.jl:130 
Base.IteratorsMD._isless(newret, Base.front(I1), Base.front(I2))
││││││││││││││ for any of the union split cases, no matching method 
found for call signature: Base.IteratorsMD._isless(newret::Int64, 
Base.front::typeof(Base.front)(I1::Tuple{Vararg{Int64}})::Union{Tuple{}, 
Tuple{Int64, Vararg{Int64}}}, 
Base.front::typeof(Base.front)(I2::Tuple{Vararg{Int64}})::Union{Tuple{}, 
Tuple{Int64, Vararg{Int64}}})
│││││││││││││└───────────────────────────
││││┌ @ array.jl:2059 Base.prevind(A, i)
│││││┌ @ multidimensional.jl:159 
Base.IteratorsMD.dec(Base.getproperty(i, :I), Base.getproperty(iter, 
:indices))
││││││┌ @ multidimensional.jl:502 Base.IteratorsMD.__dec(state, indices)
│││││││┌ @ multidimensional.jl:521 
Base.IteratorsMD.__dec(Base.IteratorsMD.tail(state), 
Base.IteratorsMD.tail(indices))
││││││││┌ @ multidimensional.jl:516 Base.getindex(indices, 1)
│││││││││┌ @ tuple.jl:29 Base.getfield(t, i, $(Expr(:boundscheck)))
││││││││││ invalid builtin function call: Base.getfield(t::Tuple{}, 
i::Int64, $(Expr(:boundscheck)))
│││││││││└───────────────
```