### PR TITLE
re-fix #151

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -724,20 +724,13 @@ function transform_abstract_global_symbols!(interp::JETInterpreter, src::CodeInf
         end
     end
 
-    function _transform_abstract_global_symbols!(x, scope)
+    prewalk_and_transform!(src) do x, scope
         if isa(x, Symbol)
             slot = get(abstrct_global_variables, x, nothing)
-            if !isnothing(slot)
-                return SlotNumber(slot)
-            end
-        elseif isa(x, GotoIfNot)
-            newcond = _transform_abstract_global_symbols!(x.cond, scope)
-            return GotoIfNot(newcond, x.dest)
+            isnothing(slot) || return SlotNumber(slot)
         end
-
         return x
     end
-    prewalk_and_transform!(_transform_abstract_global_symbols!, src)
 
     resize!(src.slotnames, nslots)
     resize!(src.slotflags, nslots)

--- a/test/test_virtualprocess.jl
+++ b/test/test_virtualprocess.jl
@@ -45,6 +45,36 @@ end
         end
         @test isempty(res.toplevel_error_reports)
     end
+
+    let
+        res = @analyze_toplevel begin
+            module A
+            struct X end
+            export X
+            end
+
+            module B
+            import ..Main.A
+            println(A.X)
+            end
+
+            module C
+            import ..Main.A: X
+            println(X)
+            end
+
+            module D
+            using ..Main.A
+            println(X)
+            end
+
+            module E
+            using ..Main.A: X
+            println(X)
+            end
+        end
+        @test isempty(res.toplevel_error_reports)
+    end
 end
 
 @testset "fix toplevel global `Symbol`" begin


### PR DESCRIPTION
After #156, `fix_self_references!` replaces original self-referencing
`Symbol` with the un-canonicalized version of it, so that JET never uses
`Module` object in `CodeInfo` level.
That's especially because `Module` object is prohibited in module usage
expressions.

It turns out that the replaced `Symbol` can be something like
`var"Main.##JETVirtualModule##"`, and then abstract interpretation will
report false errors, just because it's not a valid global-ref.

This PR fixes it by only using symbolic replacements in module usages,
and keep to use `Module` object in other parts.