### PR TITLE
power-up module context virtualization

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -130,8 +130,6 @@ end
 SUITE["self profiling"] = @jetbenchmarkable(
     analyze_call(JET.virtual_process, (AbstractString,
                                        AbstractString,
-                                       Module,
-                                       Module,
                                        JET.JETInterpreter,
                                        JET.ToplevelConfig,
                                        )),

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -24,6 +24,7 @@ JET.AbstractGlobal
 
 ```@docs
 JET.virtual_process
+JET.virtualize_module_context
 JET.ConcreteInterpreter
 JET.partially_interpret!
 ```

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -459,14 +459,10 @@ end
 
 """
     report_file([io::IO = stdout],
-                filename::AbstractString,
-                mod::Module = Main;
+                filename::AbstractString;
                 jetconfigs...) -> res::ReportResult
 
 Analyzes `filename`, prints the collected error reports to the `io` stream, and finally returns $(@doc ReportResult)
-
-The following optional positional arguments can be specified:
-- `mod::Module`: the module context in which the top-level execution will be simulated
 
 This function will look for `$CONFIG_FILE_NAME` configuration file in the directory of `filename`,
   and search _up_ the file tree until any `$CONFIG_FILE_NAME` is (or isn't) found.
@@ -496,12 +492,11 @@ See [Configuration File](@ref) for more details.
     See [Logging Configurations](@ref) for more details.
 """
 function report_file(io::IO,
-                     filename::AbstractString,
-                     mod::Module = Main;
+                     filename::AbstractString;
                      # enable top-level info logger by default for entry from file
                      toplevel_logger::Union{Nothing,IO} = IOContext(io, LOGGER_LEVEL_KEY => INFO_LOGGER_LEVEL),
                      jetconfigs...)
-    res = analyze_file(filename, mod; toplevel_logger, jetconfigs...)
+    res = analyze_file(filename; toplevel_logger, jetconfigs...)
     return report_result(io, res; jetconfigs...)
 end
 report_file(args...; jetconfigs...) = report_file(stdout::IO, args...; jetconfigs...)
@@ -649,37 +644,27 @@ end
 """
     report_text([io::IO = stdout],
                 text::AbstractString,
-                filename::AbstractString = "top-level",
-                mod::Module = Main;
+                filename::AbstractString = "top-level";
                 jetconfigs...) -> res::ReportResult
 
 Analyzes `text`, prints the collected error reports to the `io` stream, and finally returns $(@doc ReportResult)
-
-The following optional positional arguments can be specified:
-- `filename`: the file containing `text` (if exists)
-- `mod::Module`: the module context in which the top-level execution will be simulated
 """
 function report_text(io::IO,
                      text::AbstractString,
-                     filename::AbstractString = "top-level",
-                     mod::Module = Main;
+                     filename::AbstractString = "top-level";
                      jetconfigs...)
-    res = analyze_text(text, filename, mod; jetconfigs...)
+    res = analyze_text(text, filename; jetconfigs...)
     return report_result(io, res; jetconfigs...)
 end
 report_text(args...; jetconfigs...) = report_text(stdout::IO, args...; jetconfigs...)
 
 function analyze_text(text::AbstractString,
-                      filename::AbstractString = "top-level",
-                      actualmod::Module = Main,
-                      virtualmod::Module = gen_virtual_module(actualmod);
+                      filename::AbstractString = "top-level";
                       jetconfigs...)
     interp = JETInterpreter(; jetconfigs...)
     config = ToplevelConfig(; jetconfigs...)
     return virtual_process(text,
                            filename,
-                           actualmod,
-                           virtualmod,
                            interp,
                            config,
                            )

--- a/src/print.jl
+++ b/src/print.jl
@@ -109,20 +109,19 @@ function print_reports(io::IO, res::VirtualProcessResult; jetconfigs...)
               res.toplevel_error_reports :
               res.inference_error_reports
 
-    postprocess = gen_postprocess(res.actual2virtual...)
-
-    return print_reports(io, reports, postprocess; jetconfigs...)
+    return print_reports(io, reports, gen_postprocess(res.actual2virtual); jetconfigs...)
 end
 
 # maybe test entry
 print_reports(args...; jetconfigs...) = print_reports(stdout::IO, args...; jetconfigs...)
 
-# fix virtual module printing based on string manipulation; the "actual" modules may not be
-# loaded into this process
-function gen_postprocess(actualmod, virtualmod)
+# when virtualized, fix virtual module printing based on string manipulation;
+# the "actual" modules may not be loaded into this process
+gen_postprocess(::Nothing) = return identity
+function gen_postprocess((actualmod, virtualmod)::Actual2Virtual)
     virtual = string(virtualmod)
     actual  = string(actualmod)
-    return actualmod == Main ?
+    return actualmod === Main ?
            Fix2(replace, "Main." => "") ∘ Fix2(replace, virtual => actual) :
            Fix2(replace, virtual => actual)
 end

--- a/src/watch.jl
+++ b/src/watch.jl
@@ -40,7 +40,6 @@ end
 """
     report_and_watch_file([io::IO = stdout],
                           filename::AbstractString,
-                          mod::Module = Main;
                           jetconfigs...)
 
 Watches `filename` and keeps re-triggering analysis with [`report_file`](@ref) on code update.

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -46,15 +46,13 @@ end
 
     @testset "special case splat call signature" begin
         let
-            vmod = gen_virtual_module()
-            res = @analyze_toplevel vmod begin
+            res = @analyze_toplevel begin
                 foo(args...) = sum(args)
                 foo(rand(Char, 1000000000)...)
             end
 
             io = IOBuffer()
-            postprocess = JET.gen_postprocess(res.actual2virtual...)
-            @test print_reports(io, res.inference_error_reports, postprocess)
+            @test print_reports(io, res.inference_error_reports, JET.gen_postprocess(res.actual2virtual))
             let s = String(take!(io))
                 @test occursin("1 possible error found", s)
                 @test occursin(Regex("@ $(escape_string(@__FILE__)):$((@__LINE__)-8)"), s) # toplevel call signature

--- a/test/test_virtualprocess.jl
+++ b/test/test_virtualprocess.jl
@@ -368,13 +368,12 @@ end
         f1 = normpath(FIXTURE_DIR, "include1.jl")
         f2 = normpath(FIXTURE_DIR, "include1.jl")
 
-        amod = @__MODULE__
-        vmod = gen_virtual_module(amod)
-        res = analyze_file(f1, amod, vmod)
+        context = gen_virtual_module(@__MODULE__)
+        res = analyze_file(f1; context, virtualize = false)
 
         @test f1 in res.included_files
         @test f2 in res.included_files
-        @test is_concrete(vmod, :foo)
+        @test is_concrete(context, :foo)
         @test isempty(res.toplevel_error_reports)
         @test isempty(res.inference_error_reports)
     end


### PR DESCRIPTION
- [x] test
- [ ] fix an error in abstract interpretation from the following snippet
   ```julia
   julia> report_file(JET.fullbasepath("math.jl");
                      context = Base,                  # `Base.Math`'s root module
                      analyze_from_definitions = true, # there're only definitions in `Base`
                      )
   ```