### PR TITLE
fix #118, never interacts with native code cache

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -17,6 +17,8 @@ JET.const_prop_entry_heuristic
 JET.analyze_task_parallel_code!
 JET.is_from_same_frame
 JET.AbstractGlobal
+JET.JET_REPORT_CACHE
+JET.JET_CODE_CACHE
 ```
 
 

--- a/docs/src/usages.md
+++ b/docs/src/usages.md
@@ -35,17 +35,6 @@ report_text
 
 There are utilities for checking JET analysis in a running Julia session like REPL or such.
 
-!!! warning
-    They are supposed to be used for testing of JET or some quick check, and you're not expected to use JET in the same
-    Julia session where you "seriously" run your code.
-    This is because JET analysis itself will create code cache, which isn't necessarily same as the code that Julia's native
-    compiler does. In particular, JET currently disables inlining for reasons and it can have a potent impact on the
-    performance of your code in actual execution.
-
-    JET in the future will offer a more "proper" UI to render analysis result to users, whose process isn't supposed to
-    interact with actual user's runtime in any way (I'm thinking of IDE/CI integration or such).
-    Then these utilities will only be used for testing of JET itself, and not be really user-facing.
-
 ```@docs
 report_call
 @report_call

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -29,8 +29,6 @@ function CC.typeinf(interp::JETInterpreter, frame::InferenceState)
 
     ret = @invoke typeinf(interp::AbstractInterpreter, frame::InferenceState)
 
-    push!(ANALYZED_LINFOS, linfo) # analyzed !
-
     interp.current_frame = prev_frame
 
     #= logging start =#
@@ -189,14 +187,14 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
             end
             push!(cache, AnalysisResult(linfo, given_argtypes, overridden_by_const, local_cache))
         elseif frame.cached # only cache when `NativeInterpreter` does
-            @assert !haskey(JET_GLOBAL_CACHE, linfo) || isentry "invalid global caching $linfo"
+            @assert !haskey(JET_REPORT_CACHE, linfo) || isentry "invalid global caching $linfo"
             global_cache = InferenceErrorReportCache[]
             for report in this_caches
                 # # TODO make this hold
                 # @assert first(report.st).linfo === linfo "invalid global caching"
                 cache_report!(global_cache, report)
             end
-            JET_GLOBAL_CACHE[linfo] = global_cache
+            JET_REPORT_CACHE[linfo] = global_cache
         end
     end
 


### PR DESCRIPTION
We need to carefully inspect the benchmark result on self-profiling.