### PR TITLE
set `at-optlevel` to 1

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -1,6 +1,9 @@
 @doc read(normpath(dirname(@__DIR__), "README.md"), String)
 module JET
 
+# not sure why, but a benchmark showed this is faster
+Base.Experimental.@optlevel 1
+
 const CC = Core.Compiler
 
 @static isdefined(CC, :AbstractInterpreter) || throw(ErrorException("JET.jl only works with Julia versions 1.6 and higher"))


### PR DESCRIPTION
Not too much sure why, but the benchmark on self-profiling showed that
setting that to `0` or `1` leads to faster analysis.