### PR TITLE
[experiment] better analysis performance

### DIFF
--- a/src/jetcache.jl
+++ b/src/jetcache.jl
@@ -21,12 +21,6 @@ This cache is completely separated from the `NativeInterpreter`'s global cache, 
 """
 const JET_CODE_CACHE = IdDict{UInt, IdDict{MethodInstance,CodeInstance}}()
 
-function CC.code_cache(interp::JETInterpreter)
-    cache  = JETGlobalCache(interp)
-    worlds = WorldRange(get_world_counter(interp))
-    return WorldView(cache, worlds)
-end
-
 struct JETGlobalCache
     interp::JETInterpreter
 end
@@ -36,6 +30,50 @@ jet_report_cache(interp::JETInterpreter)         = JET_REPORT_CACHE[cache_key(in
 jet_report_cache(wvc::WorldView{JETGlobalCache}) = jet_report_cache(wvc.cache.interp)
 jet_code_cache(interp::JETInterpreter)           = JET_CODE_CACHE[cache_key(interp)]
 jet_code_cache(wvc::WorldView{JETGlobalCache})   = jet_code_cache(wvc.cache.interp)
+
+function CC.code_cache(interp::JETInterpreter)
+    cache  = JETGlobalCache(interp)
+    worlds = WorldRange(get_world_counter(interp))
+    return WorldView(cache, worlds)
+end
+
+function CC.cache_result!(interp::JETInterpreter, result::InferenceResult)
+    valid_worlds = result.valid_worlds
+    if CC.last(valid_worlds) == get_world_counter()
+        # if we've successfully recorded all of the backedges in the global reverse-cache,
+        # we can now widen our applicability in the global cache too
+        valid_worlds = WorldRange(CC.first(valid_worlds), typemax(UInt))
+    end
+
+    linfo = result.linfo
+
+    # check if the existing linfo metadata is also sufficient to describe the current inference result
+    # to decide if it is worth caching this
+    already_inferred = CC.already_inferred_quick_test(interp, linfo)
+    if !already_inferred && CC.haskey(WorldView(code_cache(interp), valid_worlds), linfo)
+        already_inferred = true
+    end
+    # TODO: also don't store inferred code if we've previously decided to interpret this function
+    if !already_inferred
+        inferred_result = CC.transform_result_for_cache(interp, linfo, valid_worlds, result.src)
+
+        # cache code
+        jet_code_cache(code_cache(interp))[linfo] = CodeInstance(result, inferred_result, valid_worlds)
+
+        # cache reports
+        cache = jet_report_cache(interp)
+        @static JET_DEV_MODE && @assert !haskey(cache, linfo) || isentry "invalid global caching $linfo"
+        global_cache = InferenceErrorReportCache[]
+        for report in report_store(result)
+            # # TODO make this hold
+            # @assert first(report.st).linfo === linfo "invalid global caching"
+            cache_report!(global_cache, report)
+        end
+        cache[linfo] = global_cache
+    end
+    unlock_mi_inference(interp, result.linfo)
+    nothing
+end
 
 CC.haskey(wvc::WorldView{JETGlobalCache}, mi::MethodInstance) = haskey(jet_code_cache(wvc), mi)
 
@@ -47,9 +85,10 @@ function CC.get(wvc::WorldView{JETGlobalCache}, mi::MethodInstance, default)
         global_cache = get(jet_report_cache(wvc), mi, nothing)
         if isa(global_cache, Vector{InferenceErrorReportCache})
             interp = wvc.cache.interp
+            sv = interp.current_frame
             for cached in global_cache
-                restored = restore_cached_report!(cached, interp)
-                push!(interp.to_be_updated, restored) # should be updated in `abstract_call` (after exiting `typeinf_edge`)
+                restored = restore_cached_report!(cached, sv)
+                report!(sv, restored)
                 # # TODO make this hold
                 # @assert first(cached.vst).linfo === mi "invalid global restoring"
             end
@@ -102,70 +141,72 @@ end
 # local cache
 # ===========
 
-struct JETLocalCache
-    interp::JETInterpreter
-    cache::Vector{InferenceResult}
-end
+CC.get_inference_cache(interp::JETInterpreter) = get_inference_cache(interp.native)
 
-CC.get_inference_cache(interp::JETInterpreter) = JETLocalCache(interp, get_inference_cache(interp.native))
-
-function CC.cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::JETLocalCache)
-    inf_result = cache_lookup(linfo, given_argtypes, cache.cache)
-
-    isa(inf_result, InferenceResult) || return nothing
-
-    # constant prop' hits a cycle (recur into same non-constant analysis), we just bail out
-    isa(inf_result.result, InferenceState) && return inf_result
-
-    # cache hit, try to restore local report caches
-    interp = cache.interp
-    sv = interp.current_frame::InferenceState
-
-    analysis_result = jet_cache_lookup(linfo, given_argtypes, interp.cache)
-
-    # corresponds to report throw away logic in `_typeinf(interp::JETInterpreter, frame::InferenceState)`
-    filter!(!is_from_same_frame(sv.linfo, linfo), interp.reports)
-
-    if isa(analysis_result, AnalysisResult)
-        for cached in analysis_result.cache
-            restored = restore_cached_report!(cached, interp)
-            push!(interp.to_be_updated, restored) # should be updated in `abstract_call_method_with_const_args`
-            # # TODO make this hold
-            # @assert first(cached.vst).linfo === linfo "invalid local restoring"
-        end
-    end
-
-    return inf_result
-end
-
-# should sync with the implementation of `cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::Vector{InferenceResult})`
-function jet_cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::Vector{AnalysisResult})
-    method = linfo.def::Method
-    nargs::Int = method.nargs
-    method.isva && (nargs -= 1)
-    length(given_argtypes) >= nargs || return nothing
-    for cached_result in cache
-        cached_result.linfo === linfo || continue
-        cache_match = true
-        cache_argtypes = cached_result.argtypes
-        cache_overridden_by_const = cached_result.overridden_by_const
-        for i in 1:nargs
-            if !is_argtype_match(given_argtypes[i],
-                                 cache_argtypes[i],
-                                 CC.getindex(cache_overridden_by_const, i))
-                cache_match = false
-                break
-            end
-        end
-        if method.isva && cache_match
-            cache_match = is_argtype_match(tuple_tfunc(given_argtypes[(nargs + 1):end]),
-                                           cache_argtypes[end],
-                                           CC.getindex(cache_overridden_by_const, CC.length(cache_overridden_by_const)))
-        end
-        cache_match || continue
-        return cached_result
-    end
-    return nothing
-end
-
-CC.push!(cache::JETLocalCache, inf_result::InferenceResult) = CC.push!(cache.cache, inf_result)
+# struct JETLocalCache
+#     interp::JETInterpreter
+#     cache::Vector{InferenceResult}
+# end
+#
+# CC.get_inference_cache(interp::JETInterpreter) = JETLocalCache(interp, get_inference_cache(interp.native))
+#
+# function CC.cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::JETLocalCache)
+#     inf_result = cache_lookup(linfo, given_argtypes, cache.cache)
+#
+#     isa(inf_result, InferenceResult) || return nothing
+#
+#     # constant prop' hits a cycle (recur into same non-constant analysis), we just bail out
+#     isa(inf_result.result, InferenceState) && return inf_result
+#
+#     # cache hit, try to restore local report caches
+#     interp = cache.interp
+#     sv = interp.current_frame::InferenceState
+#
+#     analysis_result = jet_cache_lookup(linfo, given_argtypes, interp.cache)
+#
+#     # corresponds to report throw away logic in `_typeinf(interp::JETInterpreter, frame::InferenceState)`
+#     filter!(!is_from_same_frame(sv.linfo, linfo), interp.reports)
+#
+#     if isa(analysis_result, AnalysisResult)
+#         for cached in analysis_result.cache
+#             restored = restore_cached_report!(cached, sv)
+#             push!(interp.to_be_updated, restored) # should be updated in `abstract_call_method_with_const_args`
+#             # # TODO make this hold
+#             # @assert first(cached.vst).linfo === linfo "invalid local restoring"
+#         end
+#     end
+#
+#     return inf_result
+# end
+#
+# # should sync with the implementation of `cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::Vector{InferenceResult})`
+# function jet_cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::Vector{AnalysisResult})
+#     method = linfo.def::Method
+#     nargs::Int = method.nargs
+#     method.isva && (nargs -= 1)
+#     length(given_argtypes) >= nargs || return nothing
+#     for cached_result in cache
+#         cached_result.linfo === linfo || continue
+#         cache_match = true
+#         cache_argtypes = cached_result.argtypes
+#         cache_overridden_by_const = cached_result.overridden_by_const
+#         for i in 1:nargs
+#             if !is_argtype_match(given_argtypes[i],
+#                                  cache_argtypes[i],
+#                                  CC.getindex(cache_overridden_by_const, i))
+#                 cache_match = false
+#                 break
+#             end
+#         end
+#         if method.isva && cache_match
+#             cache_match = is_argtype_match(tuple_tfunc(given_argtypes[(nargs + 1):end]),
+#                                            cache_argtypes[end],
+#                                            CC.getindex(cache_overridden_by_const, CC.length(cache_overridden_by_const)))
+#         end
+#         cache_match || continue
+#         return cached_result
+#     end
+#     return nothing
+# end
+#
+# CC.push!(cache::JETLocalCache, inf_result::InferenceResult) = CC.push!(cache.cache, inf_result)

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -376,12 +376,12 @@ function cache_report!(cache, report::T) where {T<:InferenceErrorReport}
     return push!(cache, new)
 end
 
-function restore_cached_report!(cache::InferenceErrorReportCache, interp)
+function restore_cached_report!(cache::InferenceErrorReportCache, sv::InferenceState)
     report = restore_cached_report(cache)
     if isa(report, UncaughtExceptionReport)
-        stash_uncaught_exception!(interp, report)
+        stash_uncaught_exception!(sv, report)
     else
-        report!(interp, report)
+        report!(sv, report)
     end
     return report
 end


### PR DESCRIPTION
In this PR I'm trying to improve the performance of abstraction interpretation based analysis.

Currently I'm refactoring the whole report maintenance and cache logic with Julia built with the following diff
> `git diff`
```diff
diff --git a/base/compiler/types.jl b/base/compiler/types.jl
index 773047d2b0..7983eb3de4 100644
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -29,9 +29,11 @@ mutable struct InferenceResult
     result # ::Type, or InferenceState if WIP
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
-    function InferenceResult(linfo::MethodInstance, given_argtypes = nothing, va_override=false)
+    metadata # may be used by external consumer
+    function InferenceResult(linfo::MethodInstance,
+        given_argtypes = nothing, va_override=false, metadata = nothing)
         argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes, va_override)
-        return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange())
+        return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange(), metadata)
     end
 end
 ```