### PR TITLE
CI: Remove `continue-on-error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         arch:
           - x64
           - x86
-        allow-failure: [true]
         exclude:
           - os: macOS-latest
             arch: x86

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:


### PR DESCRIPTION
If `allow-failure` is `true`, then even if the package tests fail, CI will still be green, and it will be difficult to notice if package tests start failing.

cc: @aviatesk 