### PR TITLE
add a report for detecting infinite iteration via return type

### DIFF
--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -247,6 +247,17 @@ function CC.abstract_call_method(interp::JETInterpreter, method::Method, @nospec
         end
     end
 
+    if method.name === :iterate
+        v, _, _ = ret
+        ret_type = (isa(v, Const) ? Core.Typeof(v.val) :
+                    isa(v, Core.PartialStruct) ? v.typ :
+                    isa(v, DataType) || isa(v, Union) ? v :
+                    return)::Type
+        if ret_type !== Union{Nothing, Tuple{Int64, Int64}}
+            report!(interp, InfiniteIterationErrorReport(interp, sv, ret_type))
+        end
+    end
+
     update_reports!(interp, sv)
 
     return ret

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -247,17 +247,6 @@ function CC.abstract_call_method(interp::JETInterpreter, method::Method, @nospec
         end
     end
 
-    if method.name === :iterate
-        v, _, _ = ret
-        ret_type = (isa(v, Const) ? Core.Typeof(v.val) :
-                    isa(v, Core.PartialStruct) ? v.typ :
-                    isa(v, DataType) || isa(v, Union) ? v :
-                    return)::Type
-        if ret_type !== Union{Nothing, Tuple{Int64, Int64}}
-            report!(interp, InfiniteIterationErrorReport(interp, sv, ret_type))
-        end
-    end
-
     update_reports!(interp, sv)
 
     return ret

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -298,6 +298,8 @@ extract_type_decls(x) = @isexpr(x, :(::)) ? last(x.args) : Any
 
 @reportdef DivideErrorReport(interp, sv)
 
+@reportdef InfiniteIterationErrorReport(interp, sv, ret_type::Type)
+
 # TODO we may want to hoist `InvalidConstXXX` errors into top-level errors
 
 @reportdef InvalidConstantRedefinition(interp, sv, mod::Module, name::Symbol, @nospecialize(t′), @nospecialize(t))
@@ -534,3 +536,5 @@ get_msg(::Type{UncaughtExceptionReport}, interp, sv, throw_blocks) = isone(lengt
     "may throw" :
     "may throw either of"
 get_msg(::Type{NativeRemark}, interp, sv, s) = s
+get_msg(::Type{InfiniteIterationErrorReport}, interp, sv, ret_type::Type) =
+    "invalid return type $ret_type for `iterate` method; should be Union{Nothing, Tuple{Any, Any}}"

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -298,7 +298,7 @@ extract_type_decls(x) = @isexpr(x, :(::)) ? last(x.args) : Any
 
 @reportdef DivideErrorReport(interp, sv)
 
-@reportdef InfiniteIterationErrorReport(interp, sv, ret_type::Type)
+@reportdef InfiniteIterationErrorReport(interp, sv)
 
 # TODO we may want to hoist `InvalidConstXXX` errors into top-level errors
 
@@ -536,5 +536,5 @@ get_msg(::Type{UncaughtExceptionReport}, interp, sv, throw_blocks) = isone(lengt
     "may throw" :
     "may throw either of"
 get_msg(::Type{NativeRemark}, interp, sv, s) = s
-get_msg(::Type{InfiniteIterationErrorReport}, interp, sv, ret_type::Type) =
-    "invalid return type $ret_type for `iterate` method; should be Union{Nothing, Tuple{Any, Any}}"
+get_msg(::Type{InfiniteIterationErrorReport}, interp, sv) =
+    "invalid return type for `iterate` method; should be Union{Nothing, Tuple{Any, Any}}"


### PR DESCRIPTION
Addresses #135 

Looks at the return type of an overloaded `iterate` method and reports an error if it's not `Union{Nothing, Tuple{Int64, Int64}}`.

TODO: make this work for `Union{Nothing, Tuple{<: Any, <: Any}}`