### PR TITLE
wip: report infinite iteration

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -47,6 +47,8 @@ import .CC:
     abstract_eval_special_value,
     abstract_eval_value,
     abstract_eval_statement,
+    typeinf_local,
+    abstract_iteration,
     # typeinfer.jl
     typeinf,
     _typeinf,
@@ -108,6 +110,7 @@ import .CC:
     BasicBlock,
     slot_id,
     widenconst,
+    widenconditional,
     ⊑,
     is_throw_call,
     tmerge,
@@ -401,6 +404,13 @@ macro jetconfigurable(funcdef)
     return esc(funcdef)
 end
 const _JET_CONFIGURATIONS = Dict{Symbol,Symbol}()
+
+macro get!(x, key, default)
+    return quote
+        x, key = $(esc(x)), $(esc(key))
+        haskey(x, key) ? x[key] : (x[key] = $(esc(default)))
+    end
+end
 
 # utils
 # -----

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -508,6 +508,17 @@ let s = sprint(showerror, DivideError())
     global get_msg(::Type{DivideErrorReport}, interp, sv::InferenceState) = s
 end
 
+@reportdef struct InfiniteIterationErrorReport <: InferenceErrorReport
+    @nospecialize(typ)
+end
+# if provided, use program counter where infinite iteration(s) is found
+function InfiniteIterationErrorReport(interp, sv::InferenceState, @nospecialize(typ), pc = nothing)
+    vst = VirtualFrame[get_virtual_frame(interp, sv, isnothing(pc) ? get_currpc(sv) : pc)]
+    msg = "iterate(::$typ) won't terminate"
+    sig = get_sig(interp, sv, isnothing(pc) ? get_stmt(sv) : get_stmt(sv, pc))
+    return InfiniteIterationErrorReport(vst, msg, sig, typ)
+end
+
 # TODO we may want to hoist `InvalidConstXXX` errors into top-level errors
 
 @reportdef struct InvalidConstantRedefinition <: InferenceErrorReport


### PR DESCRIPTION
WIP because I found this is better to be generalized to a control flow
analysis that checks for "never reaching exit points".
For As an example, `sum(a for a in NeverTeminate(::Int))` will come down
to `Base._fold_impl`, which directly uses `iterate(::NeverTeminate, [state])`,
against which the current implementation based on the iteration protocol
can't report an error.

> Adapated from https://github.com/JuliaLang/julia/blob/24d9eab45632bdb3120c9e664503745eb58aa2d6/base/reduce.jl#L53-L65

```julia
function _foldl_impl(op::OP, init, itr) where {OP}
    # Unroll the while loop once; if init is known, the call to op may
    # be evaluated at compile time
    y = iterate(itr)
    y === nothing && return init
    v = op(init, y[1])
    while true
        y = iterate(itr, y[2])
        y === nothing && break
        v = op(v, y[1])
    end
    return v
end
```

> In a lowered representation

```julia
CodeInfo(
1 ─       Core.NewvarNode(:(v))
│         y = Base.iterate(itr)
│   %3  = y === Base.nothing
└──       goto #3 if not %3
2 ─       return init
3 ─ %6  = Base.getindex(y, 1)
└──       v = (op)(init, %6)
4 ┄       goto #8 if not true
5 ─ %9  = Base.getindex(y, 2)
│         y = Base.iterate(itr, %9)
│   %11 = y === Base.nothing
└──       goto #7 if not %11
6 ─       goto #8
7 ─ %14 = v
│   %15 = Base.getindex(y, 1)
│         v = (op)(%14, %15)
└──       goto #4
8 ┄       return v
)
```

We can report infinite iteration by checking both `goto #3 if not %3` and
`goto #7 if not %11` never happens and thus this function never returns.

---

- closes #135 
- closes #179 