### PR TITLE
refactor report interface

### DIFF
--- a/.JET.toml
+++ b/.JET.toml
@@ -3,8 +3,5 @@ concretization_patterns = [
   "JET_DEV_MODE = x_",
   "EGAL_TYPES = x_",
   "_JET_CONFIGURATIONS = x_",
-  "INFERENCE_ERROR_REPORT_DECL2DOCS = x_",
-  "INFERENCE_ERROR_REPORT_FIELD_DECLS = x_",
-  "INFERENCE_ERROR_REPORT_FIELD_NAMES = x_",
-  "implement_cache_interfaces(x__)"
+  "INFERENCE_ERROR_REPORT_FIELD_DECLS = x_"
 ]

--- a/.JET.toml
+++ b/.JET.toml
@@ -2,5 +2,9 @@ analyze_from_definitions = true
 concretization_patterns = [
   "JET_DEV_MODE = x_",
   "EGAL_TYPES = x_",
-  "_JET_CONFIGURATIONS = x_"
+  "_JET_CONFIGURATIONS = x_",
+  "INFERENCE_ERROR_REPORT_DECL2DOCS = x_",
+  "INFERENCE_ERROR_REPORT_FIELD_DECLS = x_",
+  "INFERENCE_ERROR_REPORT_FIELD_NAMES = x_",
+  "implement_cache_interfaces(x__)"
 ]

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -38,7 +38,6 @@ JET.partially_interpret!
 JET.VirtualFrame
 JET.VirtualStackTrace
 JET.InferenceErrorReport
-JET.@reportdef
 JET.ToplevelErrorReport
 ```
 

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -447,18 +447,16 @@ include("virtualprocess.jl")
 include("watch.jl")
 include("print.jl")
 
-let
-    function implement_cache_interfaces(t0)
-        for t in subtypes(t0)
-            if isabstracttype(t)
-                implement_cache_interfaces(t)
-                continue
-            end
-            implement_cache_interface(t, @__MODULE__)
+function implement_cache_interfaces(t0, m)
+    for t in subtypes(t0)
+        if isabstracttype(t)
+            implement_cache_interfaces(t, m)
+            continue
         end
+        implement_cache_interface(t, m)
     end
-    implement_cache_interfaces(InferenceErrorReport)
 end
+implement_cache_interfaces(InferenceErrorReport, @__MODULE__)
 
 # entry
 # =====

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -202,6 +202,9 @@ _isexpr_check(ex::Expr, heads)                = in(ex.head, heads)
 _isexpr_check(ex::Expr, head::Symbol, n::Int) = ex.head === head && length(ex.args) == n
 _isexpr_check(ex::Expr, heads, n::Int)        = in(ex.head, heads) && length(ex.args) == n
 
+islnn(@nospecialize(_)) = false
+islnn(::LineNumberNode) = true
+
 """
     @invoke f(arg::T, ...; kwargs...)
 
@@ -338,9 +341,6 @@ macro withmixedhash(typedef)
     end
 end
 
-islnn(@nospecialize(_)) = false
-islnn(::LineNumberNode) = true
-
 """
     const EGAL_TYPES = $(EGAL_TYPES)
 
@@ -446,6 +446,19 @@ include("optimize.jl")
 include("virtualprocess.jl")
 include("watch.jl")
 include("print.jl")
+
+let
+    function implement_cache_interfaces(t0)
+        for t in subtypes(t0)
+            if isabstracttype(t)
+                implement_cache_interfaces(t)
+                continue
+            end
+            implement_cache_interface(t, @__MODULE__)
+        end
+    end
+    implement_cache_interfaces(InferenceErrorReport)
+end
 
 # entry
 # =====

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -447,17 +447,6 @@ include("virtualprocess.jl")
 include("watch.jl")
 include("print.jl")
 
-function implement_cache_interfaces(t0, m)
-    for t in subtypes(t0)
-        if isabstracttype(t)
-            implement_cache_interfaces(t, m)
-            continue
-        end
-        implement_cache_interface(t, m)
-    end
-end
-implement_cache_interfaces(InferenceErrorReport, @__MODULE__)
-
 # entry
 # =====
 

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -285,8 +285,7 @@ function CC.abstract_invoke(interp::JETInterpreter, argtypes::Vector{Any}, sv::I
     return ret
 end
 
-@eval struct InvalidInvokeErrorReport <: InferenceErrorReport
-    $(INFERENCE_ERROR_REPORT_FIELD_DECLS...)
+@reportdef struct InvalidInvokeErrorReport <: InferenceErrorReport
     argtypes::Vector{Any}
 end
 

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -285,9 +285,12 @@ function CC.abstract_invoke(interp::JETInterpreter, argtypes::Vector{Any}, sv::I
     return ret
 end
 
-@reportdef InvalidInvokeErrorReport(interp, sv, argtypes::Vector{Any})
+@eval struct InvalidInvokeErrorReport <: InferenceErrorReport
+    $(INFERENCE_ERROR_REPORT_FIELD_DECLS...)
+    argtypes::Vector{Any}
+end
 
-function get_msg(::Type{InvalidInvokeErrorReport}, interp, sv, argtypes::Vector{Any})
+function get_msg(::Type{InvalidInvokeErrorReport}, interp, sv::InferenceState, argtypes::Vector{Any})
     fallback_msg = "invalid invoke" # mostly because of runtime unreachable
 
     ft = widenconst(argtype_by_index(argtypes, 2))

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -545,7 +545,7 @@ restore_cached_report(cache::InferenceErrorReportCache) =
     cache.T(copy(cache.vst), cache.msg, cache.sig, cache.spec_args)::InferenceErrorReport
 
 # supposed to be called at top-level, and will define the report cache interface at pre-compile time
-# IDEA feels very dangerous, but `@generated` functions can replace the following logic
+# IDEA feels very dangerous, but `@generated` functions could nicely replace the following logic
 function implement_cache_interface(T::Type{<:InferenceErrorReport}, m::Module)
     spec_name2types = filter(
         ∉(INFERENCE_ERROR_REPORT_FIELD_NAMES)∘first, collect(zip(fieldnames(T), fieldtypes(T))))

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -103,6 +103,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
                 # the optimization so far has found this statement is never "reachable";
                 # JET reports it since it will invoke undef var error at runtime, or will just
                 # be dead code otherwise
+                # TODO use me: loc = get_lin(frame, get_codeloc(frame, idx))
                 report!(interp, LocalUndefVarErrorReport(interp, frame, sym))
             # else
                 # by excluding this pass, JET accepts some false negatives (i.e. don't report

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -103,8 +103,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
                 # the optimization so far has found this statement is never "reachable";
                 # JET reports it since it will invoke undef var error at runtime, or will just
                 # be dead code otherwise
-                # TODO use me: loc = get_lin(frame, get_codeloc(frame, idx))
-                report!(interp, LocalUndefVarErrorReport(interp, frame, sym))
+                report!(interp, LocalUndefVarErrorReport(interp, frame, sym, idx))
             # else
                 # by excluding this pass, JET accepts some false negatives (i.e. don't report
                 # those that may actually happen on actual execution)

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -48,8 +48,10 @@ end
             return bar # undefined in this pass
         end
         @test length(interp.reports) === 1
-        @test first(interp.reports) isa LocalUndefVarErrorReport
-        @test first(interp.reports).name === :bar
+        r = first(interp.reports)
+        @test r isa LocalUndefVarErrorReport
+        @test r.name === :bar
+        @test last(r.vst).line == (@__LINE__)-6
     end
 
     # deeper level
@@ -67,14 +69,18 @@ end
 
         interp, frame = Core.eval(m, :($analyze_call(baz, (Bool,))))
         @test length(interp.reports) === 1
-        @test first(interp.reports) isa LocalUndefVarErrorReport
-        @test first(interp.reports).name === :bar
+        r = first(interp.reports)
+        @test r isa LocalUndefVarErrorReport
+        @test r.name === :bar
+        @test last(r.vst).line == (@__LINE__)-10
 
         # works when cached
         interp, frame = Core.eval(m, :($analyze_call(baz, (Bool,))))
         @test length(interp.reports) === 1
-        @test first(interp.reports) isa LocalUndefVarErrorReport
-        @test first(interp.reports).name === :bar
+        r = first(interp.reports)
+        @test r isa LocalUndefVarErrorReport
+        @test r.name === :bar
+        @test last(r.vst).line == (@__LINE__)-18
     end
 
     # try to exclude false negatives as possible (by collecting reports in after-optimization pass)


### PR DESCRIPTION
- removed intrusive `@reportdef`
- use functions and `Core.eval` instead to remove duplicated code