### PR TITLE
process `invoke`d error location signature

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -83,6 +83,7 @@ import Core:
     Const,
     SSAValue,
     SlotNumber,
+    Argument,
     Slot,
     ReturnNode,
     SimpleVector,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ include("setup.jl")
         include("test_jetcache.jl")
     end
 
+    @testset "reports.jl" begin
+        include("test_reports.jl")
+    end
+
     # tests with Windows-paths is just an hell
     @static Sys.iswindows() || @testset "print.jl" begin
         include("test_print.jl")

--- a/test/test_reports.jl
+++ b/test/test_reports.jl
@@ -1,0 +1,40 @@
+# similar to ⊆, but respect the sequence, ignore char vs. string difference
+function ⫇(a, b)
+    normalize(@nospecialize(x)) = x
+    normalize(c::AbstractChar)  = string(c)
+    a = normalize.(a)
+    b = normalize.(b)
+
+    n = length(a)
+    i = 1
+    for bi in b
+        if a[i] == bi
+            i += 1
+        else
+            i = 1
+        end
+        i == n && return true
+    end
+    return false
+end
+
+@testset "error location signature" begin
+    interp, frame = analyze_call((Char,Char)) do a, b
+        a + b
+    end
+    @test length(interp.reports) == 1
+    r = first(interp.reports)
+    @test isa(r, NoMethodErrorReport)
+    @test Any['(', 'a', Char, ", ", 'b', Char, ')'] ⫇ r.sig
+end
+
+@testset ":invoke signature" begin
+    m = @fixturedef begin
+        foo(s::AbstractString) = throw(ArgumentError(s))
+    end
+    interp, frame = analyze_call(m.foo, (String,))
+    @test length(interp.reports) == 1
+    r = first(interp.reports)
+    @test isa(r, UncaughtExceptionReport)
+    @test Any['(', 's', String, ')', ArgumentError] ⫇ r.sig
+end


### PR DESCRIPTION
Before `@report_call rand(String)`:
```julia
┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:259 Random.rand(Random.default_rng(), _)
│┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:256 Random.rand(rng, Random.Sampler(rng, _, Random.Val(1)))
││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:253 Random.Sampler(rng, X, Random.Val(1))
│││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:139 Random.Sampler(Random.typeof_rng(rng), x, r)
││││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:145 Random.Sampler(::Type{Random.MersenneTwister}, ::Random.SamplerType{String}, ::Val{1})
│││││ may throw: Random.throw($(Expr(:invoke, MethodInstance for ArgumentError(::String), :(Random.ArgumentError), "Sampler for this object is not defined"))::ArgumentError)
││││└────────────────────────────────────────────────────────────────────────────────────
Union{}
```

After `@report_call rand(String)`:
```julia
═════ 1 possible error found ═════
┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:259 Random.rand(Random.default_rng(), _)
│┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:256 Random.rand(rng, Random.Sampler(rng, _, Random.Val(1)))
││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:253 Random.Sampler(rng, X, Random.Val(1))
│││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:139 Random.Sampler(Random.typeof_rng(rng), x, r)
││││┌ @ /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.7/Random/src/Random.jl:145 Random.Sampler(::Type{Random.MersenneTwister}, ::Random.SamplerType{String}, ::Val{1})
│││││ may throw: Random.throw(Random.ArgumentError("Sampler for this object is not defined")::ArgumentError)
││││└────────────────────────────────────────────────────────────────────────────────────
Union{}
```