### PR TITLE
wip: fix #203, setup configuration interface to ignore reports

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -202,6 +202,12 @@ else
     ignorelimited(@nospecialize(x)) = x
 end
 
+@static if isdefined(Base, Symbol("@aggressive_constprop"))
+    import Base: @aggressive_constprop
+else
+    macro aggressive_constprop(x) esc(x) end # not available
+end
+
 # macros
 # ------
 
@@ -848,7 +854,7 @@ function may_report_get_staged!(interp::JETInterpreter, mi::MethodInstance)
         ccall(:jl_code_for_staged, Any, (Any,), mi)
     catch err
         # if user code throws error, wrap and report it
-        report!(interp, GeneratorErrorReport(interp, mi, err))
+        @report!(GeneratorErrorReport(interp, mi, err))
     end
 end
 

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -57,7 +57,7 @@ function CC.abstract_call_gf_by_type(interp::JETInterpreter, @nospecialize(f),
     end
     if isa(info, MethodMatchInfo)
         if is_empty_match(info)
-            report!(interp, NoMethodErrorReport(interp, sv, atype))
+            @report!(NoMethodErrorReport(interp, sv, atype))
         end
     elseif isa(info, UnionSplitInfo)
         # check each match for union-split signature
@@ -74,7 +74,7 @@ function CC.abstract_call_gf_by_type(interp::JETInterpreter, @nospecialize(f),
         end
 
         if !isnothing(ts)
-            report!(interp, NoMethodErrorReport(interp, sv, ts))
+            @report!(NoMethodErrorReport(interp, sv, ts))
         end
     end
 
@@ -284,7 +284,7 @@ function CC.abstract_invoke(interp::JETInterpreter, argtypes::Vector{Any}, sv::I
         # if the error type (`Bottom`) is propagated from the `invoke`d call, the error has
         # already been reported within `typeinf_edge`, so ignore that case
         if !isa(ret.info, InvokeCallInfo)
-            report!(interp, InvalidInvokeErrorReport(interp, sv, argtypes))
+            @report!(InvalidInvokeErrorReport(interp, sv, argtypes))
         end
     end
 
@@ -364,7 +364,7 @@ function CC.abstract_eval_special_value(interp::JETInterpreter, @nospecialize(e)
             end
         else
             # report access to undefined global variable
-            report!(interp, GlobalUndefVarErrorReport(interp, sv, mod, name))
+            @report!(GlobalUndefVarErrorReport(interp, sv, mod, name))
 
             # `ret` at this point should be annotated as `Any` by `NativeInterpreter`, and we
             # just pass it as is to collect as much error points as possible within this frame
@@ -410,11 +410,11 @@ function CC.abstract_eval_value(interp::JETInterpreter, @nospecialize(e), vtypes
                     end
                 end
                 if !isempty(ts)
-                    report!(interp, NonBooleanCondErrorReport(interp, sv, ts))
+                    @report!(NonBooleanCondErrorReport(interp, sv, ts))
                 end
             else
                 if typeintersect(Bool, t) !== Bool
-                    report!(interp, NonBooleanCondErrorReport(interp, sv, t))
+                    @report!(NonBooleanCondErrorReport(interp, sv, t))
                     ret = Bottom
                 end
             end
@@ -535,7 +535,7 @@ function set_abstract_global!(interp::JETInterpreter, mod::Module, name::Symbol,
             prev_t = val.t
             if val.iscd && widenconst(prev_t) !== widenconst(t)
                 warn_invalid_const_global!(name)
-                report!(interp, InvalidConstantRedefinition(interp, sv, mod, name, widenconst(prev_t), widenconst(t)))
+                @report!(InvalidConstantRedefinition(interp, sv, mod, name, widenconst(prev_t), widenconst(t)))
                 return
             end
             prev_agv = val
@@ -545,7 +545,7 @@ function set_abstract_global!(interp::JETInterpreter, mod::Module, name::Symbol,
                 invalid = prev_t !== widenconst(t)
                 if invalid || !isa(t, Const)
                     warn_invalid_const_global!(name)
-                    invalid && report!(interp, InvalidConstantRedefinition(interp, sv, mod, name, prev_t, widenconst(t)))
+                    invalid && @report!(InvalidConstantRedefinition(interp, sv, mod, name, prev_t, widenconst(t)))
                     return
                 end
                 # otherwise, we can just redefine this constant, and Julia will warn it
@@ -560,7 +560,7 @@ function set_abstract_global!(interp::JETInterpreter, mod::Module, name::Symbol,
     # if this constant declaration is invalid, just report it and bail out
     if iscd && !isnew
         warn_invalid_const_global!(name)
-        report!(interp, InvalidConstantDeclaration(interp, sv, mod, name))
+        @report!(InvalidConstantDeclaration(interp, sv, mod, name))
         return
     end
 

--- a/src/legacy/abstractinterpretation
+++ b/src/legacy/abstractinterpretation
@@ -80,7 +80,7 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
         #=== abstract_call_gf_by_type patch point 1-1 start ===#
         if ts !== nothing
             # report `NoMethodErrorReport` for each union-split signature
-            $report!(interp, $NoMethodErrorReport(interp, sv, ts))
+            $(macroexpand(JET, :(@report!($NoMethodErrorReport(interp, sv, ts)))))
         end
         #=== abstract_call_gf_by_type patch point 1-1 end ===#
         info = UnionSplitInfo(infos)
@@ -104,7 +104,7 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
         #=== abstract_call_gf_by_type patch point 1-2 start ===#
         if $is_empty_match(info)
             # report `NoMethodErrorReport` for this call signature
-            $report!(interp, $NoMethodErrorReport(interp, sv, atype))
+            $(macroexpand(JET, :(@report!($NoMethodErrorReport(interp, sv, atype)))))
         end
         #=== abstract_call_gf_by_type patch point 1-2 end ===#
         applicable = matches.matches

--- a/src/legacy/abstractinterpretation
+++ b/src/legacy/abstractinterpretation
@@ -51,16 +51,7 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
                 add_remark!(interp, sv, "For one of the union split cases, too many methods matched")
                 return CallMeta(Any, false)
             end
-            #=== abstract_call_gf_by_type patch point 1-1 start ===#
-            info = MethodMatchInfo(matches)
-            if $is_empty_match(info)
-                if ts === nothing
-                    ts = Type[]
-                end
-                push!(ts, sig_n)
-            end
-            push!(infos, info)
-            #=== abstract_call_gf_by_type patch point 1-1 end ===#
+            push!(infos, MethodMatchInfo(matches))
             append!(applicable, matches)
             valid_worlds = intersect(valid_worlds, matches.valid_worlds)
             thisfullmatch = _any(match->(match::MethodMatch).fully_covers, matches)
@@ -77,13 +68,11 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
                 push!(fullmatch, thisfullmatch)
             end
         end
-        #=== abstract_call_gf_by_type patch point 1-1 start ===#
-        if ts !== nothing
-            # report `NoMethodErrorReport` for each union-split signature
-            $(macroexpand(JET, :(@report!($NoMethodErrorReport(interp, sv, ts)))))
-        end
-        #=== abstract_call_gf_by_type patch point 1-1 end ===#
         info = UnionSplitInfo(infos)
+        #=== abstract_call_gf_by_type patch point 1-1 start ===#
+        # report pass for no matching methods error
+        $report_pass!($NoMethodErrorReport, interp, sv, info, atype, argtypes)
+        #=== abstract_call_gf_by_type patch point 1-1 end ===#
     else
         mt = ccall(:jl_method_table_for, Any, (Any,), atype)
         if mt === nothing
@@ -102,10 +91,8 @@ function abstract_call_gf_by_type(interp::$JETInterpreter, @nospecialize(f), arg
         push!(fullmatch, _any(match->(match::MethodMatch).fully_covers, matches))
         info = MethodMatchInfo(matches)
         #=== abstract_call_gf_by_type patch point 1-2 start ===#
-        if $is_empty_match(info)
-            # report `NoMethodErrorReport` for this call signature
-            $(macroexpand(JET, :(@report!($NoMethodErrorReport(interp, sv, atype)))))
-        end
+        # report pass for no matching methods error
+        $report_pass!($NoMethodErrorReport, interp, sv, info, atype, argtypes)
         #=== abstract_call_gf_by_type patch point 1-2 end ===#
         applicable = matches.matches
         valid_worlds = matches.valid_worlds

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -1,0 +1,250 @@
+function report!(T::Type{<:InferenceErrorReport}, interp::JETInterpreter,  @nospecialize(spec_args...))
+    push!(interp.reports, T(interp, spec_args...))
+end
+
+function report!(T::Type{UncaughtExceptionReport}, interp::JETInterpreter,  @nospecialize(spec_args...))
+    push!(interp.uncaught_exceptions, T(interp, spec_args...))
+end
+
+@inline report_pass!(T::Type{<:InferenceErrorReport}, interp::JETInterpreter, linfo::Union{InferenceState,MethodInstance}, @nospecialize(spec_args...)) =
+    (JETAnalysisParams(interp).report_pass)(T, interp, linfo, spec_args...)
+
+"""
+    ReportPass
+
+An interface type for report passes of JET's analysis.
+"""
+abstract type ReportPass end
+
+"""
+    SoundPass <: ReportPass
+
+`ReportPass` for the sound JET analysis.
+This filter also provides the default implementation of `ReportPass`.
+"""
+struct SoundPass <: ReportPass end
+
+"""
+    BasicPass <: ReportPass
+
+`ReportPass` for the sound JET analysis.
+This filter also provides the default implementation of `ReportPass`.
+"""
+struct BasicPass <: ReportPass end
+
+# NOTE we would like to omit type declarations in `(::ReportPass)(::Type{<:InferenceErrorReport}, ...)`
+# definitions below, so that an user-defined report pass can easily exclude some of them by
+# overloading `(::CustomPass)(::Type{<:InferenceErrorReport}, @nospecialize(_...)) = return`
+
+# the fallback implementation does nothing, so that future additional report pass "declaration"
+# doesn't require the existing report pass traits to implement corresponding a report pass
+(::ReportPass)(T::Type{<:InferenceErrorReport}, interp, linfo, @nospecialize(spec_args...)) = return
+
+# NoMethodErrorReport
+
+function (::ReportPass)(::Type{NoMethodErrorReport}, interp, sv, info, @nospecialize(atype), argtypes)
+    if isa(info, MethodMatchInfo)
+        if is_empty_match(info)
+            report!(NoMethodErrorReport, interp, sv, atype)
+        end
+    elseif isa(info, UnionSplitInfo)
+        # check each match for union-split signature
+        split_argtypes = nothing
+        ts = nothing
+
+        for (i, matchinfo) in enumerate(info.matches)
+            if is_empty_match(matchinfo)
+                isnothing(split_argtypes) && (split_argtypes = switchtupleunion(argtypes))
+                isnothing(ts) && (ts = Type[])
+                sig_n = argtypes_to_type(split_argtypes[i])
+                push!(ts, sig_n)
+            end
+        end
+
+        if !isnothing(ts)
+            report!(NoMethodErrorReport, interp, sv, ts)
+        end
+    end
+end
+function is_empty_match(info::MethodMatchInfo)
+    res = info.results
+    isa(res, MethodLookupResult) || return false # when does this happen ?
+    return isempty(res.matches)
+end
+
+# InvalidReturnTypeCall
+
+function (::ReportPass)(::Type{InvalidReturnTypeCall}, interp, sv, argtypes)
+    # here we just check if the call of `return_type` is valid or not by very simple analysis
+    # we don't take (possible, but very unexpected) overloads into account here, just as
+    # `NativeInterpreter`'s `return_type_tfunc` hard-codes its return type to `Type`
+    if length(argtypes) ≠ 3
+        # invalid argument number, let's report and return error result (i.e. `Bottom`)
+        report!(InvalidReturnTypeCall, interp, sv)
+    end
+end
+
+# GlobalUndefVarErrorReport
+
+function (::ReportPass)(::Type{GlobalUndefVarErrorReport}, interp, sv, mod, name)
+    report!(GlobalUndefVarErrorReport, interp, sv, mod, name)
+end
+function (::BasicPass)(::Type{GlobalUndefVarErrorReport}, interp, sv, mod, name)
+    is_corecompiler_undefglobal(mod, name) && return
+    report!(GlobalUndefVarErrorReport, interp, sv, mod, name)
+end
+
+"""
+    is_corecompiler_undefglobal
+
+Returns `true` if this global reference is undefined inside `Core.Compiler`, but the
+  corresponding name exists in the `Base` module.
+`Core.Compiler` reuses the minimum amount of `Base` code and there're some of missing
+definitions, and `BasicPass` will exclude reports on those undefined names since they
+usually don't matter and `Core.Compiler`'s basic functionality is battle-tested and validated
+exhausively by its test suite and real-world usages
+"""
+is_corecompiler_undefglobal(mod::Module, name::Symbol) =
+    return mod === CC ? isdefined(Base, name) :
+           mod === CC.Sort ? isdefined(Base.Sort, name) :
+           false
+
+# LocalUndefVarErrorReport
+
+# these report passes use `:throw_undef_if_not` and `:(unreachable)` introduced by the native
+# optimization pass, and thus supposed to only work on post-optimization code
+(::ReportPass)(::Type{LocalUndefVarErrorReport}, interp, sv, stmts) =
+    report_undefined_local_slots!(interp, sv, stmts, false)
+(::BasicPass)(::Type{LocalUndefVarErrorReport}, interp, sv, stmts) =
+    report_undefined_local_slots!(interp, sv, stmts, true)
+
+function report_undefined_local_slots!(interp, sv, stmts::Vector{Any}, unsound::Bool)
+    for (idx, stmt) in enumerate(stmts)
+        if isa(stmt, Expr) && stmt.head === :throw_undef_if_not
+            sym::Symbol, _ = stmt.args
+
+            # slots in toplevel frame may be a abstract global slot
+            istoplevel(interp, frame) && is_global_slot(interp, sym) && continue
+
+            if unsound
+                next_idx = idx + 1
+                if checkbounds(Bool, stmts, next_idx) && is_unreachable(@inbounds stmts[next_idx])
+                    # the optimization so far has found this statement is never "reachable";
+                    # JET reports it since it will invoke undef var error at runtime, or will just
+                    # be dead code otherwise
+                    report!(LocalUndefVarErrorReport, interp, frame, sym, idx)
+                else
+                    # by excluding this pass, this analysis accepts some false negatives and
+                    # some undefined variable error may happen in actual execution (thus unsound)
+                end
+            else
+                report!(LocalUndefVarErrorReport, interp, frame, sym, idx)
+            end
+        end
+    end
+end
+
+# NonBooleanCondErrorReport
+
+function (::ReportPass)(::Type{NonBooleanCondErrorReport}, interp, sv, @nospecialize(t))
+    if isa(t, Union)
+        ts = Type[]
+        for t in Base.uniontypes(t)
+            if !(t ⊑ Bool)
+                push!(ts, t)
+            end
+        end
+        if !isempty(ts)
+            report!(NonBooleanCondErrorReport, interp, sv, ts)
+        end
+    else
+        if !(t ⊑ Bool)
+            report!(NonBooleanCondErrorReport, interp, sv, t)
+        end
+    end
+end
+function (::BasicPass)(::Type{NonBooleanCondErrorReport}, interp, sv, @nospecialize(t))
+    if isa(t, Union)
+        ts = Type[]
+        for t in Base.uniontypes(t)
+            if typeintersect(Bool, t) !== Bool
+                # TODO move this to abstractinterpretation.jl
+                if JETAnalysisParams(interp).strict_condition_check ||
+                   !(t <: Function || # !(::Function)
+                     t === Missing || # ==(::Missing, ::Any), ==(::Any, ::Missing), ...
+                     false)
+                    push!(ts, t)
+                end
+            end
+        end
+        if !isempty(ts)
+            report!(NonBooleanCondErrorReport, interp, sv, ts)
+        end
+    else
+        if typeintersect(Bool, t) !== Bool
+            report!(NonBooleanCondErrorReport, interp, sv, t)
+        end
+    end
+end
+
+# InvalidConstantRedefinition
+
+function (::ReportPass)(::Type{InvalidConstantRedefinition}, interp, sv, mod, name, @nospecialize(prev_t), @nospecialize(t))
+    report!(InvalidConstantRedefinition, interp, sv, mod, name, prev_t, t)
+end
+
+# InvalidConstantDeclaration
+
+function (::ReportPass)(::Type{InvalidConstantDeclaration}, interp, sv, mod, name)
+    report!(InvalidConstantDeclaration, interp, sv, mod, name, prev_t, t)
+end
+
+# GeneratorErrorReport
+
+# XXX what's the "soundness" of a `@generated` function ?
+# adapated from https://github.com/JuliaLang/julia/blob/f806df603489cfca558f6284d52a38f523b81881/base/compiler/utilities.jl#L107-L137
+function (::ReportPass)(::Type{GeneratorErrorReport}, interp, mi)
+    m = mi.def::Method
+    if isdefined(m, :generator)
+        # analyze_method_instance!(interp, linfo) XXX doesn't work
+        may_invoke_generator(mi) || return
+        try
+            ccall(:jl_code_for_staged, Any, (Any,), mi)
+        catch err
+            # if user code throws error, wrap and report it
+            report!(GeneratorErrorReport, interp, mi, err)
+        end
+    end
+end
+
+# SeriousExceptionReport
+
+function (::ReportPass)(::Type{SeriousExceptionReport}, interp, sv, argtypes)
+    if length(argtypes) ≥ 1
+        a = first(argtypes)
+        if isa(a, Const)
+            v = a.val
+            if isa(v, UndefKeywordError)
+                report!(UndefKeywordErrorReport, interp, sv, v, get_lin(sv))
+            end
+        end
+    end
+end
+
+# NativeRemark
+
+# ignores `NativeRemark`s by default
+(::ReportPass)(::Type{NativeRemark}, interp, sv, s) = return
+
+# InvalidInvokeErrorReport
+
+function (::ReportPass)(::Type{InvalidInvokeErrorReport}, interp, sv, rt, argtypes)
+    if ret.rt === Bottom
+        # here we report error that happens at the call of `invoke` itself.
+        # if the error type (`Bottom`) is propagated from the `invoke`d call, the error has
+        # already been reported within `typeinf_edge`, so ignore that case
+        if !isa(ret.info, InvokeCallInfo)
+            report!(InvalidInvokeErrorReport, interp, sv, argtypes)
+        end
+    end
+end

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -379,9 +379,9 @@ end
 function restore_cached_report!(cache::InferenceErrorReportCache, interp)
     report = restore_cached_report(cache)
     if isa(report, UncaughtExceptionReport)
-        stash_uncaught_exception!(interp, report)
+        push!(interp.uncaught_exceptions, report)
     else
-        report!(interp, report)
+        push!(interp.reports, report)
     end
     return report
 end

--- a/src/tfuncs.jl
+++ b/src/tfuncs.jl
@@ -16,7 +16,7 @@ function CC.builtin_tfunction(interp::JETInterpreter, @nospecialize(f), argtypes
             if isa(a, Const)
                 v = a.val
                 if isa(v, UndefKeywordError)
-                    report!(interp, UndefKeywordErrorReport(interp, sv, v, get_lin(sv)))
+                    @report!(UndefKeywordErrorReport(interp, sv, v, get_lin(sv)))
                 end
             end
         end
@@ -40,13 +40,13 @@ function CC.builtin_tfunction(interp::JETInterpreter, @nospecialize(f), argtypes
                             # TODO; `ret` should be `Any` here, add report pass here (for performance linting)
                         else
                             # report access to undefined global variable
-                            report!(interp, GlobalUndefVarErrorReport(interp, sv, mod, name))
+                            @report!(GlobalUndefVarErrorReport(interp, sv, mod, name))
                             # return Bottom
                         end
                     elseif ret === Bottom
                         # general case when an error is detected by the native `getfield_tfunc`
                         typ = widenconst(obj)
-                        report!(interp, NoFieldErrorReport(interp, sv, typ, name))
+                        @report!(NoFieldErrorReport(interp, sv, typ, name))
                         return ret
                     end
                 end
@@ -75,7 +75,7 @@ function CC.builtin_tfunction(interp::JETInterpreter, @nospecialize(f), argtypes
         t = widenconst(a)
         if t <: Base.BitSigned64 || t <: Base.BitUnsigned64
             if isa(a, Const) && a.val === zero(t)
-                report!(interp, DivideErrorReport(interp, sv))
+                @report!(DivideErrorReport(interp, sv))
                 return Bottom
             end
         end
@@ -85,7 +85,7 @@ function CC.builtin_tfunction(interp::JETInterpreter, @nospecialize(f), argtypes
         # XXX: for general case, JET just relies on the (maybe too persmissive) return type
         # from native tfuncs to report invalid builtin calls and probably there're lots of
         # false negatives
-        report!(interp, InvalidBuiltinCallErrorReport(interp, sv, argtypes))
+        @report!(InvalidBuiltinCallErrorReport(interp, sv, argtypes))
     end
 
     return ret
@@ -111,7 +111,7 @@ function CC.return_type_tfunc(interp::JETInterpreter, argtypes::Vector{Any}, sv:
     # `NativeInterpreter`'s `return_type_tfunc` hard-codes its return type to `Type`
     if length(argtypes) ≠ 3
         # invalid argument number, let's report and return error result (i.e. `Bottom`)
-        report!(interp, InvalidReturnTypeCall(interp, sv))
+        @report!(InvalidReturnTypeCall(interp, sv))
         return @static isdefined(CC, :ReturnTypeCallInfo) ?
                CallMeta(Bottom, false) :
                Bottom

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -93,7 +93,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
     # `:(unreachable)` are introduced by `optimize`
     for (idx, stmt) in enumerate(stmts)
         if isa(stmt, Expr) && stmt.head === :throw_undef_if_not
-            sym, _ = stmt.args
+            sym::Symbol, _ = stmt.args
 
             # slots in toplevel frame may be a abstract global slot
             istoplevel(interp, frame) && is_global_slot(interp, sym) && continue
@@ -103,7 +103,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
                 # the optimization so far has found this statement is never "reachable";
                 # JET reports it since it will invoke undef var error at runtime, or will just
                 # be dead code otherwise
-                report!(interp, LocalUndefVarErrorReport(interp, frame, sym, idx))
+                @report!(LocalUndefVarErrorReport(interp, frame, sym, idx))
             # else
                 # by excluding this pass, JET accepts some false negatives (i.e. don't report
                 # those that may actually happen on actual execution)
@@ -142,7 +142,7 @@ function CC._typeinf(interp::JETInterpreter, frame::InferenceState)
             push!(throw_calls, stmt)
         end
         if !isempty(throw_calls)
-            stash_uncaught_exception!(interp, UncaughtExceptionReport(interp, frame, throw_calls))
+            @report!(UncaughtExceptionReport(interp, frame, throw_calls), :uncaught_exceptions)
         end
     else
         # the non-`Bottom` result here may mean `throw` calls from the children frames

--- a/src/virtualprocess.jl
+++ b/src/virtualprocess.jl
@@ -334,7 +334,9 @@ function virtualize_module_context(actual::Module)
     return virtual
 end
 
-gen_virtual_module(root = Main; name = :JETVirtualModule) =
+const VIRTUAL_MODULE_NAME = :JETVirtualModule
+
+gen_virtual_module(root = Main; name = VIRTUAL_MODULE_NAME) =
     Core.eval(root, :(module $(gensym(name)) end))::Module
 
 function analyze_from_definitions!(interp::JETInterpreter, res::VirtualProcessResult)
@@ -598,7 +600,9 @@ function _virtual_process!(toplevelex::Expr,
     return res
 end
 
-split_module_path(m) = Symbol.(split(string(m), '.'))
+split_module_path(::Type{String}, m::Module) = split(string(m), '.')
+split_module_path(::Type{Symbol}, m::Module) = Symbol.(split_module_path(String, m))
+split_module_path(m::Module)                 = split_module_path(Symbol, m)
 
 # if virtualized, replace self references of `actualmod` with `virtualmod` (as is)
 fix_self_references!(::Nothing, x) = return
@@ -692,13 +696,13 @@ The trait to inject code into JuliaInterpreter's interpretation process; JET.jl 
 - `JuliaInterpreter.handle_err` to wrap an error happened during interpretation into
     `ActualErrorWrapped`
 """
-struct ConcreteInterpreter
+struct ConcreteInterpreter{X}
     filename::String
     lnn::LineNumberNode
     eval_with_err_handling::Function
     context::Module
     interp::JETInterpreter
-    config::ToplevelConfig
+    config::ToplevelConfig{X}
     res::VirtualProcessResult
 end
 


### PR DESCRIPTION
This PR set-ups `ignored_patterns` interface to ignore certain patterns
of reports, which can be configured by users extensively.

`ignored_patterns` is supposed to be an iterator of predicate function
and if any of given `ignored_patterns` matches a report in question,
the report will just be ignored (and nor cached).
The predicate function will be called _before_ a report is actually
constructed for the possible cut-off of the computational cost to
construct the report. Thus its signature is: `(T::Type{<:InferenceErrorReport}, interp::JETInterpreter, sv::InferenceState, spec_args::Tuple)`, where:
- `T` specifies the kind of report
- `interp` gives the context of whole analysis
- `sv::InferenceState` gives the local context of analysis
- and `spec_args` will be report-specific arguments

To inject predicate checks, now each report is constructed via `@report!`
macro, which first checks if the report matches any of `ignored_patterns`,
and if not, constructs the report and pushes it to `JETInterpreter` as
the previous `report!` function did.

This PR also defines `DEFAULT_IGNORED_PATTERNS`, namely `ignored_patterns`
applied by default. Currently it consists of `ignore_corecompiler_undefglobal`,
which ignores undefined global names in `Core.Compiler`, and it should
have some positive effects, like reduce false positive error reports
involved with `Base.return_types` and its family in general, improve
analysis performance for JET's self-profiling, etc.

The support of user-predicate functions specified via .JET configuration
file is somewhat tricky, but currently this PR uses RuntimeGeneratedFunctions.jl
and it seems to work. I'm not sure if `@nospecialize` notations works
correctly in `RuntimeGeneratedFunction`s, so some insights or benchmarks
on it will be very welcomed.