### PR TITLE
report `MethodError`s thrown by `throw` calls

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -136,7 +136,7 @@ end
 SUITE["self analysis"] = @jetbenchmarkable(
     begin
         analyzer = JET.JETAnalyzer()
-        m = methods(JET.virtual_process).ms[1]
+        m = only(methods(JET.virtual_process))
         JET.analyze_method!(analyzer, m)
     end,
     setup = begin

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -240,6 +240,10 @@ mutable struct AnalyzerState
     # stashes `UncaughtExceptionReport`s that are not caught so far
     uncaught_exceptions::Vector{UncaughtExceptionReport}
 
+    # keeps locations where `SeriousExceptionReport` are reported, in order to avoid
+    # duplicated `UncaughtExceptionReport`s on same `throw` calls
+    throw_locs::Vector{LineInfoNode}
+
     # keeps reports that should be updated when returning back the parent frame (i.e. the next time we get back to inter-procedural context)
     to_be_updated::Set{InferenceErrorReport}
 
@@ -303,6 +307,7 @@ end
                          get_cache_key_per_config(analysis_params, inf_params),
                          InferenceErrorReport[],
                          UncaughtExceptionReport[],
+                         LineInfoNode[],
                          Set{InferenceErrorReport}(),
                          current_frame,
                          false,

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -201,8 +201,6 @@ function Base.getproperty(er::InferenceErrorReport, sym::Symbol)
         getfield(er, sym)::String
     elseif sym === :sig
         getfield(er, sym)::Vector{Any}
-    elseif sym === :lin # only needed for SeriousExceptionReport
-        getfield(er, sym)::LineInfoNode
     else
         getfield(er, sym) # fallback
     end
@@ -248,6 +246,8 @@ restore_cached_report(cache::InferenceErrorReportCache) =
 
 # utility
 # -------
+
+# TODO parametric definition
 
 # a simple utility macro to define `InferenceErrorReport` w/o code duplications
 macro reportdef(ex)

--- a/src/print.jl
+++ b/src/print.jl
@@ -368,4 +368,4 @@ end
 print_error_report(io, report::NoFieldErrorReport)       = printlnstyled(io, "│ ", report.msg; color = ERROR_COLOR)
 print_error_report(io, report::LocalUndefVarErrorReport) = printlnstyled(io, "│ ", report.msg; color = ERROR_COLOR)
 print_error_report(io, report::DivideErrorReport)        = printlnstyled(io, "│ ", report.msg; color = ERROR_COLOR)
-print_error_report(io, report::UndefKeywordErrorReport)  = printlnstyled(io, "│ ", report.msg; color = ERROR_COLOR)
+print_error_report(io, report::SeriousExceptionReport)   = printlnstyled(io, "│ ", report.msg; color = ERROR_COLOR)


### PR DESCRIPTION
Now JET can report an error from `sum([])`.
```julia
julia> @report_call sum([])
═════ 1 possible error found ═════
┌ @ reducedim.jl:889 Base.#sum#724(Base.:, Base.pairs(Core.NamedTuple()), #self#, a)
│┌ @ reducedim.jl:889 Base._sum(a, dims)
││┌ @ reducedim.jl:893 Base.#_sum#726(Base.pairs(Core.NamedTuple()), #self#, a, _3)
│││┌ @ reducedim.jl:893 Base._sum(Base.identity, a, Base.:)
││││┌ @ reducedim.jl:894 Base.#_sum#727(Base.pairs(Core.NamedTuple()), #self#, f, a, _4)
│││││┌ @ reducedim.jl:894 Base.mapreduce(f, Base.add_sum, a)
││││││┌ @ reducedim.jl:322 Base.#mapreduce#717(Base.:, Base._InitialValue(), #self#, f, op, A)
│││││││┌ @ reducedim.jl:322 Base._mapreduce_dim(f, op, init, A, dims)
││││││││┌ @ reducedim.jl:330 Base._mapreduce(f, op, Base.IndexStyle(A), A)
│││││││││┌ @ reduce.jl:402 Base.mapreduce_empty_iter(f, op, A, Base.IteratorEltype(A))
││││││││││┌ @ reduce.jl:353 Base.reduce_empty_iter(Base.MappingRF(f, op), itr, ItrEltype)
│││││││││││┌ @ reduce.jl:357 Base.reduce_empty(op, Base.eltype(itr))
││││││││││││┌ @ reduce.jl:331 Base.mapreduce_empty(Base.getproperty(op, :f), Base.getproperty(op, :rf), _)
│││││││││││││┌ @ reduce.jl:345 Base.reduce_empty(op, T)
││││││││││││││┌ @ reduce.jl:322 Base.reduce_empty(Base.+, _)
│││││││││││││││┌ @ reduce.jl:313 Base.zero(_)
││││││││││││││││┌ @ missing.jl:106 Base.throw(Base.MethodError(Base.zero, Core.tuple(Base.Any)))
│││││││││││││││││ MethodError: no method matching zero(::Type{Any})
```