### PR TITLE
sort out interfaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JET"
 uuid = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 authors = ["Shuhei Kadowaki <aviatesk@gmail.com>"]
-version = "0.4.6"
+version = "0.5.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,9 +51,15 @@ function generate_api_doc(examples_pages)
         examples_contents = codeblock("Pages = $(repr(examples_pages))", "@contents")
 
         s = md"""
-        # JET.jl Pluggable Analysis Framework
+        # [JET Analyzer Framework](@id JET-Analyzer-Framework)
 
         $contents
+
+        JET offers an infrastructure to implement a "plugin" code analyzer.
+        Actually, JET's default error analyzer that explained [in the usage section](@ref usages)
+        is one specific instance of such a pluggin analyzer built on top of the framework.
+
+        In this documentation we will try to elaborate the framework APIs and showcase example analyzers.
 
         !!! warning
             The APIs described in this page is _very_ experimental and subject to changes.
@@ -89,7 +95,7 @@ let
                     "Usages" => "usages.md",
                     "Configurations" => "config.md",
                     "Internals" => "internals.md",
-                    "Pluggable Analysis Framework" => Any[
+                    "JET Analyzer Framework" => Any[
                         "API"      => generate_api_doc(examples),
                         "Examples" => examples,
                     ]

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -1,7 +1,7 @@
-# [Configurations](@id JET configurations)
+# [Configurations](@id JET-configurations)
 
 JET analysis can be flexibly fine-tuned.
-Any entry point explained in the [Usages](@ref) section can accept any of the configuration parameters described below
+Any entry point explained in [the usage section](@ref usages) can accept any of the configuration parameters described below
 as keyword arguments (or optional parameters for the interactive macros).
 For example, if you want to analyze `some/awesome/code.jl` with turning on `strict_condition_check` configuration and
 also logs inference process into `stdout`, you can do:
@@ -22,7 +22,7 @@ JET.ToplevelConfig
 ```
 
 
-## Configurations for Abstract Interpretation
+## [Configurations for Abstract Interpretation](@id abstractinterpret-config)
 
 ```@docs
 JET.JETAnalysisParams

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,12 +1,12 @@
 # Internals of JET.jl
 
-## [Abstract Interpretation Based Analysis](@ref abstract-interpretaion)
+## [Abstract Interpretation Based Analysis](@id abstractinterpret-analysis)
 
 JET.jl overloads functions with the [`Core.Compiler.AbstractInterpreter` interface](https://github.com/JuliaLang/julia/blob/master/base/compiler/types.jl), and customizes its abstract interpretation routine.
 The overloads are done on `AbstractAnalyzer <: AbstractInterpreter` so that `typeinf(::AbstractAnalyzer, ::InferenceState)` will do the customized abstract interpretation and collect type errors.
 
 Most overloads use the [`invoke`](https://docs.julialang.org/en/v1/base/base/#Core.invoke) reflection, which allows
-[`AbstractAnalyzer`](@ref) to dispatch to the original `AbstractInterpreter`'s abstract interpretation methods and still keep passing
+[`JET.AbstractAnalyzer`](@ref) to dispatch to the original `AbstractInterpreter`'s abstract interpretation methods and still keep passing
 it to the subsequent (maybe overloaded) callees (see [`JET.@invoke`](@ref) macro).
 
 ```@docs
@@ -22,7 +22,7 @@ JET.JET_CODE_CACHE
 ```
 
 
-## Top-level Analysis
+## [Top-level Analysis](@id top-level-analysis)
 
 ```@docs
 JET.virtual_process

--- a/docs/src/usages.md
+++ b/docs/src/usages.md
@@ -1,4 +1,4 @@
-# [How to Use JET.jl](@id Usages)
+# [How to Use JET.jl](@id usages)
 
 !!! note
     JET's analysis entry points follow the naming conventions below:

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -52,20 +52,20 @@ JETInterfaces.AbstractAnalyzer(analyzer::UnstableAPIAnalyzer, state::AnalyzerSta
     UnstableAPIAnalyzer(state, analyzer.is_target_module)
 JETInterfaces.ReportPass(analyzer::UnstableAPIAnalyzer) = UnstableAPIAnalysisPass()
 
-# Nest, we overload some of `Core.Compiler`'s [abstract interpretation](@ref abstract-interpretaion) methods,
-# and inject a customized analysis pass (`UnstableAPIAnalysisPass`).
+# Next, we overload some of `Core.Compiler`'s [abstract interpretation](@ref abstractinterpret-analysis) methods,
+# and inject a customized analysis pass (here we gonna name it `UnstableAPIAnalysisPass`).
 # In this analysis, we are interested in whether a binding that appears in a target code is
 # an "unstable API" or not, and we can simply check if each abstract element appeared during
 # abstract interpretation meets our criteria of "unstable API".
 # For that purpose, it's suffice to overload `Core.Compiler.abstract_eval_special_value`
 # and `Core.Compiler.builtin_tfunction`.
-# To inject a report pass, we use [`report_pass!`](@ref) interface.
+# To inject a report pass, we use [`ReportPass(::AbstractAnalyzer)`](@ref) interface.
 
 struct UnstableAPIAnalysisPass <: ReportPass end
 
 function CC.abstract_eval_special_value(analyzer::UnstableAPIAnalyzer, @nospecialize(e), vtypes::CC.VarTable, sv::CC.InferenceState)
     if analyzer.is_target_module(sv.mod) # we care only about what we wrote
-        report_pass!(UnstableAPI, analyzer, sv, e)
+        ReportPass(analyzer)(UnstableAPI, analyzer, sv, e)
     end
 
     ## recurse into JET's default abstract interpretation routine
@@ -80,7 +80,7 @@ function CC.builtin_tfunction(analyzer::UnstableAPIAnalyzer, @nospecialize(f), a
                 if isa(a2, Core.Const) && (v2 = a2.val; isa(v2, Symbol))
                     if analyzer.is_target_module(sv.mod) || # we care only about what we wrote, but with relaxed filter
                        (parent = sv.parent; isa(parent, CC.InferenceState) && analyzer.is_target_module(parent.mod))
-                        report_pass!(UnstableAPI, analyzer, sv, GlobalRef(v1, v2))
+                        ReportPass(analyzer)(UnstableAPI, analyzer, sv, GlobalRef(v1, v2))
                     end
                 end
             end
@@ -128,7 +128,7 @@ function (::UnstableAPIAnalysisPass)(::Type{UnstableAPI}, analyzer::UnstableAPIA
         analyzer.is_target_module(mod) && return # we don't care about what we defined ourselves
 
         if isunstable(mod, name)
-            report!(UnstableAPI, analyzer, sv, e)
+            add_new_report!(UnstableAPI(analyzer, sv, e), analyzer)
         end
     end
 end
@@ -172,7 +172,7 @@ end
 
 # ## Usages
 
-# Now we find "unstable API"s in your code using [JET's analysis entry points](@ref Usages)
+# Now we find "unstable API"s in your code using [JET's analysis entry points](@ref usages)
 # with passing `UnstableAPIAnalyzer` as the `analyzer` configuration.
 
 using JET # to use analysis entry points

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -495,7 +495,7 @@ ignorenotfound(@nospecialize(t)) = t === NOT_FOUND ? Bottom : t
 
 # interface
 include("interfaces.jl")
-# abstract-interpretaion based analysis
+# abstract interpretaion based analysis
 include("tfuncs.jl")
 include("abstractinterpretation.jl")
 include("typeinfer.jl")
@@ -875,7 +875,7 @@ function analyze_method_instance!(analyzer::AbstractAnalyzer, mi::MethodInstance
 end
 
 function InferenceState(result::InferenceResult, cached::Bool, analyzer::AbstractAnalyzer)
-    report_pass!(GeneratorErrorReport, analyzer, result.linfo)
+    ReportPass(analyzer)(GeneratorErrorReport, analyzer, result.linfo)
     return @invoke InferenceState(result::InferenceResult, cached::Bool, analyzer::AbstractInterpreter)
 end
 
@@ -896,7 +896,7 @@ function (::SoundBasicPass)(::Type{GeneratorErrorReport}, analyzer::AbstractAnal
             ccall(:jl_code_for_staged, Any, (Any,), mi)
         catch err
             # if user code throws error, wrap and report it
-            report!(GeneratorErrorReport, analyzer, mi, err)
+            add_new_report!(GeneratorErrorReport(analyzer, mi, err), analyzer)
         end
     end
 end
@@ -1037,13 +1037,12 @@ end
 
 reexport_as_api!(AbstractAnalyzer,
                  AnalyzerState,
+                 ReportPass,
                  InferenceErrorReport,
                  get_msg,
                  get_spec_args,
                  var"@reportdef",
-                 ReportPass,
-                 report_pass!,
-                 report!,
+                 add_new_report!,
                  )
 reexport_as_api!(subtypes(InferenceErrorReport)...; documented = false)
 reexport_as_api!(subtypes(ReportPass)...; documented = false)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -4,20 +4,35 @@
 """
     abstract type AbstractAnalyzer <: AbstractInterpreter end
 
-When `T` implements this interface (i.e. `T <: AbstractAnalyzer`), `T` is expected to implement:
-- `T(; jetconfigs...) -> T`:
-  constructs new analyzer given [JET configurations](@ref);
-  `AnalyzerState` for this analyzer should be constructed using these configurations
-- `AnalyzerState(analyzer::T) -> AnalyzerState`:
-  returns `AnalyzerState` instance, usually it's kept within `T` itself
-- `AbstractAnalyzer(analyzer::T, state::AnalyzerState) -> T`:
-  constructs new analyzer given the previous analyzer and analysis state
-- `ReportPass(analyzer::T) -> ReportPass`:
-  returns the [report pass](@ref ReportPass) of `T`
+An interface type of analyzers that are built on top of [JET's analyzer framework](@ref JET-Analyzer-Framework).
 
-For example, JET.jl defines `JETAnalyzer <: AbstractAnalyzer` as the following (modified a bit for the sake of simplicity):
+When a new type `NewAnalyzer` implements the `AbstractAnalyzer` interface, it should be declared
+as subtype of `AbstractAnalyzer`, and is expected to the following interfaces:
+
+---
+- `NewAnalyzer(; jetconfigs...) -> NewAnalyzer`: \\
+  Constructs new analyzer given [JET configurations](@ref) passed as `jetconfigs`.
+---
+- `AnalyzerState(analyzer::NewAnalyzer) -> AnalyzerState`: \\
+  Returns the [`AnalyzerState`](@ref) for `analyzer::NewAnalyzer`.
+---
+- `AbstractAnalyzer(analyzer::NewAnalyzer, state::AnalyzerState) -> NewAnalyzer`: \\
+  Constructs an new `NewAnalyzer` instance in the middle of JET's [top-level analysis](@ref top-level-analysis)
+  or [abstract interpretation based analysis](@ref abstractinterpret-analysis), given the
+  previous `analyzer::NewAnalyzer` and [`state::AnalyzerState`](@ref AnalyzerState).
+---
+- `ReportPass(analyzer::NewAnalyzer) -> ReportPass`: \\
+  Returns [`ReportPass`](@ref) used for `analyzer::NewAnalyzer`.
+---
+
+See also [`AnalyzerState`](@ref) and [`ReportPass`](@ref).
+
+# Example
+
+JET.jl defines its default error analyzer `JETAnalyzer <: AbstractAnalyzer` as the following
+(modified a bit for the sake of simplicity):
 ```julia
-# the default abstract interpreter for JET.jl
+# the default error analyzer for JET.jl
 struct JETAnalyzer{RP<:ReportPass} <: AbstractAnalyzer
     report_pass::RP
     state::AnalyzerState
@@ -26,50 +41,101 @@ end
 # AbstractAnalyzer API requirements
 
 function JETAnalyzer(;
-    report_pass::Union{Nothing,T} = nothing,
-    mode::Symbol                  = :basic,
-    jetconfigs...) where {T<:ReportPass}
-    if isnothing(report_pass)
-        # if `report_pass` isn't passed explicitly, here we configure it according to `mode`
-        report_pass = mode === :basic ? BasicPass() :
-                      mode === :sound ? SoundPass() :
-                      throw(ArgumentError("`mode` configuration should be either of `:basic` or `:sound`"))
-    end
+    report_pass::ReportPass = BasicPass(),
+    jetconfigs...)
     return JETAnalyzer(report_pass,
                        AnalyzerState(; jetconfigs...),
                        )
 end
-AnalyzerState(analyzer::JETAnalyzer)                          = analyzer.state
-AbstractAnalyzer(analyzer::JETAnalyzer, state::AnalyzerState) = JETAnalyzer(ReportPass(analyzer), state)
-ReportPass(analyzer::JETAnalyzer)                             = analyzer.report_pass
+AnalyzerState(analyzer::JETAnalyzer) =
+    return analyzer.state
+AbstractAnalyzer(analyzer::JETAnalyzer, state::AnalyzerState) =
+    return JETAnalyzer(ReportPass(analyzer), state)
+ReportPass(analyzer::JETAnalyzer) =
+    return analyzer.report_pass
 ```
 """
 abstract type AbstractAnalyzer <: AbstractInterpreter end
 
-# ReportPass
-# ==========
-
 """
-    ReportPass
+    abstract type ReportPass end
 
-An interface type for report passes of JET's analysis.
+An interface type that represents `AbstractAnalyzer`'s report pass.
+`analyzer::AbstractAnalyzer` injects report passes using the `(::ReportPass)(::Type{InferenceErrorReport}, ::AbstractAnalyzer, state, ...)`
+interface, which provides a flexible and efficient layer to configure the analysis done by `AbstractAnalyzer`.
+
+---
+
+    ReportPass(analyzer::AbstractAnalyzer) -> ReportPass
+
+If `NewAnalyzer` implements the `AbstractAnalyzer` interface, `NewAnalyzer` should implement
+this `ReportPass(analyzer::NewAnalyzer) -> ReportPass` interface.
+
+`ReportPass` allows `NewAnalyzer` to provide a very flexible configuration layer for `NewAnalyzer`'s analysis;
+an user can define their own `ReportPass` to control how `NewAnalyzer` collects report errors
+while still using the analysis routine implemented by `NewAnalyzer`.
+
+# Example
+
+For example, [`JETAnalyzer`](@ref) accepts a custom `ReportPass` passed as [JET configurations](@ref)
+(see the example documentation of [`AbstractAnalyzer`](@ref) for details).
+And we can setup a custom report pass `IgnoreAllExceptGlobalUndefVar`, that ignores all the
+reports that are otherwise collected by `JETAnalyzer` except `GlobalUndefVarErrorReport`:
+```julia
+# custom report pass that ignores all the reports except `GlobalUndefVarErrorReport`
+struct IgnoreAllExceptGlobalUndefVar <: ReportPass end
+
+# ignores all the reports analyzed by `JETAnalyzer`
+(::IgnoreAllExceptGlobalUndefVar)(::Type{<:InferenceErrorReport}, @nospecialize(_...)) = return
+
+# bypass to `BasicPass` to collect `GlobalUndefVarErrorReport`
+function (::IgnoreAllExceptGlobalUndefVar)(::Type{GlobalUndefVarErrorReport}, @nospecialize(args...))
+    BasicPass()(GlobalUndefVarErrorReport, args...)
+end
+
+no_method_error()    = 1 + "1"
+undef_global_error() = undefvar
+report_call(; report_pass=IgnoreAllExceptGlobalUndefVar()) do
+    if rand(Bool)
+        return no_method_error()    # "no matching method found" error report won't be reported here
+    else
+        return undef_global_error() # "variable undefvar is not defined" error report will be reported
+    end
+end
+```
 """
 abstract type ReportPass end
 
-# pre-defined passes
-# ------------------
+function (::Type{Analyzer})(; jetconfigs...) where Analyzer<:AbstractAnalyzer
+    error("""
+    missing `$AbstractAnalyzer` API:
+    `$Analyzer` is required to implement the `$Analyzer(; jetconfigs...) -> $Analyzer` interface.
+    See the documentation of `$AbstractAnalyzer`.
+    """)
+end
+
+function ReportPass(::Analyzer) where Analyzer<:AbstractAnalyzer
+    error("""
+    missing `$AbstractAnalyzer` API:
+    `$Analyzer` is required to implement the `$ReportPass(analyzer::$Analyzer) -> $ReportPass` interface.
+    See the documentation of `$AbstractAnalyzer` and `$ReportPass`.
+    """)
+end
+
+# pre-defined report passes
+# TODO document the definitions of errors, elaborate the difference of these two passes
 
 """
     SoundPass <: ReportPass
 
-`ReportPass` for the sound JET analysis.
+`ReportPass` for the sound `JETAnalyzer`'s error analysis.
 """
 struct SoundPass <: ReportPass end
 
 """
     BasicPass <: ReportPass
 
-`ReportPass` for the basic (default) JET analysis.
+`ReportPass` for the basic (default) `JETAnalyzer`'s error analysis.
 """
 struct BasicPass <: ReportPass end
 
@@ -216,8 +282,8 @@ end
 Base.show(io::IO, ::MIME"application/prs.juno.inline", report::InferenceErrorReport) =
     return report
 
-get_msg(T::Type{<:InferenceErrorReport}, @nospecialize(_...)) = throw("`get_msg` is not implemented for $T")
-get_spec_args(T::Type{<:InferenceErrorReport}) =                throw("`get_spec_args` is not implemented for $T")
+get_msg(T::Type{<:InferenceErrorReport}, @nospecialize(_...)) = error("`get_msg` is not implemented for $T")
+get_spec_args(T::Type{<:InferenceErrorReport}) =                error("`get_spec_args` is not implemented for $T")
 
 # default constructor to create a report from abstract interpretation routine
 function (T::Type{<:InferenceErrorReport})(analyzer::AbstractAnalyzer, state, @nospecialize(spec_args...))

--- a/src/legacy/abstractinterpretation
+++ b/src/legacy/abstractinterpretation
@@ -88,7 +88,7 @@ function abstract_call_gf_by_type(interp::AbstractAnalyzer, @nospecialize(f), ar
         info = UnionSplitInfo(infos)
         #=== abstract_call_gf_by_type patch point 1-1 start ===#
         # report pass for no matching methods error
-        report_pass!(NoMethodErrorReport, interp, sv, info, splitsigs)
+        ReportPass(interp)(NoMethodErrorReport, interp, sv, info, splitsigs)
         #=== abstract_call_gf_by_type patch point 1-1 end ===#
     else
         mt = ccall(:jl_method_table_for, Any, (Any,), atype)
@@ -109,7 +109,7 @@ function abstract_call_gf_by_type(interp::AbstractAnalyzer, @nospecialize(f), ar
         info = MethodMatchInfo(matches)
         #=== abstract_call_gf_by_type patch point 1-2 start ===#
         # report pass for no matching methods error
-        report_pass!(NoMethodErrorReport, interp, sv, info, atype)
+        ReportPass(interp)(NoMethodErrorReport, interp, sv, info, atype)
         #=== abstract_call_gf_by_type patch point 1-2 end ===#
         applicable = matches.matches
         valid_worlds = matches.valid_worlds
@@ -266,12 +266,12 @@ function (::SoundBasicPass)(::Type{NoMethodErrorReport}, analyzer::AbstractAnaly
     end
 
     if !isnothing(ts)
-        report!(NoMethodErrorReport, analyzer, sv, ts)
+        add_new_report!(NoMethodErrorReport(analyzer, sv, ts), analyzer)
     end
 end
 function (::SoundBasicPass)(::Type{NoMethodErrorReport}, analyzer::AbstractAnalyzer, sv::InferenceState, info::MethodMatchInfo, @nospecialize(atype))
     if is_empty_match(info)
-        report!(NoMethodErrorReport, analyzer, sv, atype)
+        add_new_report!(NoMethodErrorReport(analyzer, sv, atype), analyzer)
     end
 end
 

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -87,14 +87,14 @@ function CC._typeinf(analyzer::AbstractAnalyzer, frame::InferenceState)
     ret = @invoke _typeinf(analyzer::AbstractInterpreter, frame::InferenceState)
 
     # report pass for (local) undef var error
-    report_pass!(LocalUndefVarErrorReport, analyzer, frame, frame.src.code)
+    ReportPass(analyzer)(LocalUndefVarErrorReport, analyzer, frame, frame.src.code)
 
     # XXX this is a dirty fix for performance problem, we need more "proper" fix
     # https://github.com/aviatesk/JET.jl/issues/75
     unique!(report_identity_key, get_reports(analyzer))
 
     # report pass for uncaught `throw` calls
-    report_pass!(UncaughtExceptionReport, analyzer, frame, frame.src.code)
+    ReportPass(analyzer)(UncaughtExceptionReport, analyzer, frame, frame.src.code)
 
     reports_after = Set(get_reports(analyzer))
     uncaught_exceptions_after = Set(get_uncaught_exceptions(analyzer))
@@ -225,13 +225,13 @@ function report_undefined_local_slots!(analyzer::AbstractAnalyzer, frame::Infere
                     # the optimization so far has found this statement is never "reachable";
                     # JET reports it since it will invoke undef var error at runtime, or will just
                     # be dead code otherwise
-                    report!(LocalUndefVarErrorReport, analyzer, (frame, idx), sym)
+                    add_new_report!(LocalUndefVarErrorReport(analyzer, (frame, idx), sym), analyzer)
                 else
                     # by excluding this pass, this analysis accepts some false negatives and
                     # some undefined variable error may happen in actual execution (thus unsound)
                 end
             else
-                report!(LocalUndefVarErrorReport, analyzer, (frame, idx), sym)
+                add_new_report!(LocalUndefVarErrorReport(analyzer, (frame, idx), sym), analyzer)
             end
         end
     end
@@ -293,7 +293,7 @@ function (::SoundBasicPass)(::Type{UncaughtExceptionReport}, analyzer::AbstractA
             push!(throw_calls, (pc, stmt))
         end
         if !isempty(throw_calls)
-            report!(UncaughtExceptionReport, analyzer, frame, throw_calls)
+            add_new_report!(UncaughtExceptionReport(analyzer, frame, throw_calls), analyzer)
         end
     else
         # the non-`Bottom` result here may mean `throw` calls from the children frames

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -2,7 +2,7 @@
 include("patches.jl")
 
 # test utilities are extracted into a separate file for easier interactive testing from REPL
-# i.e. julia-dev -i test/interactive_utils.jl
+# i.e. julia -i test/interactive_utils.jl
 include("interactive_utils.jl")
 
 # stuff used across tests

--- a/test/test_interfaces.jl
+++ b/test/test_interfaces.jl
@@ -27,7 +27,45 @@ let
     end
 end
 
-# pluggable-analysis framework
-# ============================
+# AbstractAnalyzer API
+# ====================
 
-# NOTE this will be tested by documentation
+# NOTE actual functionalities are tested by documentation
+
+struct APIValidator <: AbstractAnalyzer
+    state::AnalyzerState
+end
+
+function compute_sins(i)
+    n = 1000000
+    out = Vector{Float64}(undef, n)
+    Threads.@threads for itr in 1:n
+        i = itr
+        out[i] = sin(i)
+    end
+    return out
+end
+
+@test_throws ErrorException @analyze_call analyzer=APIValidator compute_sins(10)
+
+# `APIValidator(; jetconfigs...) -> APIValidator`
+APIValidator(; jetconfigs...) = APIValidator(AnalyzerState(; jetconfigs...))
+
+@test_throws ErrorException @analyze_call analyzer=APIValidator compute_sins(10)
+
+# `AnalyzerState(analyzer::APIValidator) -> AnalyzerState`
+AnalyzerState(analyzer::APIValidator) = analyzer.state
+
+@test_throws ErrorException @analyze_call analyzer=APIValidator compute_sins(10)
+
+# `ReportPass(analyzer::APIValidator) -> ReportPass`
+ReportPass(analyzer::APIValidator) = IgnoreAllPass()
+
+@test_throws ErrorException @analyze_call analyzer=APIValidator compute_sins(10)
+
+# `AbstractAnalyzer(analyzer::APIValidator, state::AnalyzerState) -> APIValidator`
+AbstractAnalyzer(analyzer::APIValidator, state::AnalyzerState) = APIValidator(state)
+
+# because `APIValidator` uses `IgnoreAllPass`, we won't get any reports
+analyzer, = @analyze_call analyzer=APIValidator compute_sins(10)
+@test isempty(get_reports(analyzer))


### PR DESCRIPTION
The current infrastructure is messy. Let's sort it out and clean it up.

- remove unnecessary `report!` indirection, rename to `add_new_report!`,
  which requires explicit report constructions
- remove unnecessary `report_pass!` indirection, require explicit
  `ReportPass` constructions
- update documents