### PR TITLE
more sort out interfaces

### DIFF
--- a/benchmark/JETBenchmarkUtils.jl
+++ b/benchmark/JETBenchmarkUtils.jl
@@ -50,7 +50,7 @@ Each "evaluation" of `ex` is done in new Julia process in order to benchmark the
   have no effect for execution (of course, this is very time-consuming though ...).
 The optional positional argument `setup_ex` runs before each execution of `ex` and its
   execution statistis are not included in the benchmark result; it defaults to
-  `JET_WARMUP_EX`, which loads JET and runs a warm up analysis `@analyze_call identity(nothing)`.
+  `JET_WARMUP_EX`, which loads JET and runs a warm up analysis `@report_call identity(nothing)`.
 """
 macro benchmark_freshexec(args...)
     isn(x) = isexpr(x, :(=)) && first(x.args) === :ntimes
@@ -102,7 +102,7 @@ end
 const JET_LOAD_EX = :(using JET)
 const JET_WARMUP_EX = quote
     using JET
-    @analyze_call identity(nothing) # warm-up for JET analysis
+    @report_call identity(nothing) # warm-up for JET analysis
 end
 const JULIA_BIN = normpath(Sys.BINDIR, "julia")
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -104,22 +104,22 @@ BenchmarkTools.DEFAULT_PARAMETERS.seconds = 100.0
 const SUITE = BenchmarkGroup()
 
 SUITE["package loading"] = @jetbenchmarkable using JET
-SUITE["first time"] = @jetbenchmarkable (@analyze_call identity(nothing)) setup = (using JET)
-SUITE["easy"] = @jetbenchmarkable (@analyze_call sum("julia")) setup = begin
+SUITE["first time"] = @jetbenchmarkable (@report_call identity(nothing)) setup = (using JET)
+SUITE["easy"] = @jetbenchmarkable (@report_call sum("julia")) setup = begin
     using JET
-    @analyze_call identity(nothing)
+    @report_call identity(nothing)
 end
-SUITE["cached easy"] = @jetbenchmarkable (@analyze_call sum("julia")) setup = begin
+SUITE["cached easy"] = @jetbenchmarkable (@report_call sum("julia")) setup = begin
     using JET
-    @analyze_call sum("julia")
+    @report_call sum("julia")
 end
-SUITE["a bit complex"] = @jetbenchmarkable (@analyze_call rand(Bool)) setup = begin
+SUITE["a bit complex"] = @jetbenchmarkable (@report_call rand(Bool)) setup = begin
     using JET
-    @analyze_call identity(nothing)
+    @report_call identity(nothing)
 end
-SUITE["invalidation"] = @jetbenchmarkable (@analyze_call println(QuoteNode(nothing))) setup = begin
+SUITE["invalidation"] = @jetbenchmarkable (@report_call println(QuoteNode(nothing))) setup = begin
     using JET
-    @analyze_call println(QuoteNode(nothing))
+    @report_call println(QuoteNode(nothing))
     @eval Base begin
         function show_sym(io::IO, sym::Symbol; allow_macroname=false)
             if is_valid_identifier(sym)
@@ -133,7 +133,7 @@ SUITE["invalidation"] = @jetbenchmarkable (@analyze_call println(QuoteNode(nothi
         end
     end
 end
-# FIXME
+# FIXME debug the error and enable this performance tracking
 # SUITE["self analysis"] = @jetbenchmarkable(
 #     begin
 #         analyzer = JET.JETAnalyzer()
@@ -142,7 +142,7 @@ end
 #     end,
 #     setup = begin
 #         using JET
-#         @analyze_call identity(nothing)
+#         @report_call identity(nothing)
 #     end)
 SUITE["top-level"] = @jetbenchmarkable(
     (@analyze_toplevel begin
@@ -162,4 +162,4 @@ SUITE["top-level first time"] = @jetbenchmarkable(
         myidentity(nothing)
     end),
     setup = include("test/interactive_utils.jl"))
-SUITE["end to end"] = @jetbenchmarkable report_file(IOBuffer(), "demo.jl") setup = using JET
+SUITE["end to end"] = @jetbenchmarkable report_file("demo.jl") setup = using JET

--- a/benchmark/simple.jl
+++ b/benchmark/simple.jl
@@ -17,34 +17,34 @@ function simple_benchmark(ntimes = 5; verbose = false)
 
     let
         setup_ex = :(using JET)
-        ex       = :(@analyze_call identity(nothing))
+        ex       = :(@report_call identity(nothing))
         _simple_benchmark!(setup_ex, ex, "first-time analysis")
     end
 
     let
         setup_ex = quote
             using JET
-            @analyze_call identity(nothing)
+            @report_call identity(nothing)
         end
-        ex       = :(@analyze_call sum("julia"))
+        ex       = :(@report_call sum("julia"))
         _simple_benchmark!(setup_ex, ex, "simple analysis")
     end
 
     let
         setup_ex = quote
             using JET
-            @analyze_call sum("julia")
+            @report_call sum("julia")
         end
-        ex       = :(@analyze_call sum("julia"))
+        ex       = :(@report_call sum("julia"))
         _simple_benchmark!(setup_ex, ex, "cached simple analysis")
     end
 
     let
         setup_ex = quote
             using JET
-            @analyze_call identity(nothing)
+            @report_call identity(nothing)
         end
-        ex       = :(@analyze_call rand(Bool))
+        ex       = :(@report_call rand(Bool))
         _simple_benchmark!(setup_ex, ex, "a bit complex analysis")
     end
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -32,6 +32,14 @@ JET.partially_interpret!
 ```
 
 
+## Analysis Results
+
+```@docs
+JET.JETToplevelResult
+JET.JETCallResult
+```
+
+
 ## Error Report Interface
 
 ```@docs

--- a/docs/src/usages.md
+++ b/docs/src/usages.md
@@ -1,11 +1,5 @@
 # [How to Use JET.jl](@id usages)
 
-!!! note
-    JET's analysis entry points follow the naming conventions below:
-    - `report_xxx`: runs analysis, and then prints the collected error points
-    - `analyze_xxx`: just runs analysis, and returns the final state of the analysis
-    The `report_xxx` entries are for general users, while `analyze_xxx` is mainly for internal usages or debugging purposes.
-
 
 ## [Entry Points into Analysis](@id entry-points)
 
@@ -38,6 +32,4 @@ There are utilities for checking JET analysis in a running Julia session like RE
 ```@docs
 report_call
 @report_call
-analyze_call
-@analyze_call
 ```

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -192,12 +192,12 @@ function CC.abstract_call_method_with_const_args(analyzer::AbstractAnalyzer, res
     # update reports if constant prop' was successful
     # branch on https://github.com/JuliaLang/julia/pull/41697/
     @static if VERSION ≥ v"1.8.0-DEV.282"
-        if const_result !== nothing
+        if !isnothing(const_result)
             # successful constant prop', we also need to update reports
             update_reports!(analyzer, sv)
         end
     else
-        if getfield(const_result, 2) !== nothing
+        if !isnothing(getfield(const_result, 2))
             # successful constant prop', we also need to update reports
             update_reports!(analyzer, sv)
         end

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -178,11 +178,11 @@ Logging configurations for JET analysis.
   Examples:
   * logs into `stdout`
     ```julia
-    analyze_call(f, args...; inference_logger = stdout)
+    report_call(f, args...; inference_logger = stdout)
     ```
   * logs into `io::IOBuffer` with "debug" logger level
     ```julia
-    julia> analyze_call(f, args...; inference_logger = IOContext(io, $(repr(LOGGER_LEVEL_KEY)) => $DEBUG_LOGGER_LEVEL))
+    julia> report_call(f, args...; inference_logger = IOContext(io, $(repr(LOGGER_LEVEL_KEY)) => $DEBUG_LOGGER_LEVEL))
     ```
 ---
 !!! tip

--- a/src/jetcache.jl
+++ b/src/jetcache.jl
@@ -137,7 +137,7 @@ CC.get_inference_cache(analyzer::AbstractAnalyzer) = JETLocalCache(analyzer, get
 function CC.cache_lookup(linfo::MethodInstance, given_argtypes::Vector{Any}, cache::JETLocalCache)
     inf_result = cache_lookup(linfo, given_argtypes, cache.cache)
 
-    isa(inf_result, InferenceResult) || return nothing
+    isa(inf_result, InferenceResult) || return inf_result
 
     # constant prop' hits a cycle (recur into same non-constant analysis), we just bail out
     isa(inf_result.result, InferenceState) && return inf_result

--- a/src/locinfo.jl
+++ b/src/locinfo.jl
@@ -132,7 +132,7 @@ function _get_sig_type(analyzer::AbstractAnalyzer, (sv, _)::StateAtPC, ssa::SSAV
         sig, sig_typ = _get_sig_type(analyzer, news, get_stmt(news))
         typ = widenconst(ignorelimited(ignorenotfound(get_ssavaluetype(news))))
         sig_typ == typ || push!(sig, typ) # XXX I forgot why I added this line ...
-    end    
+    end
     return sig, typ
 end
 function _get_sig_type(analyzer::AbstractAnalyzer, s::StateAtPC, slot::SlotNumber)

--- a/src/typeinfer.jl
+++ b/src/typeinfer.jl
@@ -214,7 +214,7 @@ get_msg(T::Type{LocalUndefVarErrorReport}, analyzer::AbstractAnalyzer, state, na
 function report_undefined_local_slots!(analyzer::AbstractAnalyzer, frame::InferenceState, stmts::Vector{Any}, unsound::Bool)
     for (idx, stmt) in enumerate(stmts)
         if isa(stmt, Expr) && stmt.head === :throw_undef_if_not
-            sym::Symbol, _ = stmt.args
+            sym = stmt.args[1]::Symbol
 
             # slots in toplevel frame may be a abstract global slot
             istoplevel(analyzer, frame) && is_global_slot(analyzer, sym) && continue

--- a/src/virtualprocess.jl
+++ b/src/virtualprocess.jl
@@ -281,8 +281,29 @@ function virtual_process(x::Union{AbstractString,Expr},
         analyze_from_definitions!(analyzer, res)
     end
 
+    # TODO want to do in `analyze_from_definitions!` ?
+    unique!(report_identity_key, res.inference_error_reports)
+
     return res
 end
+
+# @withmixedhash struct VirtualFrameNoLinfo
+#     file::Symbol
+#     line::Int
+#     sig::Vector{Any}
+#     # linfo::MethodInstance
+# end
+# VirtualFrameNoLinfo(vf::VirtualFrame) = VirtualFrameNoLinfo(vf.file, vf.line, vf.sig)
+#
+# @withmixedhash struct ReportIdentityKey2
+#     T::Type{<:InferenceErrorReport}
+#     sig::Vector{Any}
+#     # entry_frame::VirtualFrame
+#     error_frame::VirtualFrameNoLinfo
+# end
+#
+# report_identity_key2(report::T) where {T<:InferenceErrorReport} =
+#     ReportIdentityKey2(T, report.sig, #=VirtualFrameNoLinfo(first(report.vst)),=# VirtualFrameNoLinfo(last(report.vst)))
 
 """
     virtualize_module_context(actual::Module)

--- a/test/interactive_utils.jl
+++ b/test/interactive_utils.jl
@@ -3,14 +3,12 @@ using JET, InteractiveUtils
 const CC = JET.CC
 
 import .CC:
-    widenconst, ⊑
+    widenconst, ⊑, Bottom
 
 import JET:
     AbstractAnalyzer,
     JETAnalyzer,
     AbstractGlobal,
-    analyze_file,
-    analyze_text,
     get_result,
     ToplevelConfig,
     virtual_process,
@@ -123,6 +121,10 @@ function _analyze_toplevel(ex, lnn, jetconfigs)
                          )
     end)
 end
+
+# `report_file` with silent top-level logger
+report_file2(args...; kwargs...) =
+    report_file(args...; toplevel_logger = nothing, kwargs...)
 
 is_concrete(mod, sym) = isdefined(mod, sym) && !isa(getfield(mod, sym), AbstractGlobal)
 is_abstract(mod, sym) = isdefined(mod, sym) && isa(getfield(mod, sym), AbstractGlobal)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -11,7 +11,7 @@ using Test
 const FIXTURE_DIR = normpath(@__DIR__, "fixtures")
 
 const ERROR_REPORTS_FROM_SUM_OVER_STRING = let
-    analyzer, frame = analyze_call(sum, (String,))
+    analyzer, = report_call(sum, (String,))
     @test !isempty(get_reports(analyzer))
     get_reports(analyzer)
 end

--- a/test/test_performance.jl
+++ b/test/test_performance.jl
@@ -1,4 +1,4 @@
 @testset "https://github.com/aviatesk/JET.jl/issues/71" begin
-    stats = @benchmark_freshexec ntimes = 1 @analyze_call println(QuoteNode(nothing))
+    stats = @benchmark_freshexec ntimes = 1 @report_call println(QuoteNode(nothing))
     @test stats.time ≤ 10
 end

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -11,7 +11,7 @@
             end
             """
 
-        res = analyze_text(s, @__FILE__)
+        res = report_text(s, @__FILE__).res
         print_reports(io, res.toplevel_error_reports)
         let s = String(take!(io))
             @test occursin("1 toplevel error found", s)
@@ -19,7 +19,7 @@
             @test occursin("syntax: unexpected \"end\"", s)
         end
 
-        res = analyze_text(s, "foo")
+        res = report_text(s, "foo").res
         print_reports(io, res.toplevel_error_reports)
         let s = String(take!(io))
             @test occursin("1 toplevel error found", s)

--- a/test/test_reports.jl
+++ b/test/test_reports.jl
@@ -19,7 +19,7 @@ function ⫇(a, b)
 end
 
 @testset "error location signature" begin
-    analyzer, frame = analyze_call((Char,Char)) do a, b
+    analyzer, = report_call((Char,Char)) do a, b
         a + b
     end
     @test length(get_reports(analyzer)) == 1
@@ -32,7 +32,7 @@ end
     m = @fixturedef begin
         foo(s::AbstractString) = throw(ArgumentError(s))
     end
-    analyzer, frame = analyze_call(m.foo, (String,))
+    analyzer, = report_call(m.foo, (String,))
     @test length(get_reports(analyzer)) == 1
     r = first(get_reports(analyzer))
     @test isa(r, UncaughtExceptionReport)


### PR DESCRIPTION
- make `report_xxx` return objects that are specific to JET's analysis
  result, i.e. `JETToplevelResult` for top-level analysis, and
  `JETCallResult` for interactive analysis
- define appropriate `show` methods for `JETToplevelResult` and `JETCallResult`,
  and now the analysis result are rendered by Julia's `show` mechanism
- remove `analyze_xxx` interfaces, just keep `report_xxx` interfaces

Co-Authored-By: Sebastian Pfitzner <pfitzseb@gmail.com>