### PR TITLE
`Test` standard library integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 JuliaInterpreter = "0.8.16"

--- a/docs/src/usages.md
+++ b/docs/src/usages.md
@@ -1,7 +1,7 @@
 # [How to Use JET.jl](@id usages)
 
 
-## [Entry Points into Analysis](@id entry-points)
+## [Top-level Entry Points](@id toplevel-entries)
 
 JET can analyze your "top-level" code.
 This means you can just give your Julia file or code to JET and get error reports.
@@ -25,11 +25,23 @@ report_text
 ```
 
 
-## [Testing, Interactive Usage](@id interactive-entries)
+## [Interactive Entry Points](@id interactive-entries)
 
 There are utilities for checking JET analysis in a running Julia session like REPL or such.
 
 ```@docs
 report_call
 @report_call
+```
+
+
+## [`Test` Integration](@id test-integration)
+
+JET offers entries that are integrated with [`Test` standard library's unit-testing infrastructure](https://docs.julialang.org/en/v1/stdlib/Test/).
+It can be used in your test suite to assert your program is free from errors that JET can detect.
+Currently, it only supports [interactive entries](@ref).
+
+```@docs
+@test_call
+test_call
 ```

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -204,7 +204,7 @@ end;
 
 # ### Analyze a real-world package
 
-# Finally we can use [JET's top-level analysis entry points](@ref entry-points) to analyze
+# Finally we can use [JET's top-level analysis entry points](@ref toplevel-entries) to analyze
 # a whole script or package.
 #
 # Here we will run `UnstableAPIAnalyzer` on [IRTools.jl](https://github.com/FluxML/IRTools.jl),

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -248,6 +248,12 @@ _isexpr_check(ex::Expr, heads, n::Int)        = in(ex.head, heads) && length(ex.
 islnn(@nospecialize(_)) = false
 islnn(::LineNumberNode) = true
 
+iskwarg(@nospecialize(x)) = @isexpr(x, :(=))
+
+# for inspection
+macro lwr(ex) QuoteNode(lower(__module__, ex)) end
+macro src(ex) QuoteNode(first(lower(__module__, ex).args)) end
+
 """
     @invoke f(arg::T, ...; kwargs...)
 
@@ -977,8 +983,8 @@ function analyze_frame!(analyzer::AbstractAnalyzer, frame::InferenceState)
     return analyzer, frame
 end
 
-# test, interactive
-# =================
+# interactive
+# ===========
 
 # TODO improve inferrability by making `analyzer` argument positional
 
@@ -1042,9 +1048,10 @@ function report_call(@nospecialize(tt::Type{<:Tuple});
     return JETCallResult(analyzer, rt, source; jetconfigs...)
 end
 
-# for inspection
-macro lwr(ex) QuoteNode(lower(__module__, ex)) end
-macro src(ex) QuoteNode(first(lower(__module__, ex).args)) end
+# Test.jl integration
+# ===================
+
+include("test.jl")
 
 # exports
 # =======
@@ -1099,6 +1106,8 @@ export
     report_package,
     report_text,
     @report_call,
-    report_call
+    report_call,
+    @test_call,
+    test_call
 
 end

--- a/src/test.jl
+++ b/src/test.jl
@@ -1,0 +1,253 @@
+# imports
+# =======
+
+import Test:
+    record
+
+# usings
+# ======
+
+import Test:
+    Test,
+    Result, Pass, Fail, Broken, Error,
+    get_testset,
+    TESTSET_PRINT_ENABLE,
+    FallbackTestSet, DefaultTestSet,
+    FallbackTestSetException
+
+"""
+    @test_call [jetconfigs...] [broken=false] [skip=false] f(args...)
+
+Runs [`@report_call jetconfigs... f(args...)`](@ref @report_call) and tests that the generic
+function call `f(args...)` is free from problems that `@report_call` can detect.
+If executed inside `@testset`, returns a `Pass` result if it is, a `Fail` result if it
+contains any error points detected, or an `Error` result if this macro encounters an
+unexpected error. When the test `Fail`s, abstract call stack to each problem location will
+also be printed to `stdout`.
+
+```julia
+julia> @test_call sincos(10)
+Test Passed
+  Expression: #= none:1 =# JET.@test_call sincos(10)
+```
+
+As with [`@report_call`](@ref), any of [JET configurations](https://aviatesk.github.io/JET.jl/dev/config/)
+or analyzer specific configurations can be given as the optional arguments `jetconfigs...` like this:
+```julia
+julia> cond = false
+
+julia> function f(n)
+            if cond           # `cond` is untyped, and will be reported by the sound analysis pass, while JET's default analysis pass will ignore it
+                return sin(n)
+            else
+                return cos(n)
+            end
+       end;
+
+julia> @test_call f(10)
+Test Passed
+  Expression: #= none:1 =# JET.@test_call f(10)
+
+julia> @test_call mode=:sound f(10)
+JET-test failed at none:1
+  Expression: #= none:1 =# JET.@test_call mode = :sound f(10)
+  ═════ 1 possible error found ═════
+  ┌ @ none:2 goto %4 if not Main.cond
+  │ non-boolean (Any) used in boolean context: goto %4 if not Main.cond
+  └──────────
+
+ERROR: There was an error during testing
+```
+
+`@test_call` is fully integrated with [`Test` standard library's unit-testing infrastructure](https://docs.julialang.org/en/v1/stdlib/Test/).
+It means, the result of `@test_call` will be included in the final `@testset` summary,
+it supports `skip` and `broken` annotations as like `@test` and its family:
+```julia
+julia> using JET, Test
+
+julia> f(ref) = isa(ref[], Number) ? sin(ref[]) : nothing;      # Julia can't propagate the type constraint `ref[]::Number` to `sin(ref[])`, JET will report `NoMethodError`
+
+julia> g(ref) = (x = ref[]; isa(x, Number) ? sin(x) : nothing); # we can make it type-stable if we extract `ref[]` into a local variable `x`
+
+julia> @testset "check errors" begin
+           ref = Ref{Union{Nothing,Int}}(0)
+           @test_call f(ref)             # fail
+           @test_call g(ref)             # fail
+           @test_call broken=true f(ref) # annotated as broken, thus still "pass"
+       end
+check errors: JET-test failed at none:3
+  Expression: #= none:3 =# JET.@test_call f(ref)
+  ═════ 1 possible error found ═════
+  ┌ @ none:1 Main.sin(Base.getindex(ref))
+  │ for 1 of union split cases, no matching method found for call signatures (Tuple{typeof(sin), Nothing})): Main.sin(Base.getindex(ref::Base.RefValue{Union{Nothing, Int64}})::Union{Nothing, Int64})
+  └──────────
+
+Test Summary: | Pass  Fail  Broken  Total
+check errors  |    1     1       1      3
+ERROR: Some tests did not pass: 1 passed, 1 failed, 0 errored, 1 broken.
+```
+"""
+macro test_call(ex0...)
+    ex0 = collect(ex0)
+
+    local broken = nothing
+    local skip   = nothing
+    idx = Int[]
+    for (i,x) in enumerate(ex0)
+        if iskwarg(x)
+            key, val = x.args
+            if key === :broken
+                if !isnothing(broken)
+                    error("invalid test macro call: cannot set `broken` keyword multiple times")
+                end
+                broken = esc(val)
+                push!(idx, i)
+            elseif key === :skip
+                if !isnothing(skip)
+                    error("invalid test macro call: cannot set `skip` keyword multiple times")
+                end
+                skip = esc(val)
+                push!(idx, i)
+            end
+        end
+    end
+    if !isnothing(broken) && !isnothing(skip)
+        error("invalid test macro call: cannot set both `skip` and `broken` keywords")
+    end
+    deleteat!(ex0, idx)
+
+    testres, orig_expr = test_exs(ex0, __module__, __source__)
+
+    return quote
+        if $(!isnothing(skip) && skip)
+            $record($get_testset(), $Broken(:skipped, $orig_expr))
+        else
+            testres = $testres
+            if $(!isnothing(broken) && broken)
+                if isa(testres, $JETTestFailure)
+                    testres = $Broken(:test_call, $orig_expr)
+                elseif isa(testres, $Pass)
+                    testres = $Error(:test_unbroken, $orig_expr, nothing, nothing, $(QuoteNode(__source__)))
+                end
+            else
+                isa(testres, $Pass) || ccall(:jl_breakpoint, $Cvoid, ($Any,), testres)
+            end
+            $record($get_testset(), testres)
+        end
+    end
+end
+
+get_exceptions() = @static if isdefined(Base, :current_exceptions)
+    Base.current_exceptions()
+else
+    Base.catch_stack()
+end
+@static if !hasfield(Pass, :source)
+    Pass(test_type::Symbol, orig_expr, data, thrown, source) = Pass(test_type, orig_expr, data, thrown)
+end
+
+function test_exs(ex0, m, source)
+    analysis = gen_call_with_extracted_types_and_kwargs(m, :report_call, ex0)
+    orig_expr = QuoteNode(
+        Expr(:macrocall, GlobalRef(@__MODULE__, Symbol("@test_call")), source, ex0...))
+    source = QuoteNode(source)
+    testres = :(try
+        result = $analysis
+        if $length($get_reports(result.analyzer)) == 0
+            $Pass(:test_call, $orig_expr, nothing, nothing, $source)
+        else
+            $JETTestFailure($orig_expr, $source, result)
+        end
+    catch err
+        isa(err, $InterruptException) && rethrow()
+        $Error(:test_error, $orig_expr, err, $get_exceptions(), $source)
+    end) |> Base.remove_linenums!
+    return testres, orig_expr
+end
+
+"""
+    test_call(f, types = Tuple{}; broken::Bool = false, skip::Bool = false, jetconfigs...)
+    test_call(tt::Type{<:Tuple}; broken::Bool = false, skip::Bool = false, jetconfigs...)
+
+Runs [`report_call(f, types; jetconfigs...`](@ref report_call) and tests that the generic
+function call `f(args...)` is free from problems that `report_call` can detect.
+Except that it takes a type signature rather than a call expression, this function works
+in the same way as [`@test_call`](@ref).
+"""
+function test_call(@nospecialize(args...);
+                   broken::Bool = false, skip::Bool = false,
+                   jetconfigs...)
+    source = LineNumberNode(@__LINE__, @__FILE__)
+    kwargs = map(((k,v),)->Expr(:kw, k, v), collect(jetconfigs))
+    orig_expr = :($test_call($(args...); $(kwargs...)))
+
+    if skip
+        record(get_testset(), Broken(:skipped, orig_expr))
+    else
+        testres = try
+            result = report_call(args...; jetconfigs...)
+            if length(get_reports(result.analyzer)) == 0
+                Pass(:test_call, orig_expr, nothing, nothing, source)
+            else
+                JETTestFailure(orig_expr, source, result)
+            end
+        catch err
+            isa(err, InterruptException) && rethrow()
+            Error(:test_error, orig_expr, err, get_exceptions(), source)
+        end
+
+        if broken
+            if isa(testres, JETTestFailure)
+                testres = Broken(:test_call, orig_expr)
+            elseif isa(testres, Pass)
+                testres = Error(:test_unbroken, orig_expr, nothing, nothing, source)
+            end
+        else
+            isa(testres, Pass) || ccall(:jl_breakpoint, Cvoid, (Any,), testres)
+        end
+        record(get_testset(), testres)
+    end
+end
+
+# NOTE we will just show abstract call strack, and won't show backtrace of actual test executions
+
+struct JETTestFailure <: Result
+    orig_expr::Expr
+    source::LineNumberNode
+    result::JETCallResult
+end
+
+const TEST_INDENTS = "  "
+
+function Base.show(io::IO, t::JETTestFailure)
+    printstyled(io, "JET-test failed"; bold=true, color=Base.error_color())
+    print(io, " at ")
+    printstyled(io, something(t.source.file, :none), ":", t.source.line, "\n"; bold=true, color=:default)
+    println(io, TEST_INDENTS, "Expression: ", t.orig_expr)
+    # print abstract call stack, with appropriate indents
+    _, ctx = Base.unwrapcontext(io)
+    buf = IOBuffer()
+    ioctx = IOContext(buf, ctx)
+    show(ioctx, t.result)
+    lines = replace(String(take!(buf)), '\n'=>string('\n',TEST_INDENTS))
+    print(io, TEST_INDENTS, lines)
+end
+
+Base.show(io::IO, ::MIME"application/prs.juno.inline", t::JETTestFailure) =
+    return t
+
+function Test.record(::FallbackTestSet, t::JETTestFailure)
+    println(t)
+    throw(FallbackTestSetException("There was an error during testing"))
+end
+
+function Test.record(ts::DefaultTestSet, t::JETTestFailure)
+    if TESTSET_PRINT_ENABLE[]
+        printstyled(ts.description, ": ", color=:white)
+        print(t)
+        println()
+    end
+    # HACK convert to `Fail` so that test summarization works correctly
+    push!(ts.results, Fail(:test_call, t.orig_expr, nothing, nothing, t.source))
+    return t
+end

--- a/src/virtualprocess.jl
+++ b/src/virtualprocess.jl
@@ -1,7 +1,7 @@
 """
 Configurations for top-level analysis.
 These configurations will be active for all the top-level entries explained in the
-  [top-level analysis entry points](@ref entry-points) section.
+  [top-level analysis entry points](@ref toplevel-entries) section.
 
 ---
 - `context::Bool = Main` \\

--- a/test/interactive_utils.jl
+++ b/test/interactive_utils.jl
@@ -18,7 +18,8 @@ import JET:
     InferenceErrorReport,
     print_reports,
     get_reports,
-    get_cache
+    get_cache,
+    iskwarg
 
 function subtypes_recursive!(t, ts)
     push!(ts, t)
@@ -99,8 +100,6 @@ macro analyze_toplevel2(xs...)
         $(esc(vmod)), ret2
     end)
 end
-
-iskwarg(@nospecialize(x)) = isexpr(x, :(=))
 
 function _analyze_toplevel(ex, lnn, jetconfigs)
     toplevelex = (isexpr(ex, :block) ?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,4 +37,8 @@ include("setup.jl")
     @testset "interface.jl" begin
         include("test_interfaces.jl")
     end
+
+    @testset "Test.jl integration" begin
+        include("test_test.jl")
+    end
 end

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -1,0 +1,167 @@
+import Base.Meta: isexpr
+import MacroTools: @capture, postwalk
+
+# runs `f()` in an isolated testset, so that it doesn't influence the currently running test suite
+function with_isolated_testset(f)
+    ts = Test.DefaultTestSet("isolated")
+    Test.push_testset(ts)
+    try
+        mktemp() do path, io
+            redirect_stdout(io) do
+                f()
+            end
+        end
+    catch err
+        rethrow(err)
+    finally
+        Test.pop_testset()
+    end
+    return ts
+end
+
+macro addfntest(macro_test)
+    func_test = postwalk(macro_test) do x
+        pat = :(@test_call(args__))
+        if @capture(x, $pat)
+            if isexpr(x, :macrocall)
+                kwargs = map(x->Expr(:kw, x.args...), x.args[findall(x->isexpr(x,:(=)), x.args)])
+                testex = x.args[findfirst(x->isexpr(x,:call), x.args)::Int]
+                return :(test_call(Base.typesof($(testex.args...)); $(kwargs...)))
+            end
+        end
+        return x
+    end
+
+    return quote
+        $macro_test
+        $func_test
+    end
+end
+
+# positive case
+goodf(var) = var
+@addfntest let
+    ts = with_isolated_testset() do
+        @test_call goodf(10) # ok
+    end
+    @test ts.n_passed == 1
+end
+
+# negative case
+# NOTE the following test is line-sensitive !
+badf(var) = undefvar
+let
+    ts = with_isolated_testset() do
+        @test_call badf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Fail)
+    @test r.source === LineNumberNode((@__LINE__)-6, @__FILE__)
+end
+
+# actual error within `@test_call`
+# NOTE the following test is line-sensitive !
+let
+    ts = with_isolated_testset() do
+        @test_call undeff(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Error)
+    @test r.source === LineNumberNode((@__LINE__)-6, @__FILE__)
+    @test occursin("UndefVarError", r.value)
+end
+
+# supports `skip` keyword
+@addfntest let
+    ts = with_isolated_testset() do
+        @test_call skip=true badf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Broken)
+    @test r.test_type === :skipped
+
+    ts = with_isolated_testset() do
+        skip = true
+        @test_call skip=skip badf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Broken)
+    @test r.test_type === :skipped
+end
+
+# supports `broken` keyword
+@addfntest let
+    ts = with_isolated_testset() do
+        @test_call broken=true badf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Broken)
+    @test r.test_type === :test_call
+
+    ts = with_isolated_testset() do
+        broken = true
+        @test_call broken=broken badf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Broken)
+    @test r.test_type === :test_call
+
+    ts = with_isolated_testset() do
+        @test_call broken=true goodf(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Error)
+    @test r.test_type === :test_unbroken
+end
+
+# supports JET's configurations
+# synced with example used for the `@test_call` docstring
+cond = false
+function f(n)
+    if cond           # `cond` is untyped, and will be reported by the sound analysis pass, while JET's default analysis pass will ignore it
+        return sin(n)
+    else
+        return cos(n)
+    end
+end
+@addfntest let
+    ts = with_isolated_testset() do
+        @test_call f(10) # ok
+    end
+    @test ts.n_passed == 1
+
+    ts = with_isolated_testset() do
+        @test_call f(10) # still be ok
+    end
+    @test ts.n_passed == 1
+
+    ts = with_isolated_testset() do
+        @test_call mode=:sound f(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Fail)
+
+    ts = with_isolated_testset() do
+        @test_call mode=:sound broken=true f(10)
+    end
+    @test ts.n_passed == 0
+    @test length(ts.results) == 1
+    r = ts.results[1]
+    @test isa(r, Test.Broken)
+end


### PR DESCRIPTION
I mostly borrowed from [the implementations in JETTest.jl](https://github.com/aviatesk/JETTest.jl/blob/74059c33681dd3949f4711d54e9e05526ca83456/src/dispatch.jl),
but with generalization.