### PR TITLE
simplify code location queries

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -494,6 +494,10 @@ end
 
 ignorenotfound(@nospecialize(t)) = t === NOT_FOUND ? Bottom : t
 
+# location
+
+include("locinfo.jl")
+
 # includes
 # ========
 
@@ -505,7 +509,6 @@ include("abstractinterpretation.jl")
 include("typeinfer.jl")
 include("analyzer.jl")
 include("jetcache.jl")
-include("locinfo.jl")
 # top-level analysis
 include("graph.jl")
 include("virtualprocess.jl")

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -482,9 +482,9 @@ function maybe_initialize_caches!(analyzer::AbstractAnalyzer)
 end
 
 # check if we're in a toplevel module
-@inline istoplevel(analyzer::AbstractAnalyzer, sv::InferenceState)    = istoplevel(analyzer, sv.linfo)
-@inline istoplevel(::AbstractAnalyzer, ::OptimizationState)           = false # optimization never happen for top-level code
-@inline istoplevel(analyzer::AbstractAnalyzer, linfo::MethodInstance) = get_toplevelmod(analyzer) === linfo.def
+@inline istoplevel(sv::InferenceState)    = istoplevel(sv.linfo)
+@inline istoplevel(::OptimizationState)   = false # optimization never happen for top-level code
+@inline istoplevel(linfo::MethodInstance) = isa(linfo.def, Module)
 
 is_global_slot(analyzer::AbstractAnalyzer, slot::Int)   = slot in keys(get_global_slots(analyzer))
 is_global_slot(analyzer::AbstractAnalyzer, slot::Slot)  = is_global_slot(analyzer, slot_id(slot))

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -287,7 +287,7 @@ get_spec_args(T::Type{<:InferenceErrorReport}) =                error("`get_spec
 
 # default constructor to create a report from abstract interpretation routine
 function (T::Type{<:InferenceErrorReport})(analyzer::AbstractAnalyzer, state, @nospecialize(spec_args...))
-    vf = get_virtual_frame(analyzer, state)
+    vf = get_virtual_frame(state)
     msg = get_msg(T, analyzer, state, spec_args...)
     return T([vf], msg, vf.sig, spec_args...)
 end

--- a/src/legacy/abstractinterpretation
+++ b/src/legacy/abstractinterpretation
@@ -122,7 +122,7 @@ function abstract_call_gf_by_type(interp::AbstractAnalyzer, @nospecialize(f), ar
     edges = MethodInstance[]
     nonbot = 0  # the index of the only non-Bottom inference result if > 0
     seen = 0    # number of signatures actually inferred
-    istoplevel = sv.linfo.def isa Module
+    # istoplevel = sv.linfo.def isa Module
     multiple_matches = napplicable > 1
 
     if f !== nothing && napplicable == 1 && is_method_pure(applicable[1]::MethodMatch)
@@ -142,7 +142,7 @@ function abstract_call_gf_by_type(interp::AbstractAnalyzer, @nospecialize(f), ar
         method = match.method
         sig = match.spec_types
         #=== abstract_call_gf_by_type patch point 2 start ===#
-        if istoplevel && !isdispatchtuple(sig) && !JET.istoplevel(interp, sv) # keep going for "our" toplevel frame
+        if #= istoplevel && !isdispatchtuple(sig) =# false # keep going for "our" toplevel frame
         #=== abstract_call_gf_by_type patch point 2 end ===#
             # only infer concrete call sites in top-level expressions
             add_remark!(interp, sv, "Refusing to infer non-concrete call site in top-level expression")

--- a/src/tfuncs.jl
+++ b/src/tfuncs.jl
@@ -77,7 +77,7 @@ end
 get_spec_args(report::SeriousExceptionReport) = (report.err,)
 
 function SeriousExceptionReport(analyzer::AbstractAnalyzer, state::InferenceState, err)
-    vf = get_virtual_frame(analyzer, state)
+    vf = get_virtual_frame(state)
     msg = string(first(split(sprint(showerror, err), '\n')))
     ret = SeriousExceptionReport([vf], msg, vf.sig, err)
     push!(get_throw_locs(analyzer), get_lin((state, get_currpc(state))))
@@ -203,7 +203,7 @@ function istoplevel_globalref(analyzer::AbstractAnalyzer, sv::InferenceState)
     def.name === :getproperty || return false
     def.sig === Tuple{typeof(getproperty), Module, Symbol} || return false
     parent = sv.parent
-    return !isnothing(parent) && istoplevel(analyzer, parent)
+    return !isnothing(parent) && istoplevel(parent)
 end
 
 # `return_type_tfunc` internally uses `abstract_call` to model `Core.Compiler.return_type`


### PR DESCRIPTION
Especially, we really don't need to pass on `analyzer::AbstractAnalyzer`
around to correctly check if a frame is top-level module or not, because
JET analyzes top-level thunk only from `virtual_process`.
And it vastly simplifies the accompanying code locations queries.