### PR TITLE
enable toplevel optimization and eliminate some toplevel special casings

### DIFF
--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -385,9 +385,6 @@ function CC.abstract_eval_special_value(analyzer::AbstractAnalyzer, @nospecializ
                 # if it's really not defined, the error will be generated later anyway
                 e = GlobalRef(get_toplevelmod(analyzer), get_slotname(sv, e))
             end
-        elseif isa(e, Symbol)
-            # (already concretized) toplevel global symbols
-            e = GlobalRef(get_toplevelmod(analyzer), e)
         end
     end
 
@@ -749,7 +746,7 @@ function is_constant_declared(name::Symbol, sv::InferenceState)
     return any(sv.src.code) do @nospecialize(x)
         if @isexpr(x, :const)
             arg = first(x.args)
-            # `transform_global_symbols!` replaces all the global symbols in this toplevel frame with `Slot`s
+            # `transform_abstract_global_symbols!` replaces all the global symbols in this toplevel frame with `Slot`s
             if isa(arg, Slot)
                 return get_slotname(sv, arg) === name
             end

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -482,8 +482,7 @@ function maybe_initialize_caches!(analyzer::AbstractAnalyzer)
 end
 
 # check if we're in a toplevel module
-@inline istoplevel(sv::InferenceState)    = istoplevel(sv.linfo)
-@inline istoplevel(::OptimizationState)   = false # optimization never happen for top-level code
+@inline istoplevel(sv::State)             = istoplevel(sv.linfo)
 @inline istoplevel(linfo::MethodInstance) = isa(linfo.def, Module)
 
 is_global_slot(analyzer::AbstractAnalyzer, slot::Int)   = slot in keys(get_global_slots(analyzer))

--- a/src/locinfo.jl
+++ b/src/locinfo.jl
@@ -160,15 +160,7 @@ function _get_sig_type((sv, _)::StateAtPC, arg::Argument)
     return Any[sig, typ], typ
 end
 _get_sig_type(_::StateAtPC, gr::GlobalRef) = Any[string(gr.mod, '.', gr.name)], nothing
-function _get_sig_type(s::StateAtPC, name::Symbol)
-    sv = first(s)
-    if istoplevel(sv)
-        # this is concrete global variable, form the global reference
-        return _get_sig_type(s, GlobalRef(sv.linfo.def, name))
-    else
-        return Any[repr(name; context = :compact => true)], nothing
-    end
-end
+_get_sig_type(_::StateAtPC, name::Symbol) = Any[repr(name; context = :compact => true)], nothing
 function _get_sig_type(s::StateAtPC, gotoifnot::GotoIfNot)
     sig  = Any[string("goto %", gotoifnot.dest, " if not "), _get_sig(s, gotoifnot.cond)...]
     return sig, nothing

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -134,9 +134,7 @@ end
         @test isempty(get_reports(analyzer))
     end
 
-    # with the current approach, local undefined variables in toplevel frame can't be found
-    # since we don't cache toplevel frame and thus it won't be optimized
-    let
+    let # should work for top-level analysis
         res = @analyze_toplevel begin
             foo = let
                 if rand(Bool)
@@ -146,7 +144,9 @@ end
                 end
             end
         end
-        @test_broken !isempty(res.inference_error_reports)
+        @test length(res.inference_error_reports) === 1 &&
+              first(res.inference_error_reports) isa LocalUndefVarErrorReport &&
+              first(res.inference_error_reports).name === :bar
     end
 end
 


### PR DESCRIPTION
Better to work with <https://github.com/JuliaLang/julia/pull/42013>, but
I also added an hacky fallback that makes use of the existing method
definition pipeline.