### PR TITLE
`JETAnalyzer`: don't report errors on abstract frames

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -25,7 +25,7 @@ JET.ToplevelConfig
 ## [Configurations for Abstract Interpretation](@id abstractinterpret-config)
 
 ```@docs
-JET.JETAnalysisParams
+JET.JETInferenceParams
 ```
 
 

--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -652,7 +652,7 @@ function CC._typeinf(interp::AbstractAnalyzer, frame::InferenceState)
         result = frame.result
         reports = get_reports(result)
 
-        if !isentry(frame)
+        if frame.parent !== nothing
             # get back to the caller what we got from these results
             add_caller_cache!(interp, reports)
 

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -1,5 +1,10 @@
 # NOTE: this file keeps patches for julia itself to make JET.jl test keep passing
 
+# https://github.com/JuliaLang/julia/pull/42195
+@static if VERSION < v"1.8.0-DEV.510"
+    @eval Base isequal(x, y) = (x == y)::Bool # all `missing` cases are handled in missing.jl
+end
+
 # TODO remove this patch once https://github.com/aviatesk/JET.jl/issues/184 is resolved
 @static if VERSION ≥ v"1.8.0-DEV.421"
     @eval Base mapreduce_empty(f, op, T) = _empty_reduce_error()


### PR DESCRIPTION
For `BasicPass`, we skip errors reported from abstract frames.

- fixes #184
- fixes #154