### PR TITLE
remove `@isexpr` hacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:
         version:
+          - '1'
           - 'nightly'
-          - '1.7-nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JET.jl employs Julia's type inference for bug reports.
 
 !!! note
     The latest version of JET requires Julia versions **1.7 and higher**;
-    JET is tested against [the current v1.7 release candidate](https://julialang.org/downloads/#upcoming_release) as well as [nightly version](https://julialang.org/downloads/nightlies/). \
+    JET is tested against [the current stable release](https://julialang.org/downloads/#current_stable_release) as well as [nightly version](https://julialang.org/downloads/nightlies/). \
     Also note that JET deeply relies on the type inference routine implemented in [the Julia compiler](https://github.com/JuliaLang/julia/tree/master/base/compiler),
     and so the analysis result can vary depending on your Julia version.
     In general, the newer your Julia version is, more accurately and quickly your can expect JET to analyze your code,

--- a/examples/dispatch_analysis.jl
+++ b/examples/dispatch_analysis.jl
@@ -56,7 +56,7 @@ import JET:
     JET,
     @invoke,
     get_source,
-    @isexpr
+    isexpr
 
 struct DispatchAnalyzer{T} <: AbstractAnalyzer
     state::AnalyzerState
@@ -155,7 +155,7 @@ JETInterface.get_msg(::Type{RuntimeDispatchReport}, _) =
 function (::DispatchAnalysisPass)(::Type{RuntimeDispatchReport}, analyzer::DispatchAnalyzer, caller::CC.InferenceResult, opt::CC.OptimizationState)
     (; sptypes, slottypes) = opt
     for (pc, x) in enumerate(opt.src.code)
-        if @isexpr(x, :call)
+        if isexpr(x, :call)
             ft = CC.widenconst(CC.argextype(first(x.args), opt.src, sptypes, slottypes))
             ft <: Core.Builtin && continue # ignore `:call`s of language intrinsics
             add_new_report!(caller, RuntimeDispatchReport((opt, pc)))

--- a/src/abstractinterpret/inferenceerrorreport.jl
+++ b/src/abstractinterpret/inferenceerrorreport.jl
@@ -370,7 +370,7 @@ macro reportdef(ex)
     @assert Core.eval(__module__, S) <: InferenceErrorReport
 
     spec_decls = map(spec_sigs) do x
-        if @isexpr(x, :macrocall) && x.args[1] === Symbol("@nospecialize")
+        if isexpr(x, :macrocall) && x.args[1] === Symbol("@nospecialize")
             return x.args[3]
         end
         return x
@@ -421,5 +421,5 @@ macro reportdef(ex)
     end
 end
 
-extract_decl_name(@nospecialize(x)) = (@isexpr(x, :(::)) ? first(x.args) : x)::Symbol
-extract_decl_type(@nospecialize(x)) = @isexpr(x, :(::)) ? last(x.args) : GlobalRef(Core, :Any)
+extract_decl_name(@nospecialize(x)) = (isexpr(x, :(::)) ? first(x.args) : x)::Symbol
+extract_decl_type(@nospecialize(x)) = isexpr(x, :(::)) ? last(x.args) : GlobalRef(Core, :Any)

--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -760,7 +760,7 @@ function CC.finish(me::InferenceState, analyzer::AbstractAnalyzer)
         cfg = compute_basic_blocks(stmts)
         assigns = Dict{Int,Bool}() # slot id => is this deterministic
         for (pc, stmt) in enumerate(stmts)
-            if @isexpr(stmt, :(=))
+            if isexpr(stmt, :(=))
                 lhs = first(stmt.args)
                 if isa(lhs, Slot)
                     slot = slot_id(lhs)
@@ -823,7 +823,7 @@ function collect_slottypes(sv::InferenceState)
         stmt = stmts[i]
         state = states[i]
         # find all reachable assignments to locals
-        if isa(state, VarTable) && @isexpr(stmt, :(=))
+        if isa(state, VarTable) && isexpr(stmt, :(=))
             lhs = first(stmt.args)
             if isa(lhs, Slot)
                 vt = ssavaluetypes[i] # don't widen const
@@ -938,7 +938,7 @@ get_msg(::Type{InvalidConstantDeclaration}, sv::InferenceState, mod::Module, nam
 
 function is_constant_declared(name::Symbol, sv::InferenceState)
     return any(sv.src.code) do @nospecialize(x)
-        if @isexpr(x, :const)
+        if isexpr(x, :const)
             arg = first(x.args)
             # `transform_abstract_global_symbols!` replaces all the global symbols in this toplevel frame with `Slot`s
             if isa(arg, Slot)

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -202,7 +202,7 @@ function (::OptAnalysisPass)(::Type{CapturedVariableReport}, analyzer::OptAnalyz
     for (pc, typ) in enumerate(frame.src.ssavaluetypes::Vector{Any})
         if typ === Core.Box
             stmt = frame.src.code[pc]
-            if @isexpr(stmt, :(=))
+            if isexpr(stmt, :(=))
                 lhs = first(stmt.args)
                 if isa(lhs, SlotNumber)
                     name = frame.src.slotnames[slot_id(lhs)]
@@ -278,7 +278,7 @@ function (::OptAnalysisPass)(::Type{RuntimeDispatchReport}, analyzer::OptAnalyze
                 CC.in(pc, throw_blocks) && continue
             end
         end
-        if @isexpr(x, :call)
+        if isexpr(x, :call)
             ft = widenconst(argextype(first(x.args), src, sptypes, slottypes))
             ft <: Builtin && continue # ignore `:call`s of language intrinsics
             if analyzer.function_filter(ft)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -423,7 +423,7 @@ function _virtual_process!(s::AbstractString,
 
     toplevelex = parse_input_line(s; filename)
 
-    if @isexpr(toplevelex, (:error, :incomplete))
+    if isexpr(toplevelex, (:error, :incomplete))
         # if there's any syntax error, try to identify all the syntax error location
         append!(res.toplevel_error_reports, collect_syntax_errors(s, filename))
     elseif isnothing(toplevelex)
@@ -447,7 +447,7 @@ function _virtual_process!(toplevelex::Expr,
                            context::Module,
                            res::VirtualProcessResult,
                            )
-    @assert @isexpr(toplevelex, :toplevel)
+    @assert isexpr(toplevelex, :toplevel)
 
     local lnn::LineNumberNode = LineNumberNode(0, filename)
 
@@ -488,7 +488,7 @@ function _virtual_process!(toplevelex::Expr,
         lwr = lower(mod, x)
 
         # here we should capture syntax errors found during lowering
-        if @isexpr(lwr, :error)
+        if isexpr(lwr, :error)
             msg = first(lwr.args)
             push!(res.toplevel_error_reports, SyntaxErrorReport("syntax: $msg", filename, lnn.line))
             return nothing
@@ -532,7 +532,7 @@ function _virtual_process!(toplevelex::Expr,
                 lwr = lower_with_err_handling(context, blk)
 
                 isnothing(lwr) && break # error happened during lowering
-                @isexpr(lwr, :thunk) || break # literal
+                isexpr(lwr, :thunk) || break # literal
 
                 src = first((lwr::Expr).args)::CodeInfo
 
@@ -554,7 +554,7 @@ function _virtual_process!(toplevelex::Expr,
 
         # we will end up lowering `x` later, but special case `macrocall`s and expand it here
         # this is because macros can arbitrarily generate `:toplevel` and `:module` expressions
-        if @isexpr(x, :macrocall)
+        if isexpr(x, :macrocall)
             newx = macroexpand_with_err_handling(context, x)
 
             # if any error happened during macro expansion, bail out now and continue
@@ -566,7 +566,7 @@ function _virtual_process!(toplevelex::Expr,
             if first(x.args) === GlobalRef(Core, Symbol("@doc"))
                 # `@doc` macro usually produces :block expression, but may also produce :toplevel
                 # one when attached to a module expression
-                @assert @isexpr(newx, :block) || @isexpr(newx, :toplevel)
+                @assert isexpr(newx, :block) || isexpr(newx, :toplevel)
                 append!(exs, reverse!((newx::Expr).args))
             else
                 push!(exs, newx)
@@ -576,7 +576,7 @@ function _virtual_process!(toplevelex::Expr,
         end
 
         # flatten container expression
-        if @isexpr(x, :toplevel)
+        if isexpr(x, :toplevel)
             append!(exs, reverse(x.args))
             continue
         end
@@ -586,9 +586,9 @@ function _virtual_process!(toplevelex::Expr,
         # "toplevel definitions" inside of the loaded modules shouldn't be evaluated in a
         # context of `context` module
 
-        if @isexpr(x, :module)
+        if isexpr(x, :module)
             newblk = x.args[3]
-            @assert @isexpr(newblk, :block)
+            @assert isexpr(newblk, :block)
             newtoplevelex = Expr(:toplevel, newblk.args...)
 
             x.args[3] = Expr(:block) # empty module's code body
@@ -604,7 +604,7 @@ function _virtual_process!(toplevelex::Expr,
         end
 
         # can't wrap `:global` declaration into a block
-        if @isexpr(x, :global)
+        if isexpr(x, :global)
             eval_with_err_handling(context, x)
             continue
         end
@@ -613,7 +613,7 @@ function _virtual_process!(toplevelex::Expr,
         lwr = lower_with_err_handling(context, blk)
 
         isnothing(lwr) && continue # error happened during lowering
-        @isexpr(lwr, :thunk) || continue # literal
+        isexpr(lwr, :thunk) || continue # literal
 
         src = first((lwr::Expr).args)::CodeInfo
 
@@ -826,11 +826,11 @@ function select_direct_requirement!(concretize, stmts, edges)
             continue
         end
 
-        if @isexpr(stmt, :(=))
+        if isexpr(stmt, :(=))
             lhs, rhs = stmt.args
             stmt = rhs
         end
-        if @isexpr(stmt, :call)
+        if isexpr(stmt, :call)
             f = stmt.args[1]
 
             # special case `include` calls
@@ -971,7 +971,7 @@ function JuliaInterpreter.step_expr!(interp::ConcreteInterpreter, frame::Frame, 
 end
 
 function collect_toplevel_signature!(interp::ConcreteInterpreter, frame::Frame, @nospecialize(node))
-    if @isexpr(node, :method, 3)
+    if isexpr(node, :method, 3)
         sigs = node.args[2]
         atype_params, sparams, _ = @lookup(moduleof(frame), frame, sigs)::SimpleVector
         # t = atype_params[1]
@@ -984,7 +984,7 @@ function collect_toplevel_signature!(interp::ConcreteInterpreter, frame::Frame, 
     end
 end
 
-ismoduleusage(@nospecialize(x)) = @isexpr(x, (:import, :using, :export))
+ismoduleusage(@nospecialize(x)) = isexpr(x, (:import, :using, :export))
 
 # assuming `ismoduleusage(x)` holds
 function to_simple_module_usages(x::Expr)
@@ -1006,7 +1006,7 @@ function to_simple_module_usages(x::Expr)
                 return [x]
             else
                 # using A: sym1, sym2, ...
-                @assert @isexpr(arg, :(:))
+                @assert isexpr(arg, :(:))
                 a, as... = arg.args
                 return Expr.(x.head, Expr.(arg.head, Ref(a), as))::Vector{Expr}
             end
@@ -1153,8 +1153,8 @@ function collect_syntax_errors(s, filename)
             !isnothing(ex)
         end
         line += count(==('\n'), s[index:nextindex-1])
-        report = @isexpr(ex, :error) ? SyntaxErrorReport(string("syntax: ", first(ex.args)), filename, line) :
-                 @isexpr(ex, :incomplete) ? SyntaxErrorReport(first(ex.args), filename, line) :
+        report = isexpr(ex, :error) ? SyntaxErrorReport(string("syntax: ", first(ex.args)), filename, line) :
+                 isexpr(ex, :incomplete) ? SyntaxErrorReport(first(ex.args), filename, line) :
                  nothing
         isnothing(report) || push!(reports, report)
         index = nextindex

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1520,7 +1520,7 @@ end
         slice = JET.select_statements(src)
 
         for (i, stmt) in enumerate(src.code)
-            if JET.@isexpr(stmt, :(=))
+            if JET.isexpr(stmt, :(=))
                 lhs, rhs = stmt.args
                 if isa(lhs, Core.SlotNumber)
                     if src.slotnames[lhs.id] === :w || src.slotnames[lhs.id] === :sum


### PR DESCRIPTION
Now v1.7 is released, we don't need to use this hack in order to propagate
`isa(x, Expr)` constraint inter-procedurally.