### PR TITLE
Work on supporting foreign calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,11 +18,3 @@ LoweredCodeUtils = "~2.1.0"
 MacroTools = "0.5.6"
 Revise = "3.1.15"
 julia = "1.7"
-
-[extras]
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Logging", "Random", "Test"]

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -636,7 +636,7 @@ function _virtual_process!(toplevelex::Expr,
         all(concretized) && continue
 
         # concretize the unoptimized source for the analyzer
-        concretize = select_statements(src, false)
+        concretized = select_statements(src, false)
 
         analyzer = AbstractAnalyzer(analyzer, concretized, context)
 

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -793,6 +793,7 @@ function partially_interpret!(interp::ConcreteInterpreter, mod::Module, src::Cod
     # generate optimized code to support foreign calls,
     # see https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/13
     frame = Frame(mod, src)
+    @assert length(frame.framecode.src.code) == length(src.code)
     concretize = select_statements(frame.framecode.src, true)
 
     with_toplevel_logger(interp.analyzer, ≥(DEBUG_LOGGER_LEVEL)) do @nospecialize(io)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -636,10 +636,10 @@ function _virtual_process!(toplevelex::Expr,
         all(concretized) && continue
 
         # concretize the unoptimized source for the analyzer
-        concretize = select_statements(src)
+        concretize = select_statements(src, false)
 
         analyzer = AbstractAnalyzer(analyzer, concretized, context)
-        
+
         _, result = analyze_toplevel!(analyzer, src)
 
         append!(res.inference_error_reports, get_reports(result)) # collect error reports
@@ -794,7 +794,7 @@ Partially interprets statements in `frame.framecode.src` using JuliaInterpreter.
 - special-cases `include` calls so that top-level analysis recursively enters the included file
 """
 function partially_interpret!(interp::ConcreteInterpreter, frame::Frame)
-    concretize = select_statements(frame.framecode.src)
+    concretize = select_statements(frame.framecode.src, true)
 
     with_toplevel_logger(interp.analyzer, ≥(DEBUG_LOGGER_LEVEL)) do @nospecialize(io)
         line, file = interp.lnn.line, interp.lnn.file
@@ -808,20 +808,20 @@ function partially_interpret!(interp::ConcreteInterpreter, frame::Frame)
 end
 
 # select statements that should be concretized, and actually interpreted rather than abstracted
-function select_statements(src::CodeInfo)
+function select_statements(src::CodeInfo, optimized::Bool)
     stmts = src.code
     edges = CodeEdges(src)
 
     concretize = fill(false, length(stmts))
 
-    select_direct_requirement!(concretize, stmts, edges)
+    select_direct_requirement!(concretize, stmts, edges, optimized)
 
     select_dependencies!(concretize, src, edges)
 
     return concretize
 end
 
-function select_direct_requirement!(concretize, stmts, edges)
+function select_direct_requirement!(concretize, stmts, edges, optimized)
     for (i, stmt) in enumerate(stmts)
         if begin
                 ismethod(stmt)      || # don't abstract away method definitions
@@ -851,8 +851,12 @@ function select_direct_requirement!(concretize, stmts, edges)
             # - https://github.com/timholy/Revise.jl/blob/266ed68d7dd3bea67c39f96513cda30bbcd7d441/src/lowered.jl#L53
             # - https://github.com/timholy/Revise.jl/blob/266ed68d7dd3bea67c39f96513cda30bbcd7d441/src/lowered.jl#L87-L88
             if begin
-                    is_quotenode_egal(f, Core.eval) ||
-                    isa(f, GlobalRef) && f.name === :eval
+                    optimized ?
+                        (is_quotenode_egal(f, Core.eval) ||
+                         isa(f, GlobalRef) && f.name === :eval) :
+                        (f === :eval ||
+                         (callee_matches(f, Base, :getproperty) && is_quotenode_egal(stmt.args[end], :eval)) ||
+                         isa(f, GlobalRef) && f.name === :eval)
                 end
                 # statement `i` may be the equivalent of `f = Core.eval`, so require each
                 # stmt that calls `eval` via `f(expr)`

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -848,8 +848,7 @@ function select_direct_requirement!(concretize, stmts, edges)
             # - https://github.com/timholy/Revise.jl/blob/266ed68d7dd3bea67c39f96513cda30bbcd7d441/src/lowered.jl#L53
             # - https://github.com/timholy/Revise.jl/blob/266ed68d7dd3bea67c39f96513cda30bbcd7d441/src/lowered.jl#L87-L88
             if begin
-                    f === :eval ||
-                    (callee_matches(f, Base, :getproperty) && is_quotenode_egal(stmt.args[end], :eval)) ||
+                    is_quotenode_egal(f, Core.eval) ||
                     isa(f, GlobalRef) && f.name === :eval
                 end
                 # statement `i` may be the equivalent of `f = Core.eval`, so require each

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -627,7 +627,7 @@ function _virtual_process!(toplevelex::Expr,
                                      config,
                                      res,
                                      )
-        # Generate optimized code to support foreign calls,
+        # generate optimized code to support foreign calls,
         # see https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/13
         frame = Frame(context, src)
         concretized = partially_interpret!(interp, frame)
@@ -635,8 +635,11 @@ function _virtual_process!(toplevelex::Expr,
         # bail out if nothing to analyze (just a performance optimization)
         all(concretized) && continue
 
-        analyzer = AbstractAnalyzer(analyzer, concretized, context)
+        # concretize the unoptimized source for the analyzer
+        concretize = select_statements(src)
 
+        analyzer = AbstractAnalyzer(analyzer, concretized, context)
+        
         _, result = analyze_toplevel!(analyzer, src)
 
         append!(res.inference_error_reports, get_reports(result)) # collect error reports

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -793,7 +793,6 @@ function partially_interpret!(interp::ConcreteInterpreter, mod::Module, src::Cod
     # generate optimized code to support foreign calls,
     # see https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/13
     frame = Frame(mod, src)
-    @assert length(frame.framecode.src.code) == length(src.code)
     concretize = select_statements(frame.framecode.src, true)
 
     with_toplevel_logger(interp.analyzer, ≥(DEBUG_LOGGER_LEVEL)) do @nospecialize(io)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -790,14 +790,14 @@ function partially_interpret!(interp::ConcreteInterpreter, mod::Module, src::Cod
     with_toplevel_logger(interp.analyzer, ≥(DEBUG_LOGGER_LEVEL)) do @nospecialize(io)
         line, file = interp.lnn.line, interp.lnn.file
         println(io, "concretization plan at $file:$line:")
-        print_with_code(io, frame.framecode.src, concretize)
+        print_with_code(io, src, concretize)
     end
 
-    # generate unoptimized JuliaInterpreter code
-    # see https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/13
+    # NOTE if `JuliaInterpreter.optimize!` may modify `src`, `src` and `concretize` can be inconsistent
+    # here we create `JuliaInterpreter.Frame` by ourselves disabling the optimization (#277)
     # TODO: change to a better Frame constructor when available
     framecode = JuliaInterpreter.FrameCode(mod, src, optimize=false)
-    @assert length(framecode.src.code) == length(src.code)
+    @assert length(framecode.src.code) == length(concretize)
     frame = Frame(framecode, JuliaInterpreter.prepare_framedata(framecode, Any[]))
     selective_eval_fromstart!(interp, frame, concretize, #= istoplevel =# true)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,8 @@
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1534,7 +1534,7 @@ end
             @eval global getsum() = $sum # concretization is forced
             write(product) # should NOT be selected
         end
-        slice = JET.select_statements(src, false)
+        slice = JET.select_statements(src)
 
         for (i, stmt) in enumerate(src.code)
             if JET.isexpr(stmt, :(=))

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1517,7 +1517,7 @@ end
             @eval global getsum() = $sum # concretization is forced
             write(product) # should NOT be selected
         end
-        slice = JET.select_statements(src)
+        slice = JET.select_statements(src, false)
 
         for (i, stmt) in enumerate(src.code)
             if JET.isexpr(stmt, :(=))

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1026,16 +1026,18 @@ end
     @testset "https://github.com/aviatesk/JET.jl/issues/280" begin
         res = @analyze_toplevel begin
             using Libdl
-            llvmpaths = filter(lib -> occursin(r"LLVM\b", basename(lib)), Libdl.dllist())
-            if length(llvmpaths) != 1
-                throw(ArgumentError("Found one or multiple LLVM libraries"))
+            let
+                llvmpaths = filter(lib -> occursin(r"LLVM\b", basename(lib)), Libdl.dllist())
+                if length(llvmpaths) != 1
+                    throw(ArgumentError("Found one or multiple LLVM libraries"))
+                end
+                libllvm = Libdl.dlopen(llvmpaths[1])
+                gethostcpufeatures = Libdl.dlsym(libllvm, :LLVMGetHostCPUFeatures)
+                ccall(gethostcpufeatures, Cstring, ())
             end
-            libllvm = Libdl.dlopen(llvmpaths[1])
-            gethostcpufeatures = Libdl.dlsym(libllvm, :LLVMGetHostCPUFeatures)
-            ccall(gethostcpufeatures, Cstring, ())
         end
 
-        @test isempty(res.toplevel_error_reports) 
+        @test isempty(res.toplevel_error_reports)
     end
 end
 

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1022,6 +1022,21 @@ end
 
         @test isempty(res.toplevel_error_reports)
     end
+
+    @testset "https://github.com/aviatesk/JET.jl/issues/280" begin
+        res = @analyze_toplevel begin
+            using Libdl
+            llvmpaths = filter(lib -> occursin(r"LLVM\b", basename(lib)), Libdl.dllist())
+            if length(llvmpaths) != 1
+                throw(ArgumentError("Found one or multiple LLVM libraries"))
+            end
+            libllvm = Libdl.dlopen(llvmpaths[1])
+            gethostcpufeatures = Libdl.dlsym(libllvm, :LLVMGetHostCPUFeatures)
+            ccall(gethostcpufeatures, Cstring, ())
+        end
+
+        @test isempty(res.toplevel_error_reports) 
+    end
 end
 
 let # global declaration


### PR DESCRIPTION
Use optimized JuliaInterpreter frames to support foreign calls. Fixes #277 and #224, but breaks `eval` tests. Open question: should 

```
        analyzer = AbstractAnalyzer(analyzer, concretized, context)

        _, result = analyze_toplevel!(analyzer, src)
```

use `frame.framecode.src` instead to be synced with `concretized`? That change would break even more tests.
