### PR TITLE
update to JuliaInterpreter@0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JuliaInterpreter = "0.8.16"
-LoweredCodeUtils = "~2.1.0"
+JuliaInterpreter = "0.9"
+LoweredCodeUtils = "2.2"
 MacroTools = "0.5.6"
-Revise = "3.1.15"
+Revise = "3.3"
 julia = "1.7"
 
 [extras]


### PR DESCRIPTION
CI should run successfully once we tag new minor version of JuliaInterpreter.jl.

/cc @goerch thanks so much for your work on https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/503 :) 