### PR TITLE
Add docs on SnoopCompile integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### behind the moar for performance ...
 
-JET.jl employs Julia's type inference for bug reports.
+JET.jl employs Julia's type inference to detect potential bugs.
 
 !!! note
     The latest version of JET requires Julia versions **1.7 and higher**;
@@ -195,6 +195,13 @@ If you apply the diff (i.e. update and save the demo.jl), JET will automatically
 No errors !
 ```
 
+## Limitations
+
+JET explores the functions you call directly as well as their *inferrable* callees. However, if the argument-types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors!` does not imply that your entire codebase is free of errors.
+
+JET integrates with [SnoopCompile](https://github.com/timholy/SnoopCompile.jl), and you can sometimes use SnoopCompile to collect the data to perform more comprehensive analyses. SnoopCompile's limitation is that it only collects data for calls that have not been previously inferred, so you must perform this type of analysis in a fresh session.
+
+See [SnoopCompile's JET-integration documentation](https://timholy.github.io/SnoopCompile.jl/stable/jet/) for further details.
 
 ## Roadmap
 

--- a/docs/src/optanalysis.md
+++ b/docs/src/optanalysis.md
@@ -27,6 +27,7 @@ JET implements such an analyzer that investigates optimized representation of yo
 anywhere the compiler failed in optimization. Especially, it can find where Julia creates captured variables, where
 runtime dispatch will happen, and where Julia gives up the optimization work due to unresolvable recursive function call.
 
+[SnoopCompile also detects inference failures](https://timholy.github.io/SnoopCompile.jl/stable/snoopi_deep_analysis/), but JET and SnoopCompile use different mechanisms: JET performs *static* analysis of a particular call, while SnoopCompile performs *dynamic* analysis of new inference. As a consequence, JET's detection of inference failures is reproducible (you can run the same analysis repeatedly and get the same result) but terminates at any non-inferrable node of the call graph: you will miss runtime dispatch in any non-inferrable callees. Conversely, SnoopCompile's detection of inference failures can explore the entire callgraph, but only for those portions that have not been previously inferred, and the analysis cannot be repeated in the same session.
 
 ## [Quick Start](@id optanalysis-quick-start)
 


### PR DESCRIPTION
This links documentation on SnoopCompile's JET integration. There's also a comparison between JET's and SnoopCompile's runtime-dispatch analysis; the identical corresponding paragraph for SnoopCompile is https://github.com/timholy/SnoopCompile.jl/pull/277.