### PR TITLE
rework caching logic

### DIFF
--- a/examples/dispatch_analysis.jl
+++ b/examples/dispatch_analysis.jl
@@ -55,7 +55,6 @@ const CC = Core.Compiler
 import JET:
     JET,
     @invoke,
-    get_source,
     isexpr
 
 struct DispatchAnalyzer{T} <: AbstractAnalyzer
@@ -106,7 +105,7 @@ function CC.finish(frame::CC.InferenceState, analyzer::DispatchAnalyzer)
     if !analyzer.frame_filter(frame)
         push!(analyzer.opts, false)
     else
-        if isa(get_source(frame.result), CC.OptimizationState)
+        if isa(frame.result, CC.OptimizationState)
             push!(analyzer.opts, true)
         else # means, compiler decides not to do optimization
             ReportPass(analyzer)(OptimizationFailureReport, analyzer, frame.result)
@@ -129,7 +128,7 @@ function CC.finish!(analyzer::DispatchAnalyzer, frame::CC.InferenceState)
     caller = frame.result
 
     ## get the source before running `finish!` to keep the reference to `OptimizationState`
-    src = get_source(caller)
+    src = caller.src
 
     ## run `finish!(::AbstractAnalyzer, ::CC.InferenceState)` first to convert the optimized `IRCode` into optimized `CodeInfo`
     ret = @invoke CC.finish!(analyzer::AbstractAnalyzer, frame::CC.InferenceState)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -393,7 +393,7 @@ function analyze_from_definitions!(analyzer::AbstractAnalyzer, res::VirtualProce
                     analyzer, (first(mms)::MethodMatch).method;
                     # JETAnalyzer{BasicPass}: don't report errors unless this frame is concrete
                     set_entry = false)
-                append!(res.inference_error_reports, get_reports(result))
+                append!(res.inference_error_reports, get_reports(analyzer, result))
                 continue
             end
         end
@@ -621,7 +621,7 @@ function _virtual_process!(toplevelex::Expr,
 
         _, result = analyze_toplevel!(analyzer, src)
 
-        append!(res.inference_error_reports, get_reports(result)) # collect error reports
+        append!(res.inference_error_reports, get_reports(analyzer, result)) # collect error reports
     end
 
     return res

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -25,4 +25,4 @@ function test_sum_over_string(ers)
     end
 end
 test_sum_over_string(res::JET.VirtualProcessResult) = test_sum_over_string(res.inference_error_reports)
-test_sum_over_string(res::JET.JETCallResult) = test_sum_over_string(get_reports(res.result))
+test_sum_over_string(res::JET.JETCallResult) = test_sum_over_string(get_reports(res))


### PR DESCRIPTION
The primary motivation for this is to eliminate as much dirty overloads
around `typeinf` as possible. Also I'm trying to avoid hijacking `InferenceResult.src`
field to keep JET's analysis result by maintaining a dictionary within
`AnalyzerState` to keep reports associating with `InferenceResult`
(which is essentially the same approach as what we are doing with Cthulhu).