### PR TITLE
adds `ignored_modules` configuration

### DIFF
--- a/test/analyzers/test_jetanalyzer.jl
+++ b/test/analyzers/test_jetanalyzer.jl
@@ -720,9 +720,7 @@ end
     end
 end
 
-@testset "target_modules" begin
-    # from `PrintConfig` docstring
-
+@testset "configured_reports" begin
     M = Module()
     @eval M begin
         function foo(a)
@@ -732,18 +730,35 @@ end
         end
     end
 
-    let
-        result = @report_call M.foo("julia")
-        @test length(get_reports_with_test(result)) == 3
+    let result = @report_call M.foo("julia")
+        test_sum_over_string(result)
         @test any(get_reports_with_test(result)) do report
             isa(report, GlobalUndefVarErrorReport) && report.name === :undefsum
         end
     end
 
-    let
-        result = @report_call target_modules=(M,) M.foo("julia")
+    let result = @report_call target_modules=(M,) M.foo("julia")
         report = only(get_reports_with_test(result))
         @test isa(report, GlobalUndefVarErrorReport) && report.name === :undefsum
+    end
+
+    let result = @report_call target_modules=(AnyFrameModule(M),) M.foo("julia")
+        test_sum_over_string(result)
+        @test any(get_reports_with_test(result)) do report
+            isa(report, GlobalUndefVarErrorReport) && report.name === :undefsum
+        end
+    end
+
+    let result = @report_call ignored_modules=(Base,) M.foo("julia")
+        report = only(get_reports_with_test(result))
+        @test isa(report, GlobalUndefVarErrorReport) && report.name === :undefsum
+    end
+
+    let result = @report_call ignored_modules=(M,) M.foo("julia")
+        test_sum_over_string(result)
+        @test !any(get_reports_with_test(result)) do report
+            isa(report, GlobalUndefVarErrorReport) && report.name === :undefsum
+        end
     end
 end
 


### PR DESCRIPTION
```julia
julia> function compute(x)
           r = 1
           s = 0.0
           n = 1
           @time while r < x
               s += 1/n
               if s ≥ r
                   println("round $r/$x has been finished") # we're not interested type-instabilities within this call
                   r += 1
               end
               n += 1
           end
           return n, s
       end
compute (generic function with 1 method)

julia> @test_opt ignored_modules=(Base,) compute(42)
Test Passed
```

Also extends the existing `target_modules` so that user can specify how
module context is matched with `InferenceErrorReport`'s stack trace.

This commit also implements additional configuration layers that let
users to implement their own module context matcher and report filtering
strategy in general. We should still try to improve their documentation
though.