### PR TITLE
Fix minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JET.jl employs Julia's type inference to detect potential bugs.
     JET is tested against [the current stable release](https://julialang.org/downloads/#current_stable_release) as well as [nightly version](https://julialang.org/downloads/nightlies/). \
     Also note that JET deeply relies on the type inference routine implemented in [the Julia compiler](https://github.com/JuliaLang/julia/tree/master/base/compiler),
     and so the analysis result can vary depending on your Julia version.
-    In general, the newer your Julia version is, more accurately and quickly your can expect JET to analyze your code,
+    In general, the newer your Julia version is, the more accurately and quickly you can expect JET to analyze your code,
     assuming the Julia compiler keeps evolving all the time from now on.
 
 !!! tip
@@ -116,13 +116,13 @@ julia> report_and_watch_file("demo.jl"; annotate_types = true)
 ```
 
 Hooray!
-JET.jl found possible error points (e.g. `MethodError: no method matching isless(::String, ::Int64)`) given toplevel call signatures of generic functions (e.g. `fib("1000")`).
+JET.jl found possible error points (e.g. `MethodError: no method matching isless(::String, ::Int64)`) given top-level call signatures of generic functions (e.g. `fib("1000")`).
 
 Note that JET can find these errors while demo.jl is so inefficient (especially the `fib` implementation) that it would never terminate in actual execution.
 That is possible because JET analyzes code only on _type level_.
 This technique is often called "abstract interpretation" and JET internally uses Julia's native type inference implementation, so it can analyze code as fast/correctly as Julia's code generation.
 
-Lastly let's apply the following diff to demo.jl so that it works nicely:
+Lastly, let's apply the following diff to demo.jl so that it works nicely:
 
 > fix-demo.jl.diff
 
@@ -197,7 +197,7 @@ No errors detected
 
 ## Limitations
 
-JET explores the functions you call directly as well as their *inferrable* callees. However, if the argument-types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors detected` does not imply that your entire codebase is free of errors.
+JET explores the functions you call directly as well as their *inferrable* callees. However, if the argument types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors detected` does not imply that your entire codebase is free of errors.
 
 JET integrates with [SnoopCompile](https://github.com/timholy/SnoopCompile.jl), and you can sometimes use SnoopCompile to collect the data to perform more comprehensive analyses. SnoopCompile's limitation is that it only collects data for calls that have not been previously inferred, so you must perform this type of analysis in a fresh session.
 
@@ -206,19 +206,19 @@ See [SnoopCompile's JET-integration documentation](https://timholy.github.io/Sno
 ## Roadmap
 
 - **more accuracy**: abstract interpretation can be improved yet more
-  * switch to new type lattice design: to simplify the addition of further improvements
-  * design and introduce a more proper backward-analysis pass, e.g. effect and escape analysis: to enable further constraint propagation
+  * switch to a new type of lattice design: to simplify the addition of further improvements
+  * design and introduce a more proper backwards-analysis pass, e.g. effect and escape analysis: to enable further constraint propagation
 - **more performance**: JET should be much faster
   * aggregate similar errors more smartly and aggressively
   * introduce parallelism to Julia's native type inference routine
 - **better documentation**: especially JET needs a specification of its error reports
-- **editor/IDE integration**: GUI would definitely be more appropriate for showing JET's analysis result
+- **editor/IDE integration**: GUI would be more appropriate for showing JET's analysis result
   * **smarter code dependency tracking**: the watch mode currently re-analyzes the whole code on each update, which is the most robust and least efficient option. When integrated with an IDE, fancier incremental analysis based on smarter code dependency tracking like what [Revise.jl](https://github.com/timholy/Revise.jl) does would be needed
-  * **LSP support**: ideally I hope to extend JET to provide some of LSP features other than diagnostics, e.g. auto-completions, rename refactor, taking type-level information into account
+  * **LSP support**: ideally, I hope to extend JET to provide some of LSP features other than diagnostics, e.g. auto-completion, rename refactor, taking type-level information into account
 
 
 ## Acknowledgement
 
 This project started as my undergrad thesis project at Kyoto University, supervised by Prof. Takashi Sakuragawa.
 We were heavily inspired by [ruby/typeprof](https://github.com/ruby/typeprof), an experimental type understanding/checking tool for Ruby.
-The grad thesis about this project is published at <https://github.com/aviatesk/grad-thesis>, but currently it's only available in Japanese.
+The grad thesis about this project is published at <https://github.com/aviatesk/grad-thesis>, but currently, it's only available in Japanese.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -2,13 +2,13 @@
 
 ## [Abstract Interpretation](@id abstractinterpret)
 
-In order to perform type level program analysis, JET.jl uses
+In order to perform type-level program analysis, JET.jl uses
 [`Core.Compiler.AbstractInterpreter` interface](https://github.com/JuliaLang/julia/blob/master/base/compiler/types.jl),
-and customizes its abstract interpretation by overloading subset of `Core.Compiler` functions, that are originally
+and customizes its abstract interpretation by overloading a subset of `Core.Compiler` functions, that are originally
 developed for Julia compiler's type inference and optimizations that aim at generating efficient native code for CPU execution.
 
 [`JET.AbstractAnalyzer`](@ref) overloads a set of `Core.Compiler` functions to implement the "core" functionalities
-of JET's analysis, including inter-procedural error report propagation and caching of analysis result.
+of JET's analysis, including inter-procedural error report propagation and caching of the analysis result.
 And each plugin analyzer (e.g. [`JET.JETAnalyzer`](@ref)) will overload more `Core.Compiler` functions so that it can
 perform its own program analysis on top of the core `AbstractAnalyzer` infrastructure.
 

--- a/docs/src/jetanalysis.md
+++ b/docs/src/jetanalysis.md
@@ -1,13 +1,13 @@
 # [Error Analysis](@id jetanalysis)
 
 Julia's type system is quite expressive and its type inference is strong enough to generate
-fairly optimized code from highly generic program written in a concise syntax.
+fairly optimized code from a highly generic program written in a concise syntax.
 But as opposed to other statically-compiled languages, Julia by design does _not_ error nor
 warn anything even if it detects possible errors during its compilation process no matter
-how serious they are. In essence Julia achieves a highly generic and composable programming
+how serious they are. In essence, Julia achieves highly generic and composable programming
 by delaying all the errors and warnings to the runtime.
 
-This is actually a core design choice of the language. On the one hand, Julia's dynamism
+This is a core design choice of the language. On the one hand, Julia's dynamism
 allows it to work in places where data types can not be fully decided ahead of runtime
 (e.g. when the program is duck-typed with generic pieces of code, or when the program
 consumes some data that is only known at runtime). On the other hand, with Julia, it's
@@ -27,11 +27,11 @@ based on a technique called
 This way JET can also analyze _just a normal_ Julia program and smartly detect possible
 errors statically, without requiring any additional setups like scattering type annotations
 just for the sake of analysis but preserving original polymorphism and composability of
-the program, as much effectively as the Julia compiler can optimize your Julia program.
+the program, as effectively as the Julia compiler can optimize your Julia program.
 
 ## [Quick Start](@id jetanalysis-quick-start)
 
-First you need to install JET: JET is an ordinary Julia package, so you can install it via
+First, you need to install JET: JET is an ordinary Julia package, so you can install it via
 Julia's built-in package manager and use it as like other packages.
 ```@repl quickstart
 ; # ] add JET # install JET via the built-in package manager
@@ -39,12 +39,12 @@ Julia's built-in package manager and use it as like other packages.
 using JET
 ```
 
-Let's start with a simplest example: how JET can find anything wrong with `sum("julia")`?
+Let's start with the simplest example: how JET can find anything wrong with `sum("julia")`?
 [`@report_call`](@ref) and [`report_call`](@ref) analyzes a given function call and report
 back possible problems. They can be used in a similar way as
 [`@code_typed`](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed)
 and [`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed).
-Those [interactive entry points](@ref jetanalysis-interactive-entry) are the most easiest
+Those [interactive entry points](@ref jetanalysis-interactive-entry) are the easiest
 way to use JET:
 ```@repl quickstart
 @report_call sum("julia")
@@ -60,7 +60,7 @@ We should note that `@report_call sum("julia")` could detect both of those two d
 errors that can happen at runtime. This is because `@report_call` does a static analysis —
 it analyzes the function call in a way that does not rely on one instance of runtime
 execution, but rather it reasons about all the possible executions!
-This is one of the biggest advantages of static analysis, because other alternatives to
+This is one of the biggest advantages of static analysis because other alternatives to
 check software qualities like "testing" usually rely on _some_ runtime execution and they
 can only cover a subset of all the possible executions.
 
@@ -81,15 +81,15 @@ bar(s::String) = parse(Int, s)
 ```
 
 Now let's fix this problematic code.
-First we can fix the definition of `bar` so that it accepts generic `AbstractString` input.
+First, we can fix the definition of `bar` so that it accepts generic `AbstractString` input.
 JET's analysis result can be dynamically updated when we refine a function definition,
 and so we just need to add a new `bar(::AbstractString)` definition.
-As for the second error, let's assume, for some reason, we're not interested fixing it and
+As for the second error, let's assume, for some reason, we're not interested in fixing it and
 we want to ignore errors that may happen within `Base`. Then we can use the
 [`target_modules`](@ref result-config) configuration to limit the analysis scope to
 the current module context to ignore the possible error that may happen within `sum(a)`[^1].
 
-[^1]: We used `target_modules` just for the sake of demonstration. In order to make it more
+[^1]: We used `target_modules` just for the sake of demonstration. To make it more
       idiomatic, we should initialize `a` as typed vector `a = Int[]`, and then we won't
       get any problem from `sum(a)` even without the `target_modules` configuration.
 
@@ -107,7 +107,7 @@ JET offers other error reporting passes, including the "sound" error detection (
 as well as the simpler "typo" detection pass ([`JET.TypoPass`](@ref))[^2].
 They can be switched using the `mode` configuration:
 
-[^2]: Actually JET offers the framework to define your own abstract interpretation based analysis.
+[^2]: JET offers the framework to define your own abstract interpretation-based analysis.
       See [`AbstractAnalyzer`-Framework](@ref) if interested.
 
 ```@repl quickstart
@@ -120,10 +120,10 @@ function myifelse(cond, a, b)
 end
 
 # the default analysis pass doesn't report "non-boolean (T) used in boolean context" error
-# as far as there is possibility when the condition "can" be bool (NOTE: Bool <: Integer)
+# as far as there is a possibility when the condition "can" be bool (NOTE: Bool <: Integer)
 report_call(myifelse, (Integer, Int, Int))
 
-# the sound analyzer doens't permit such a case: it requires the type of a conditional value to be `Bool` strictly
+# the sound analyzer doesn't permit such a case: it requires the type of a conditional value to be `Bool` strictly
 report_call(myifelse, (Integer, Int, Int); mode=:sound)
 
 function strange_sum(a)
@@ -139,7 +139,7 @@ end
 # - `sum(a::Vector{Any})` can throw when `a` is empty
 @report_call strange_sum([])
 
-# the typo dection pass will only report the "typo"
+# the typo detection pass will only report the "typo"
 @report_call mode=:typo strange_sum([])
 ```
 
@@ -164,11 +164,11 @@ using Test
 end
 ```
 
-JET actually uses JET itself in its test pipeline: JET's static analysis has been proven to
+JET uses JET itself in its test pipeline: JET's static analysis has been proven to
 be very useful and helped its development a lot.
 If interested, take a peek at [JET's `"self check !!!"` testset](https://github.com/aviatesk/JET.jl/blob/master/test/runtests.jl).
 
-Lastly, let's see the example that demonstrates JET can analyze "top-level" program.
+Lastly, let's see the example that demonstrates JET can analyze a "top-level" program.
 The top-level analysis should be considered as a somewhat experimental feature, and at this moment
 you may need additional configurations to run it correctly. Please read the descriptions of
 [top-level entry points](@ref jetanalysis-toplevel-entry) and choose an appropriate entry point for
@@ -206,16 +206,16 @@ JET can also analyze your "top-level" program: it can just take your Julia scrip
 and will report possible errors.
 
 Note that JET will analyze your top-level program "half-statically": JET will selectively
-interpret and actually load "definitions" (like a function or struct definition) and try to
+interpret and load "definitions" (like a function or struct definition) and try to
 simulate Julia's top-level code execution process.
 While it tries to avoid executing any other parts of code like function calls and analyzes
 them based on abstract interpretation instead (and this is a part where JET statically analyzes your code).
 If you're interested in how JET selects "top-level definitions", please see [`JET.virtual_process`](@ref).
 
 !!! warning
-    Because JET will actually interpret "definitions" in your code, that part of top-level analysis
+    Because JET will interpret "definitions" in your code, that part of top-level analysis
     certainly _runs_ your code. So we should note that JET can cause some side effects from your code;
-    for example JET will try to expand all the macros used in your code, and so the side effects
+    for example, JET will try to expand all the macros used in your code, and so the side effects
     involved with macro expansions will also happen in JET's analysis process.
 
 ```@docs

--- a/docs/src/optanalysis.md
+++ b/docs/src/optanalysis.md
@@ -1,29 +1,29 @@
 # [Optimization Analysis](@id optanalysis)
 
-Successful type inference and optimization is key to high-performing Julia programs.
+Successful type inference and optimization are key to high-performing Julia programs.
 But as mentioned in [the performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/), there are some
 chances where Julia can not infer the types of your program very well and can not optimize it well accordingly.
 
 While there are many possibilities of "type-instabilities", like usage of non-constant global variable most notably,
 probably the most tricky one would be ["captured variable"](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured)
 – Julia can not really well infer the type of variable that is observed and modified by both inner function and enclosing one.
-And such type instabilities can lead to various optimization failures. One of the most common barrier to the performance
+And such type instabilities can lead to various optimization failures. One of the most common barriers to performance
 is known as "runtime dispatch", which happens when a matching method can't be resolved by the compiler due to the lack
 of type information and it is looked up at runtime instead. Since runtime dispatch is caused by poor type information,
 it often indicates the compiler could not do other optimizations including inlining and scalar replacements of aggregates.
 
-In order to avoid such problems, we usually inspect output of [`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed)
+In order to avoid such problems, we usually inspect the output of [`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed)
 or its family, and check if there is anywhere type is not well inferred and optimization was not successful.
-But the problem is that one needs to have enough knowledge about the inference and optimization in order to interpret
+But the problem is that one needs to have enough knowledge about inference and optimization in order to interpret
 the output. Another problem is that they can only present the "final" output of the inference and optimization, and we
-can not inspect the entire call graph and may miss to find where a problem actually happened and how the type-instability
+can not inspect the entire call graph and may miss finding where a problem actually happened and how the type-instability
 has been propagated.
 There is a nice package called [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), which allows us to look at
 the outputs of `code_typed` by _descending_ into a call tree, recursively and interactively. The workflow with Cthulhu
-is much more efficient and powerful, but still, it requires much familiarity with Julia compiler and it tends to be tedious.
+is much more efficient and powerful, but still, it requires much familiarity with the Julia compiler and it tends to be tedious.
 
-So, why not automate it ?
-JET implements such an analyzer that investigates optimized representation of your program and _automatically_ detects
+So, why not automate it?
+JET implements such an analyzer that investigates the optimized representation of your program and _automatically_ detects
 anywhere the compiler failed in optimization. Especially, it can find where Julia creates captured variables, where
 runtime dispatch will happen, and where Julia gives up the optimization work due to unresolvable recursive function call.
 
@@ -73,7 +73,7 @@ end;
 ```
 [^1]: Technically, it's fully integrated with [Julia's method invalidation system](https://julialang.org/blog/2020/08/invalidations/).
 
-`@report_opt` can also report existence of captured variables, which are really better to be eliminated within
+`@report_opt` can also report the existence of captured variables, which are really better to be eliminated within
 performance-sensitive context:
 ```@repl quickstart
 # the examples below are all adapted from https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
@@ -104,7 +104,7 @@ function abmult(r::Int)
         r = -r
     end
     # we can try to eliminate the capturing
-    # and now this function would be most high-performing
+    # and now this function would be the most performing
     f = let r = r
         x -> x * r
     end
@@ -125,7 +125,7 @@ function compute(x)
         if s ≥ r
             # `println` call is full of runtime dispatches for good reasons
             # and we're not interested in type-instabilities within this call
-            # since we know it's only called few times
+            # since we know it's only called a few times
             println("round $r/$x has been finished")
             r += 1
         end
@@ -139,11 +139,11 @@ end
 @report_opt target_modules=(@__MODULE__,) compute(30) # focus on what we wrote, and no error should be reported
 ```
 
-There is also [`function_filter`](@ref optanalysis-config), which can ignore specific function call.
+There is also [`function_filter`](@ref optanalysis-config), which can ignore specific function calls.
 
-[`@test_opt`](@ref) can be used to assert that a given function call is free from the performance pitfalls.
+[`@test_opt`](@ref) can be used to assert that a given function call is free from performance pitfalls.
 It is fully integrated with [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s unit-testing infrastructure,
-and we can use it as like other `Test` macros e.g. `@test`:
+and we can use it like other `Test` macros e.g. `@test`:
 ```@repl quickstart
 @test_opt sumup(cos)
 
@@ -188,7 +188,7 @@ JET.test_opt
 By default, JET doesn't offer top-level entry points for the optimization analysis, because it's usually used for only a
 selective portion of your program.
 But if you want you can just use [`report_file`](@ref) or similar top-level entry points with specifying
-`analyzer = OptAnalyzer` configuration in order to apply the optimization analysis on top-level script,
+`analyzer = OptAnalyzer` configuration in order to apply the optimization analysis on a top-level script,
 e.g. `report_file("path/to/file.jl"; analyzer = OptAnalyzer)`.
 
 


### PR DESCRIPTION
As part of the JuliaCon hackathon, I have fixed a few typos that I've noticed and ran the docs through Grammarly. In case of ambiguity, I have googled for the more popular spelling.

No active code has been changed.

I'm happy to withdraw this PR if it's not helpful.
