### PR TITLE
fix RecursiveIncludeErrorReport non recursive

### DIFF
--- a/test/fixtures/includetwice.jl
+++ b/test/fixtures/includetwice.jl
@@ -1,0 +1,6 @@
+module A
+    include("include2.jl")
+end
+module B
+    include("include2.jl")
+end

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -538,6 +538,16 @@ end
     end
 
     let
+        f1 = normpath(FIXTURE_DIR, "includetwice.jl")
+        f2 = normpath(FIXTURE_DIR, "include2.jl")
+        res = report_file2(f1)
+
+        @test f1 in res.res.included_files
+        @test f2 in res.res.included_files
+        @test isempty(res.res.toplevel_error_reports)
+    end
+
+    let
         modf = normpath(FIXTURE_DIR, "modinclude.jl")
         inc2 = normpath(FIXTURE_DIR, "include2.jl")
 


### PR DESCRIPTION
Do not raise RecursiveIncludeErrorReport when a file is included twice but not recursively.
This issue didn't allow analyzing Metatheory.jl project because it loaded a [file with macros](https://github.com/JuliaSymbolics/Metatheory.jl/blob/master/src/docstrings.jl) from 2 different modules.

This is the fixture file I added to reproduce the issue
```
module A
    include("include2.jl")
end
module B
    include("include2.jl")
end
```