### PR TITLE
perf tweak, disable optimization for `JETAnalyzer` analysis

### DIFF
--- a/src/abstractinterpret/inferenceerrorreport.jl
+++ b/src/abstractinterpret/inferenceerrorreport.jl
@@ -372,6 +372,7 @@ function handle_sig!(sig::Vector{Any}, s::StateAtPC, rn::ReturnNode)
     end
     return sig
 end
+is_unreachable(@nospecialize(x)) = isa(x, ReturnNode) && !isdefined(x, :val)
 
 function handle_sig!(sig::Vector{Any}, ::StateAtPC, qn::QuoteNode)
     v = qn.value


### PR DESCRIPTION
This significantly improves the analysis performance, but it turns out
that the reachability analysis to find `LocalUndefVarErrorReport`
reasonably is a bit hard to be done on abstract interpretation level.
But I'd like to disable it for now, while taking the performance advantage.