### PR TITLE
`JETAnalyzer`: be more optimistic for type-declared global variables

### DIFF
--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -801,6 +801,9 @@ function report_undef_var!(analyzer::JETAnalyzer, sv::InferenceState, mod::Modul
             report |= true
         else
             if is_corecompiler_undefglobal(mod, name)
+            elseif VERSION ≥ v"1.8.0-DEV.1465" && ccall(:jl_binding_type, Any, (Any, Any), mod, name) !== nothing
+                # if this global var is explicitly type-declared, it will be likely get assigned somewhere
+                # TODO give this permission only to top-level analysis
             else
                 report |= true
             end


### PR DESCRIPTION
E.g.:
```julia
julia> @analyze_toplevel analyze_from_definitions=true begin
           global var::String
           function __init__()
               global var
               var = "init"
           end
           getvar() = (global var; var)
       end
No errors detected
```

The sound mode still remains to be sound.
Ideally this should be enabled only for top-level analysis with the `analyze_from_definitions=true` option enabled, but it is left for another day.