### PR TITLE
Add oldest supported Julia released to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:
         version:
+          - '1.8.0' # lowest version supported
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:
         version:
-          - '1.8.0' # lowest version supported
+          - '1.8.1' # lowest version supported
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ JuliaInterpreter = "0.9"
 LoweredCodeUtils = "2.2"
 MacroTools = "0.5.6"
 Revise = "3.3"
-julia = "1.8"
+julia = "1.8.1"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
Currently, JET.jl's CI does not test against the lowest supported version of Julia. This is problematic, because JET reaches deep into Julia internals, and so new Julia version are expected to break JET often.

For example, for users of Julia v 1.7, Pkg currently installs a version of Julia (0.6.2) which does not support Julia 1.7, meaning that JET breaks when they try to use it.

To prevent future releases of JET which specify compatibility with old versions of Julia it's not really compatible with, I propose adding the oldest compatible version of Julia to CI. If JET then no longer supports this version, it will be caught in CI, and the supported version of Julia in `Project.toml` can be updated.

Prevents issues like #386, #263 