### PR TITLE
Update README and add tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,200 +5,95 @@
 ![CI](https://github.com/aviatesk/JET.jl/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/aviatesk/JET.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/aviatesk/JET.jl)
 
-JET.jl employs Julia's type inference system to detect potential bugs.
+JET employs Julia's type inference system to detect potential bugs and type instabilities.
 
-!!! note
-    The latest version of JET requires Julia versions **1.8** and higher;
-    JET is tested against [the current stable release](https://julialang.org/downloads/#current_stable_release) as well as [nightly version](https://julialang.org/downloads/nightlies/). \
-    Also note that JET deeply relies on the type inference routine implemented in [the Julia compiler](https://github.com/JuliaLang/julia/tree/master/base/compiler),
-    and so the analysis result can vary depending on your Julia version.
+:bangbang:
+    JET is tightly coupled to the Julia compiler, and so each JET release supports a limited range of Julia versions. See the `Project.toml` file for the range of supported Julia versions. The Julia package manager should install a version of JET compatible with the Julia version you are running.
+    If you want to use JET on unreleased version of Julia where compatibility with JET is yet unknown, clone this git repository and `dev` it, such that Julia compatibility is ignored.
+
+:bangbang:
+    Also note that the tight coupling of JET and the Julia compiler means that JET results can vary depending on your Julia version.
     In general, the newer your Julia version is, the more accurately and quickly you can expect JET to analyze your code,
     assuming the Julia compiler keeps evolving all the time from now on.
 
-!!! tip
-    Hold on tight and fasten your seatbelt while JET is analyzing your code for the first time.
-    Once the caches get accumulated, subsequent analysis will run at ✈ speed.
+## Quickstart
+See more commands, options and explanations in the documentation.
 
-
-## Demo
-
-Say you have this strange and buggy file and want to know where to fix:
-
-> demo.jl
+### Detect type instability with `@report_opt`
+Type instabilities can be detected in function calls using the `@report_opt` macro, which works similar to the `@code_warntype` macro. Note that, because JET relies on Julia's type inference, it cannot "see" what happens on the other side of a type instability.
 
 ```julia
-# JET.jl demonstration
-# ====================
-
-# JET can find simple errors:
-
-fib(n) = n ≤ 2 ? n : fib(n-1) + fib(n-2)
-
-fib(1000)   # => never terminates
-fib(m)      # => ERROR: UndefVarError: `m` not defined
-fib("1000") # => ERROR: MethodError: no method matching isless(::String, ::Int64)
-
-# JET supports all Julia language features:
-
-# it supports user-defined types and functions
-struct Ty{T}
-    fld::T
-end
-function foo(a)
-    v = Ty(a)
-    return bar(v)
-end
-
-# it can analyze code with macros
-@inline bar(n::T)     where {T<:Number} = n < 0 ? zero(T) : one(T)
-@inline bar(v::Ty{T}) where {T<:Number} = bar(v.fdl) # typo "fdl"
-@inline bar(v::Ty)                      = bar(convert(Number, v.fld))
-
-foo(1.2) # => ERROR: type Ty has no field fdl
-foo("1") # => ERROR: MethodError: Cannot `convert` an object of type String to an object of type Number
-
-# even staged code can be analyzed
-# (adapted from https://github.com/JuliaLang/julia/blob/9f665c19e076ab37cbca2d0cc99283b82e99c26f/base/namedtuple.jl#L253-L264)
-@generated function badmerge(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
-    names = Base.merge_names(an, bn)
-    types = Base.merge_types(names, a, b)
-    vals = Any[ :(getfield($(Base.sym_in(names[n], bn) ? :b : :a), $(names[n]))) for n in 1:length(names) ] # missing quote, just ends up with under vars
-    :( NamedTuple{$names,$types}(($(vals...),)) )
-end
-
-badmerge((x=1,y=2), (y=3,z=1)) # => ERROR: UndefVarError: `x` not defined
+julia> @report_opt foldl(+, Any[]; init=0)
+═════ 1 possible error found ═════
+┌ @ reduce.jl:193 Base.:(var"#foldl#260")(kw..., _3, op, itr)
+│┌ @ reduce.jl:193 Core.kwfunc(mapfoldl)(merge(Base.NamedTuple(), kw), mapfoldl, identity, op, itr)
+││┌ @ reduce.jl:170 Base.:(var"#mapfoldl#259")(init, _3, f, op, itr)
+│││┌ @ reduce.jl:170 Base.mapfoldl_impl(f, op, init, itr)
+││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
+│││││┌ @ reduce.jl:48 v = Base._foldl_impl(op, nt, itr)
+││││││┌ @ reduce.jl:62 op(%22, %42)
+│││││││ runtime dispatch detected: op::Base.BottomRF{typeof(+)}(%22::Any, %42::Any)::Any
+│││││││└────────────────
 ```
 
-You can have JET.jl detect possible errors:
+### Detect type errors with `@report_call`
+This works best on type stable code, so use `@report_opt` liberally before using `@report_call`.
+```julia
+julia> @report_call foldl(+, Char[])
+═════ 2 possible errors found ═════
+┌ @ reduce.jl:193 Base.:(var"#foldl#260")(pairs(NamedTuple()), #self#, op, itr)
+│┌ @ reduce.jl:193 mapfoldl(identity, op, itr)
+││┌ @ reduce.jl:170 Base.:(var"#mapfoldl#259")(Base._InitialValue(), #self#, f, op, itr)
+│││┌ @ reduce.jl:170 Base.mapfoldl_impl(f, op, init, itr)
+││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
+│││││┌ @ reduce.jl:48 v = Base._foldl_impl(op, nt, itr)
+││││││┌ @ reduce.jl:62 v = op(v, y[1])
+│││││││┌ @ reduce.jl:81 op.rf(acc, x)
+││││││││ no matching method found `+(::Char, ::Char)`: (op::Base.BottomRF{typeof(+)}).rf::typeof(+)(acc::Char, x::Char)
+│││││││└────────────────
+│││││┌ @ reduce.jl:49 Base.reduce_empty_iter(op, itr)
+││││││┌ @ reduce.jl:378 Base.reduce_empty_iter(op, itr, Base.IteratorEltype(itr))
+│││││││┌ @ reduce.jl:379 Base.reduce_empty(op, eltype(itr))
+││││││││┌ @ reduce.jl:355 Base.reduce_empty(op.rf, T)
+│││││││││┌ @ reduce.jl:338 zero(T)
+││││││││││ no matching method found `zero(::Type{Char})`: zero(T::Type{Char})
+│││││││││└─────────────────
+```
+
+### Analyze packages with `report_package`
+This looks for all method definitions and analyses function calls based on their signatures. Note that this is less accurate than `@report_call`, because the actual input types cannot be known for generic methods.
 
 ```julia
-julia> using JET
+julia> using AbstractTrees
 
-julia> report_and_watch_file("demo.jl"; annotate_types=true)
-[toplevel-info] virtualized the context of Main (took 0.184 sec)
-[toplevel-info] entered into demo.jl
-[toplevel-info]  exited from demo.jl (took 7.523 sec)
-┌ @ demo.jl:9 fib(m)
-│ `m` is not defined
-└─────────────
-┌ @ demo.jl:10 fib("1000")
-│┌ @ demo.jl:6 n::String :≤ 2
-││┌ @ operators.jl:392 x::String < y::Int64
-│││┌ @ operators.jl:343 isless(x::String, y::Int64)
-││││ no matching method found `isless(::String, ::Int64)`: isless(x::String, y::Int64)
-│││└────────────────────
-┌ @ demo.jl:28 foo(1.2)
-│┌ @ demo.jl:20 bar(v)
-││┌ @ demo.jl:25 (v::Ty{Float64}).fdl
-│││┌ @ Base.jl:37 Base.getfield(x::Ty{Float64}, f::Symbol)
-││││ type Ty{Float64} has no field fdl
-│││└──────────────
-┌ @ demo.jl:29 foo("1")
-│┌ @ demo.jl:20 bar(v)
-││┌ @ demo.jl:26 convert(Number, (v::Ty{String}).fld::String)
-│││ no matching method found `convert(::Type{Number}, ::String)`: convert(Number, (v::Ty{String}).fld::String)
-││└──────────────
-┌ @ demo.jl:40 badmerge(NamedTuple{(:x, :y)}(tuple(1, 2)::Tuple{Int64, Int64})::NamedTuple{(:x, :y), Tuple{Int64, Int64}}, NamedTuple{(:y, :z)}(tuple(3, 1)::Tuple{Int64, Int64})::NamedTuple{(:y, :z), Tuple{Int64, Int64}})
-│┌ @ demo.jl:33 getfield(a::NamedTuple{(:x, :y), Tuple{Int64, Int64}}, x)
-││ `x` is not defined
-│└──────────────
-│┌ @ demo.jl:33 getfield(b::NamedTuple{(:y, :z), Tuple{Int64, Int64}}, y)
-││ `y` is not defined
-│└──────────────
-│┌ @ demo.jl:33 getfield(b::NamedTuple{(:y, :z), Tuple{Int64, Int64}}, z)
-││ `z` is not defined
-│└──────────────
+julia> report_package(AbstractTrees)
+ [ some output elided ]
+═════ 4 possible errors found ═════
+┌ @ /home/jakni/.julia/packages/AbstractTrees/x9S7q/src/base.jl:260 AbstractTrees.collect(Core.apply_type(StableNode, T), ch)
+│┌ @ array.jl:647 Base._collect(T, itr, Base.IteratorSize(itr))
+││┌ @ array.jl:649 Base._array_for(T, isz, Base._similar_shape(itr, isz))
+│││┌ @ array.jl:679 Base._similar_shape(itr, isz)
+││││┌ @ array.jl:664 axes(itr)
+│││││┌ @ abstractarray.jl:95 size(A)
+││││││ no matching method found `size(::Base.HasLength)`: size(A::Base.HasLength)
+│││││└───────────────────────
+││││┌ @ array.jl:663 length(itr)
+│││││ no matching method found `length(::Base.HasLength)`: length(itr::Base.HasLength)
+││││└────────────────
+┌ @ /home/jakni/.julia/packages/AbstractTrees/x9S7q/src/indexing.jl:137 AbstractTrees.idx.tree
+│ `AbstractTrees.idx` is not defined
+└───────────────────────────────────────────────────────────────────────
+┌ @ /home/jakni/.julia/packages/AbstractTrees/x9S7q/src/indexing.jl:137 AbstractTrees.idx.index
+│ `AbstractTrees.idx` is not defined
+└───────────────────────────────────────────────────────────────────────
 ```
-
-Hooray!
-JET.jl found possible error points (e.g. `MethodError: no method matching isless(::String, ::Int64)`) given top-level call signatures of generic functions (e.g. `fib("1000")`).
-
-Note that JET can find these errors while demo.jl is so inefficient (especially the `fib` implementation) that it would never terminate in actual execution.
-That is possible because JET analyzes code only on _type level_.
-This technique is often called "abstract interpretation" and JET internally uses Julia's native type inference implementation, so it can analyze code as fast/correctly as Julia's code generation.
-
-Lastly, let's apply the following diff to demo.jl so that it works nicely:
-
-> fix-demo.jl.diff
-
-```diff
-diff --git a/demo.jl b/demo.jl
-index f868d2f..634e130 100644
---- a/demo.jl
-+++ b/demo.jl
-@@ -4,11 +4,21 @@
- # fibonacci
- # ---------
-
--fib(n) = n ≤ 2 ? n : fib(n-1) + fib(n-2)
-+# cache, cache, cache
-+function fib(n::T) where {T<:Number}
-+    cache = Dict(zero(T)=>zero(T), one(T)=>one(T))
-+    return _fib(n, cache)
-+end
-+_fib(n, cache) = if haskey(cache, n)
-+    cache[n]
-+else
-+    cache[n] = _fib(n-1, cache) + _fib(n-2, cache)
-+end
-
--fib(1000)   # never terminates in ordinal execution
--fib(m)      # undef var
--fib("1000") # obvious type error
-+fib(BigInt(1000)) # will terminate in ordinal execution as well
-+m = 1000          # define m
-+fib(m)
-+fib(parse(Int, "1000"))
-
-
- # language features
-@@ -26,19 +36,19 @@ end
-
- # macros will be expanded
- @inline bar(n::T)     where {T<:Number} = n < 0 ? zero(T) : one(T)
--@inline bar(v::Ty{T}) where {T<:Number} = bar(v.fdl) # typo "fdl"
-+@inline bar(v::Ty{T}) where {T<:Number} = bar(v.fld) # typo fixed
- @inline bar(v::Ty)                      = bar(convert(Number, v.fld))
-
- foo(1.2)
--foo("1") # `String` can't be converted to `Number`
-+foo('1') # `Char` will be converted to `UInt32`
-
- # even staged programming
- # adapted from https://github.com/JuliaLang/julia/blob/9f665c19e076ab37cbca2d0cc99283b82e99c26f/base/namedtuple.jl#L253-L264
--@generated function badmerge(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
-+@generated function goodmerge(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
-     names = Base.merge_names(an, bn)
-     types = Base.merge_types(names, a, b)
--    vals = Any[ :(getfield($(Base.sym_in(names[n], bn) ? :b : :a), $(names[n]))) for n in 1:length(names) ] # missing quote, just ends up with under vars
-+    vals = Any[ :(getfield($(Base.sym_in(names[n], bn) ? :b : :a), $(QuoteNode(names[n])))) for n in 1:length(names) ] # names quoted, should work as expected
-     :( NamedTuple{$names,$types}(($(vals...),)) )
- end
-
--badmerge((x=1,y=2), (y=3,z=1))
-+goodmerge((x=1,y=2), (y=3,z=1))
-```
-
-If you apply the diff (i.e. update and save the demo.jl), JET will automatically re-trigger analysis, and this time, won't complain anything:
-
-> `git apply fix-demo.jl.diff`
-
-```julia
-[toplevel-info] virtualized the context of Main (took 0.002 sec)
-[toplevel-info] entered into demo.jl
-[toplevel-info]  exited from demo.jl (took 1.004 sec)
-No errors detected
-```
-
 
 ## Limitations
-
-JET explores the functions you call directly as well as their *inferrable* callees. However, if the argument types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors detected` does not imply that your entire codebase is free of errors.
+JET explores the functions you call directly as well as their *inferrable* callees. However, if the argument types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors detected` does not imply that your entire codebase is free of errors. To increase the confidence in JET's results use `@report_opt` to make sure your code is inferrible.
 
 JET integrates with [SnoopCompile](https://github.com/timholy/SnoopCompile.jl), and you can sometimes use SnoopCompile to collect the data to perform more comprehensive analyses. SnoopCompile's limitation is that it only collects data for calls that have not been previously inferred, so you must perform this type of analysis in a fresh session.
 
 See [SnoopCompile's JET-integration documentation](https://timholy.github.io/SnoopCompile.jl/stable/jet/) for further details.
-
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ JET employs Julia's type inference system to detect potential bugs and type inst
 See more commands, options and explanations in the documentation.
 
 ### Detect type instability with `@report_opt`
-Type instabilities can be detected in function calls using the `@report_opt` macro, which works similar to the `@code_warntype` macro. Note that, because JET relies on Julia's type inference, it cannot "see" what happens on the other side of a type instability.
+Type instabilities can be detected in function calls using the `@report_opt` macro, which works similar to the `@code_warntype` macro.
+Note that, because JET relies on Julia's type inference, if a chain of inference is broken due to dynamic dispatch, then all downstream function calls will be unknown to the compiler, and so JET cannot analyze them.
 
 ```julia
 julia> @report_opt foldl(+, Any[]; init=0)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -86,11 +86,16 @@ function generate_api_doc(examples_pages)
 end
 
 let
+    DocMeta.setdocmeta!(JET, :DocTestSetup, :(using JET); recursive=true)
     examples = generate_example_docs!()
     makedocs(; modules = [JET],
                sitename = "JET.jl",
                pages = Any[
                     "README" => generate_index!(),
+                    "Tutorial" => Any[
+                        "Tutorial" => "tutorial.md",
+                        "Error kinds and how to fix them" => "errortypes.md",
+                    ],
                     "Analyses" => Any[
                         "Error Analysis" => "jetanalysis.md",
                         "Optimization Analysis" => "optanalysis.md",

--- a/docs/src/errortypes.md
+++ b/docs/src/errortypes.md
@@ -1,0 +1,211 @@
+# Errors kinds and how to fix them
+
+## `no matching method found`
+### Description
+This error occurs when running the code might throw a `MethodError` at runtime.
+Similar to normal `MethodErrors`, this happens if a function is being called without a method matching the given argument types.
+
+This is the most common error detected in most Julia code.
+
+### Example
+```@repl
+using JET # hide
+f(x::Integer) = x + one(x);
+g(x) = f(x);
+@report_call g(1.0)
+```
+
+### How to fix
+This error indicates some kind of type error in your code. You fix it like you would fix a regular `MethodError` thrown at runtime.
+
+## no matching method found (`x`/`y` union split)
+### Description
+This error occurs when a variable `x` is inferred to be a union type, and `x` being one or more of the union's members would lead to a `MethodError`. For example, if the compiler infers `x` to be of type `Union{A, B}`, and then a function `f(x)` is called which would lead to a `MethodError` if `x` is a `A`, this error would occur.
+
+More technically, this happens when one or more branches created by the compiler through union splitting contains a `no matching method found` error.
+
+### Example
+Minimal example:
+```@repl union1
+using JET # hide
+struct Foo
+    x::Union{Int, String}
+end
+
+# Errors if x.x isa String.
+# The compiler doesn't know if it's a String or Int
+f(x) = x.x + 1;
+
+@report_call f(Foo(1))
+```
+
+More common example:
+```@repl union1
+function pos_after_tab(v::AbstractArray{UInt8})
+    # findfirst can return `nothing` on no match
+    p = findfirst(isequal(UInt8('\t')), v)
+    p + 1
+end
+
+@report_call pos_after_tab(codeunits("a\tb"))
+```
+
+### How to fix
+This error is unique in that idiomatic Julia code may still lead to this error. For example, in the `pos_after_tab` function above, if the input vector does not have a `'\t'` byte, `p` will be `nothing`, and a `MethodError` will be thrown when `nothing + 1` is attempted.
+However, in many situations, the possibility of such a `MethodError` is not a mistake, but rather an idiomatic way of erroring.
+
+There are different possiblities to address this kind of error. Let's take the `pos_after_tab` example:
+
+If you actually _could_ expect `p` to legitimately be `nothing` for valid input (i.e. the input could lack a `'\t'` byte), then your function should be written to take this edge case into account:
+```@repl union
+using JET # hide
+function pos_after_tab(v::AbstractArray{UInt8})
+    p = findfirst(isequal(UInt8('\t')), v)
+    if p === nothing # handle the nothing case
+        return nothing
+    else
+        return p + 1
+    end
+end;
+@report_call pos_after_tab(codeunits("a\tb"))
+```
+
+By adding the `if p === nothing` check, the compiler will know that the type of `p` must be `Nothing` inside the `if` block, and `Int` in the `else` block. This way, the compiler knows a `MethodError` is not possible, and the error will disappear.
+
+If you expect a `'\t'` byte to always be present, such that `findfirst` always should return an `Int` for valid input, you can add a typeassert in the function to assert that the return value of `findfirst` must be, say, an `Integer`. Then, the compiler will know that if the typeassert passes, the value returned by `findfirst` cannot be `nothing` (and hence in this case must be `Int`):
+
+```@repl union
+function pos_after_tab(v::AbstractArray{UInt8})
+    p = findfirst(isequal(UInt8('\t')), v)::Integer
+    p + 1
+end;
+@report_call pos_after_tab(codeunits("a\tb"))
+```
+
+The code will still error at runtime due to the typeassert if `findfirst` returns `nothing`, but JET will no longer detect it as an error, because the programmer, by adding the typeassert, explicitly acknowledge that the compiler's inference may not be precise enough, and helps the compiler.
+
+Note that adding a typeassert also improves code quality:
+* The programmer's intent to never observe `nothing` is communicated clearly
+* After the typeassert passes, `p` is inferred to be `Int` instead of a union, and this more precise type inference generates more efficient code.
+* More precise inference reduces the risk of invalidations from the code, improving latency.
+
+A special case occurs when loading `Union`-typed fields from structs.
+Julia does not realize that loading the same field multiple times from a mutable struct necessarily returns the same object. Hence, in the following example:
+
+```@repl union2
+using JET # hide
+mutable struct Foo
+    x::Union{Int, Nothing}
+end
+
+function f(x)
+    if x.x === nothing
+        nothing
+    else
+        x.x + 1
+    end
+end;
+
+@report_call f(Foo(1))
+```
+
+We might reasonably expect the compiler to know that in the `else` branch, `x.x` must be an `Int`, since it just checked that it is not `nothing`. However, the compiler does not know that the value obtained from loading the `x` field in the expression `x.x` on the like with the if statement in this case is the same value as the value obtained when loading the `x` field in the `x.x + 1` statement.
+You can solve this issue by assigning `x.x` to a variable:
+
+```@repl union2
+function f(x)
+    y = x.x
+    if y === nothing
+        nothing
+    else
+        y + 1
+    end
+end;
+
+@report_call f(Foo(1))
+```
+
+## `X` is not defined
+### Description
+This happens when a name `X` is used in a function, but no object named `X` can be found.
+
+### Example
+```@repl defined
+using JET # hide
+f(x) = foo(x) + 1;
+
+@report_call f(1)
+```
+
+### How to fix
+This error can have a couple of causes:
+* `X` is misspelled. If so, correct the typo
+* `X` exists, but cannot be reached from the scope of the function.
+  If so, pass it in as an argument to the offending function.
+
+## type `T` has no field `F`
+### Description
+This error occurs when `Core.getfield` is (indirectly) called with a nonexisting and hardcoded field name. For example, if an object have a field called `vec` and you type it `vector`.
+### Example
+```@repl field
+using JET # hide
+struct Foo
+    my_field
+end
+f(x) = x.my_feild; # NB: Typo!
+@report_call f(Foo(1))
+```
+
+### How to fix
+This error often occurs when the field name is mistyped. Correct the typo.
+
+## BoundsError: Attempt to access `T` at index `[i]`
+### Description
+This error occurs when it is known at compile time that the call will throw a `BoundsError`.
+Note that most `BoundsErrors` cannot be predicted at compile time. For the compiler to know a function attempts to access a container out of bounds, both the container length and the index value must be known at compiletime. Hence, the error is detected for a `Tuple` input in the example below, but not for a `Vector` input.
+
+### Example
+```@repl
+using JET # hide
+get_fourth(x) = x[4]
+@report_call get_fourth((1,2,3))
+@report_call get_fourth([1,2,3]) # NB: False negative!
+```
+
+### How to fix
+If this error appears, the offending code uses a bad index. Since the error most often occurs when the index is hardcoded, simply fix the index value.
+
+## may throw
+### Description
+This error indicates that JET detected the possibility of an exception.
+By default, JET will not report this error, unless a function is inferred to _always_ throw, AND the exception is not caught in a try statement. In "sound" mode, this error is reported if the function _may_ throw.
+
+### Example
+In this example, the function is known at compile time to throw an uncaught exception, and so is reported by default:
+```@repl
+using JET # hide
+f(x) = x isa Integer ? throw("Integer") : nothing;
+@report_call f(1)
+```
+
+In this example, it's not known at compile time whether it throws, and therefore, JET reports no errors by default. In sound mode, the error is reported.
+```@repl
+using JET # hide
+f(x) = x == 9873984732 ? nothing : throw("Bad value")
+@report_call f(1)
+@report_call mode=:sound f(1)
+```
+
+In this example, the exception is handled, so JET reports no errors by default. In sound mode, the error is reported:
+```@repl
+using JET # hide
+g() = throw();
+f() = try
+    g()
+catch
+    nothing
+end;
+f()
+@report_call f()
+@report_call mode=:sound f()
+```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,0 +1,211 @@
+```@meta
+DocTestSetup = quote
+    using JET
+end
+```
+
+# JET tutorial
+JET leverages the Julia compiler's inference to check user code for type instability and type errors.
+This tutorial will demonstrate how to use JET effectively.
+It presupposes the reader has working knowledge of Julia, and understands Julian concepts such as "dynamic dispatch" and "type stability" - see the [Julia documentation](https://docs.julialang.org/en/v1/) for explanation of these concepts.
+
+Because JET relies on the compiler's type inference, it is not able to effectively analyze type unstable code.
+Making your code type stable is a prerequisite for effectively using JET's type error analysis.
+Therefore, we will begin by showing how to use JET to fix type instabilities.
+
+## Detecting type instability with `@report_opt`
+JET exports a function [`report_opt`](@ref) and the related macro [`@report_opt`](@ref).
+It works similar to the function/macro pair `(@)code_warntype` from Base - except that it automatically analyses all the way down the function chain, and that it only displays any issues found.
+
+For example, suppose we have the function:
+```@repl opt1
+add_one_first(x) = first(x) + 1;
+```
+
+Any type instabilities of a given function call can be analysed thus:
+```@repl opt1
+using JET # hide
+@report_opt add_one_first([1])
+@report_opt add_one_first(Any[1])
+```
+
+You can see that `add_one_first` is type stable when called with a `Vector{Int}`, but it leads to dynamic dispatch when called with `Vector{Any}`.
+
+Suppose now we have _two levels_ of type instability, where one type instability "hides behind" another type instability, as in this example:
+```@repl opt1
+add_one_first(x) = first(x) + 1;
+func_var = add_one_first;
+f(x) = func_var(x);
+@report_opt f(Any[1])
+```
+The dynamic dispatch we see here come from the fact that `func_var` is an untyped global variable.
+Remember that `add_one_first` was also type unstable when called with a `Vector{Any}`. So why doesn't `@report_opt` report that second type instability from calling `add_one_first(::Vector{Any})`?
+The reason is that because the Julia compiler does not know at compile time that `func_var` is equal to `add_one_first`, JET cannot "see through" the first type instability and see that `add_one_first(Any[1])` will eventually be called.
+
+If we fix the first instability by defining the global variable `my_func_var` as `const`:
+```@repl opt1
+const my_func_var = add_one_first;
+```
+
+Then the compiler knows that `add_one_first` will be called, and the second type instability from this function is revealed:
+```@repl opt1
+f(x) = my_func_var(x)
+@report_opt f(Any[1])
+```
+
+Sometimes, type instability only shows up much deeper into a call chain, several functions deep.
+This is not a problem for JET.
+In the example below, JET sees type instability ~10 function calls deep:
+```@repl opt1
+@report_opt sum(Any[1])
+```
+
+As mentioned above, effective use of JET begins with liberal use of `@report_opt` to eliminate or reduce any dynamic dispatch, such that the Julia compiler is not blinded by dynamic dispatch.
+
+After the program has been made as type stable as possible, it's time to use `@report_call` to find type errors.
+
+## Analyse methods with `@report_call`
+The function/macro pair [`report_call`](@ref) and [`@report_call`](@ref) works just like `(@)report_opt` - but where the latter reports dynamic dispatch, the former finds type errors.
+
+The `@report_call` macro analyses function calls like so:
+```@repl opt1
+@report_call sum(['a'])
+```
+
+In this example, JET found two possible type errors:
+* If the input vector is empty, the function call will error with a `MethodError` after attempting to call `zero(Char)`.
+* If the input vector has two or more elements, the call will error after attempting to call `+(::Char, ::Char)`.
+Note that these type errors show up even though the input vector had exactly one element, and so neither of these errors would actually occur at runtime if `sum(['a'])` had been executed.
+This happens because JET analyses the code on a _type_ level, only looking at the code generated with the input _types_. It does not analyze what will actually happen with the given input value.
+
+Note also that the two possible errors shown are mutally exclusive - no input will lead to both errors.
+Nonetheless, JET is able to detect both possibilities, because it analyses all possible branches in the generated function call.
+
+In contrast, if we analyse the same `sum` method on a `Vector{Int}` instead of `Vector{Char}`:
+```@repl opt1
+@report_call sum([1])
+```
+
+The two errors above do not appear. These errors do not apply to `Vector{Int}`, because `zero(Int)` is well-defined and so is `+(::Int, ::Int)`.
+This illustrates that JET does not analyze _methods_, but rather _function calls with specific types_. More precisely, JET analyses so-called _methodinstances_, since methodinstances are compiled whereas methods are not.
+
+## Analyse whole packages with `report_package`
+As shown above, _methods_ cannot be analyzed, but only _methodinstances_, i.e. methods plus the types of their arguments.
+Most packages, however, define only methods, and do not contain callsites. That is, they do not have any information about the types that these methods will be called with.
+
+However, JET is able to do limited analysis using only the method signature extracted from the method definition.
+For example, if I define this simple function:
+
+```@repl
+first_plus_n(itr, n::Real) = first(itr) + n;
+```
+
+, then _at the very least_, we can guarantee that `itr isa Any` and `n isa Real`.
+Hence, JET can analyze the methodinstance `first_plus_n(::Any, ::Real)`, using only the method definition.
+
+The JET function [`report_package`](@ref) extracts all method definitions in a package, and using the extracted signatures, runs `report_call` on them.
+For example, the package `BioSymbols` can be analysed like this:
+
+```
+julia> using JET
+
+julia> report_package(JET)
+[ output elided ]
+```
+
+Note that `report_package` is less precise than `@report_call`, because method signatures of idiomatic Julia code are often very generic, so there is less type information in the signature itself than there is when given concrete argument types.
+
+## Usage tips
+#### Use `@report_opt` before `@report_call`
+JET works best on type-stable code.
+Iron out type instabilities using `@report_opt` before using `@report_call` 
+
+#### Filtering away false postives
+It is common to find that JET finds lots of errors in your functions, which all derive from type instability and type issues in your dependencies.
+In fact, type issues from dependencies are often so plentiful they flood your analysis with false positives, which can make working with JET harder.
+
+To reduce false positives, you can use the keywords `ignored_modules` and `target_modules`.Both take an iterable of modules.
+
+The former removes any errors that originate from any of the given modules, while the latter removes any errors _except_ ones originating from these modules.
+
+For example, in the REPL (which is in module `Main`), we can define:
+```@repl call1
+f(x) = first(x) + 1
+```
+
+This throws in a `Base` function if we pass `nothing` into it:
+```@repl call1
+using JET # hide
+@report_call f(nothing)
+```
+
+Since the error originates from `Base`, we can filter the error away by ignoring `Base`, or equivalently, we may retain only the ones from `Main`. Note that we pass `(Base,)` as a 1-element Tuple of modules:
+```@repl call1
+@report_call ignored_modules=(Base,) f(nothing)
+@report_call target_modules=(@__MODULE__,) f(nothing)
+```
+
+The `AnyFrameModule` construct can be used to filter for (or against) any error where _any_ of the function calls in the callchain originates from the given module.
+For example, in the example above, the function call begins in `Main` and ends in `Base`, so the callchain includes both modules.
+Ignoring `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)` will then ignore the error:
+
+```@repl call1
+@report_call ignored_modules=(AnyFrameModule(Base),) f(nothing)
+@report_call ignored_modules=(AnyFrameModule(@__MODULE__),) f(nothing)
+```
+
+Similarly, the error would be retained if `target_modules` would have been `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)`.
+
+Beware that this filtering may filter away legitimate problems in your package. In the example above, if your code calls `f(nothing)`, the error may originate from Base, but it's clearly an error in your own code to call `f(nothing)`.
+So it is recommended to only filter away modules if they produce so many false positives that it makes using JET difficult.
+
+#### Analyze scripts and apps by using a `main` function
+Scripts and apps called from the command line have a single logical entry point. If you wrap the logic in a `main` function, JET can analyse the entire script.
+
+For example, suppose you made this command-line script which added two numbers from the command line:
+
+```julia
+a = parse(Int, first(ARGS))
+b = parse(Int, last(ARGS))
+println(a + b)
+```
+
+You could rewrite this as:
+```julia
+function main()
+    a = parse(Int, first(ARGS))
+    b = parse(Int, last(ARGS))
+    println(a + b)
+end
+
+main()
+```
+
+, and then analyse the script with JET using `@report_call main()`.
+Using a `main` function has the further advantage that it makes it for other people to understand what your script does when invoked.
+
+Alternatively, JET also provides the function [`report_file`](@ref), which you can call like:
+```julia
+julia> report_file("my_script.jl")
+```
+
+, which will be equivalent to checking `@report_call main()`, if the script contains a `main()` call at top level.
+
+#### Analyze packages using a representative workload
+As shown above, packages can be analysed with `report_package`.
+However, generic type signatures often used in packages lead to imprecise inference and thus imprecise analysis.
+
+To improve analysis, you can create a file `src/workload.jl` in your package, which uses all (or most) functionality of the pacakge.
+The function could look like:
+
+```julia
+function exercise_mypkg()
+    data = MyPkg.load_data()
+    transformed = MyPkg.transform_data(data)
+    # [ etc ...]
+end
+```
+
+Because such usage necessarily requires passing concrete types to your functions, calling `@report_call exercise_mypkg()` leads to more precise analysis than `report_package`.
+
+Furthermore, once you have written a function like `exercise_mypkg`, you can use a package like `SnoopPrecompile` to precompile the function, which will thus precompile all code exercised in the function, significantly reducing your package's latency.


### PR DESCRIPTION
This improves the docs in three areas:
* The README.md is changed to emphasize the `@report_[call|opt]` macros and `report_package`
* A tutorial is added which walks trough the various ways of using JET
* A page is added with the different kinds of errors reported by JET and what to do about them (I added this page on recommendation from a user)

This PR is done now, unless there are more comments.