### PR TITLE
`report_call` with a supremum matching method

### DIFF
--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -365,11 +365,11 @@ function analyze_additional_pass_by_type!(analyzer::AbstractAnalyzer, @nospecial
     # but what we're doing here is essentially equivalent to modifying the user code and inlining
     # the threaded code block as a usual code block, and thus the side-effects won't (hopefully)
     # confuse the abstract interpretation, which is supposed to terminate on any kind of code
-    mm = get_single_method_match(tt, InferenceParams(newanalyzer).MAX_METHODS, get_world_counter(newanalyzer))
+    match = find_single_match(tt, newanalyzer)
     @static if @isdefined(StmtInfo)
-        abstract_call_method(newanalyzer, mm.method, mm.spec_types, mm.sparams, #=hardlimit=#false, #=si=#StmtInfo(false), sv)
+        abstract_call_method(newanalyzer, match.method, match.spec_types, match.sparams, #=hardlimit=#false, #=si=#StmtInfo(false), sv)
     else
-        abstract_call_method(newanalyzer, mm.method, mm.spec_types, mm.sparams, #=hardlimit=#false, sv)
+        abstract_call_method(newanalyzer, match.method, match.spec_types, match.sparams, #=hardlimit=#false, sv)
     end
 
     return nothing

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -34,7 +34,7 @@ struct JETAnalyzer{RP<:ReportPass} <: AbstractAnalyzer
     report_pass::RP
     state::AnalyzerState
     __cache_key::UInt
-    method_table::CachedMethodTable
+    method_table::CachedMethodTable{OverlayMethodTable}
 end
 
 CC.may_optimize(::JETAnalyzer) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,24 +65,25 @@ include("setup.jl")
         JETAnalyzerT   = typeof(JET.JETAnalyzer())
         OptAnalyzerT   = typeof(JET.OptAnalyzer())
         InferenceState = Core.Compiler.InferenceState
+        annotate_types = true
 
         # error analysis
         # ==============
 
         # JETAnalyzer
         test_call(JET.analyze_frame!, (JETAnalyzerT, InferenceState);
-                  target_modules)
+                  target_modules, annotate_types)
         # OptAnalyzer
         test_call(JET.analyze_frame!, (OptAnalyzerT, InferenceState);
-                  target_modules)
+                  target_modules, annotate_types)
         # top-level
         test_call(JET.virtual_process, (String, String, JETAnalyzerT, JET.ToplevelConfig);
-                  target_modules)
+                  target_modules, annotate_types)
         # entries
         test_call(JET.report_file, (String,);
-                  target_modules)
+                  target_modules, annotate_types)
         test_call(JET.report_package, (Union{String,Module,Nothing},);
-                  target_modules)
+                  target_modules, annotate_types)
 
         # optimization analysis
         # =====================
@@ -100,6 +101,7 @@ include("setup.jl")
                ft === typeof(zero) ||
                ft === typeof(JET.copy_report) ||
                ft === typeof(JET.handle_sig!) ||
+               ft === typeof(JET._which) ||
                (@static VERSION < v"1.9.0-DEV.283" && ft === typeof(JET.rewrap_unionall)) || # requires https://github.com/JuliaLang/julia/pull/44512
                false
                 return false
@@ -109,10 +111,10 @@ include("setup.jl")
         # JETAnalyzer
         test_opt(JET.analyze_frame!, (JETAnalyzerT, InferenceState);
                  target_modules,
-                 function_filter)
+                 function_filter, annotate_types)
         # OptAnalyzer
         test_opt(JET.analyze_frame!, (OptAnalyzerT, InferenceState);
                  target_modules,
-                 function_filter)
+                 function_filter, annotate_types)
     end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,6 +1,9 @@
 @testset "report_call entry" begin
     @test_throws ErrorException("unable to find single target method for `sin(::String)`") report_call(sin, (String,))
     @test_throws ErrorException("unable to find single target method for `sin(::String)`") @report_call sin("julia")
+
+    # https://github.com/aviatesk/JET.jl/issues/427
+    test_call(getproperty, (Any,Symbol))
 end
 
 @testset "`get_package_file`" begin


### PR DESCRIPTION
fixes #427

`report_call`'s interface is designed to align with `code_typed` and the family, but it expects a single matching method. That part is more like `Base.which`. In this sense I guess we want to find a supremum matching method as an entry signature, rather than complaining a given signature is abstract or something.