### PR TITLE
limit `max_methods=1` for `analyze_from_definitions` analysis

### DIFF
--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -428,10 +428,13 @@ function analyze_from_definitions!(analyzer::AbstractAnalyzer, res::VirtualProce
                 (i == n ? println : print)(io, "analyzing from top-level definitions ... $succeeded/$n")
             end
             analyzer = AbstractAnalyzer(analyzer, _CONCRETIZED, _TOPLEVELMOD)
+            state = AnalyzerState(analyzer)
+            inf_params = state.inf_params
+            # TODO state.inf_params = JETInferenceParams(inf_params; max_methods=1)
+            state.inf_params = JETInferenceParams(; max_methods=1)
             analyzer, result = analyze_method_signature!(analyzer,
-                match.method, match.spec_types, match.sparams;
-                # JETAnalyzer{BasicPass}: don't report errors unless this frame is concrete
-                set_entry = false)
+                match.method, match.spec_types, match.sparams)
+            state.inf_params = inf_params
             append!(res.inference_error_reports, get_reports(analyzer, result))
             continue
         end

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1606,7 +1606,7 @@ end
             end
         end
         reports = res.res.inference_error_reports
-        @test_broken length(reports) == 2
+        @test length(reports) == 2
         @test all(r->isa(r,MethodErrorReport), reports)
     end
 end


### PR DESCRIPTION
We want to analyze methods whose signature isn't concrete in order to get reasonable analysis result for this kind of case:
```julia
function f1(func, x::String)
    return 1 + x
end

function f2(x::String)
    return 1 + x
end
```

but at the same time we would like to avoid to get a false positive `NonBooleanCondErrorReport` for this sort of case:
```julia
struct Foo end

function foo_or_nothing(x)
    # (::Missing == ::Foo)::Missing will lead to `NonBooleanCondErrorReport` otherwise
    return x == Foo() ? :foo : nothing
end
```

This commit implements a hack to change `max_methods` configuration for `analyze_from_definitions` only, so that we can analyze abstract entry method while cutting off the false positive.

fix #426 