### PR TITLE
virtualprocess: add special handling for Preferences.toml

### DIFF
--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -2094,7 +2094,8 @@ end
 end
 
 using Pkg
-function test_report_package(test_func, (pkgname, code))
+function test_report_package(test_func, (pkgname, code);
+                             additional_setup=(::Pkg.API.ProjectInfo)->nothing)
     old = Pkg.project().path
     pkgcode = Base.remove_linenums!(code)
     mktempdir() do tempdir
@@ -2103,6 +2104,8 @@ function test_report_package(test_func, (pkgname, code))
             Pkg.generate(pkgpath; io=devnull)
             Pkg.activate(pkgpath; io=devnull)
             Pkg.develop(; path=normpath(FIXTURE_DIR, "PkgAnalysisDep"), io=devnull)
+
+            additional_setup(Pkg.project())
 
             Pkg.activate(; temp=true, io=devnull)
             Pkg.develop(; path=pkgpath, io=devnull)
@@ -2275,6 +2278,16 @@ end
         end) do res
         r = only(res.res.toplevel_error_reports)
         @test isa(r, DependencyError) && r.pkg == "UninstalledDependency" && r.dep == "UninstalledDep"
+    end
+
+    test_report_package("LoadPreferences" => quote
+            using Preferences
+            @load_preference("LoadPreferencesConfig", false)
+            const LoadPreferencesConfig = @load_preference("LoadPreferencesConfig", false)
+        end; additional_setup = function (::Pkg.API.ProjectInfo)
+            Pkg.add("Preferences"; io=devnull)
+        end) do res
+        @test isempty(res.res.toplevel_error_reports)
     end
 end
 

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -2282,8 +2282,15 @@ end
 
     test_report_package("LoadPreferences" => quote
             using Preferences
-            @load_preference("LoadPreferencesConfig", false)
-            const LoadPreferencesConfig = @load_preference("LoadPreferencesConfig", false)
+
+            @load_preference("LoadRootConfig", false)
+            const LoadRootConfig = @load_preference("LoadRootConfig", false)
+
+            module Submodule
+            using Preferences
+            @load_preference("LoadSubConfig", false)
+            const LoadSubConfig = @load_preference("LoadSubConfig", false)
+            end
         end; additional_setup = function (::Pkg.API.ProjectInfo)
             Pkg.add("Preferences"; io=devnull)
         end) do res


### PR DESCRIPTION
This commit implements a hack to prevent Preferences.jl from throwing errors for virtual modules. This is a very dirty solution for #497, but ideally this should be replaced with a better solution if available. Without this monkey patching, we will encounter something like:
```
│ ArgumentError: Module XXX does not correspond to a loaded package!
│ Stacktrace:
│  [1] get_uuid(m::Module)
│    @ Preferences ~/.julia/packages/Preferences/VmJXL/src/utils.jl:8
│  [2] var"@load_preference"(__source__::LineNumberNode, __module__::Module, key::Any, default::Any)
│    @ Preferences ~/.julia/packages/Preferences/VmJXL/src/Preferences.jl:45
```
We can't use the CassetteOverlay-like mechanism for a cleaner implementation, since Preferences.jl might be called within `macroexpand` or `lower` of the main `_virtual_process!` loop, where we don't have control over execution. Note that this hack does not allow Preferences.jl to read or set configurations correctly. A potential TODO is to read the configurations of virtualized package being analyzed.

---

fixes #497 