### PR TITLE
docs: describe more analysis options

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -217,13 +217,13 @@ using MyPkg, JET, MethodAnalysis
 mis = methodinstances(MyPkg)    # get all the compiled methodinstances for functions owned by the package
 # Now let's filter out the ones that pass without issue
 badmis = filter(mis) do mi
-    !isempty(JET.get_reports(report_call(mi.specTypes)))
+    !isempty(JET.get_reports(report_call(mi)))
 end
 ```
 
-Then you can inspect the methodinstances in `badmis` individually with `report_call(mi.specTypes)`.
+Then you can inspect the methodinstances in `badmis` individually with `report_call(mi)`.
 
 There are two caveats to note:
 
 - `methodinstances(MyPkg)` only covers *functions* owned by `MyPkg`. If `MyPkg` defines an "extension" method `OtherPkg.f(...)`, any corresponding methodinstances would appear in the list for `OtherPkg`.
-- if you [disable precompilation](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development) for your development version of the package, you'll get a greatly-reduced list of methodinstances that does not reflect ordinary usage. JET analysis should only be performed on packages that are actively using their precompilation workloads.
+- if you [disable precompilation](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development) for your development version of the package, you'll get a greatly-reduced list of methodinstances that does not reflect ordinary usage. This style of JET analysis should only be performed on packages that are actively using their precompilation workloads.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -208,4 +208,23 @@ end
 
 Because such usage necessarily requires passing concrete types to your functions, calling `@report_call exercise_mypkg()` leads to more precise analysis than `report_package`.
 
-Furthermore, once you have written a function like `exercise_mypkg`, you can use a package like [`SnoopPrecompile`](https://github.com/timholy/SnoopCompile.jl) to precompile the function, which will thus precompile all code exercised in the function, significantly reducing your package's latency.
+Furthermore, once you have written a function like `exercise_mypkg`, you can use a package like [`PrecompileTools`](https://github.com/JuliaLang/PrecompileTools.jl) to precompile the function, which will thus precompile all code exercised in the function, significantly reducing your package's latency.
+
+Conversely, if you've already implemented a precompile workload, you can do the following:
+
+```julia
+using MyPkg, JET, MethodAnalysis
+mis = methodinstances(MyPkg)    # get all the compiled methodinstances for functions owned by the package
+# Now let's filter out the ones that pass without issue
+hasreport(report) = report !== nothing && !isempty(JET.get_reports(report))
+badmis = filter(mis) do mi
+    hasreport(report_call(mi.specTypes))
+end
+```
+
+Then you can inspect the methodinstances in `badmis` individually with `report_call(mi.specTypes)`.
+
+There are two caveats to note:
+
+- `methodinstances(MyPkg)` only covers *functions* owned by `MyPkg`. If `MyPkg` defines an "extension" method `OtherPkg.f(...)`, any corresponding methodinstances would appear in the list for `OtherPkg`.
+- if you [disable precompilation](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development) for your development version of the package, you'll get a greatly-reduced list of methodinstances that does not reflect ordinary usage. JET analysis should only be performed on packages that are actively using their precompilation workloads.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -216,9 +216,8 @@ Conversely, if you've already implemented a precompile workload, you can do the 
 using MyPkg, JET, MethodAnalysis
 mis = methodinstances(MyPkg)    # get all the compiled methodinstances for functions owned by the package
 # Now let's filter out the ones that pass without issue
-hasreport(report) = report !== nothing && !isempty(JET.get_reports(report))
 badmis = filter(mis) do mi
-    hasreport(report_call(mi.specTypes))
+    !isempty(JET.get_reports(report_call(mi.specTypes)))
 end
 ```
 

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -762,6 +762,15 @@ function analyze_and_report_call!(analyzer::AbstractAnalyzer, @nospecialize(tt::
     source = lazy"$analyzername: $sig"
     return JETCallResult(result, analyzer, source; jetconfigs...)
 end
+function analyze_and_report_call!(analyzer::AbstractAnalyzer, mi::MethodInstance;
+                                  jetconfigs...)
+    validate_configs(analyzer, jetconfigs)
+    analyzer, result = analyze_method_instance!(analyzer, mi)
+    analyzername = nameof(typeof(analyzer))
+    sig = LazyPrinter(io::IO->Base.show_tuple_as_call(io, Symbol(""), mi.specTypes))
+    source = lazy"$analyzername: $sig"
+    return JETCallResult(result, analyzer, source; jetconfigs...)
+end
 
 # TODO `analyze_builtin!` ?
 function analyze_gf_by_type!(analyzer::AbstractAnalyzer, @nospecialize(tt::Type{<:Tuple}))

--- a/test/abstractinterpret/test_inferenceerrorreport.jl
+++ b/test/abstractinterpret/test_inferenceerrorreport.jl
@@ -204,5 +204,22 @@ sparams22(::Type{A}, ::Type{B}) where B where A = zero(A), zero(B)
     end
 end
 
+@testset "from MethodInstance" begin
+    m = @fixturedef begin
+        foo(s::AbstractString) = throw(ArgumentError(s))
+    end
+    if isdefined(Base, :specializations)
+        try
+            m.foo("throws")
+        catch
+        end
+        mi = first(Base.specializations(only(methods(m.foo))))
+        result = report_call(mi)
+        r = only(get_reports_with_test(result))
+        @test isa(r, UncaughtExceptionReport)
+        @test Any['(', 's', String, ')', ArgumentError] ⫇ r.sig._sig
+    end
+end
+
 # TODO set up a dedicated module context for this testset
 # end # module test_inferenceerrorreport


### PR DESCRIPTION
This describes a workflow where you can use MethodAnalysis to grab
precompiled MethodInstances and then run JET on them.

It's possible that some of this could or should be simplified, and I would be happy to help.