### PR TITLE
ui: use stacktrace-like view for showing reports

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -3,13 +3,13 @@
 JET can be fine-tuned very flexibly.
 Any entry point explained in [JET's default error analysis](@ref jetanalysis-entry) and [the optimization analysis](@ref optanalysis-entry)
 can accept any of the configuration parameters described below as keyword arguments (or optional parameters for the interactive macros).
-For example, you can analyze the call of `sum("julia")` with the [`annotate_types`](@ref print-config) configuration enabled as like:
+For example, you can analyze the call of `sum("julia")` with the [`fullpath`](@ref print-config) configuration enabled as like:
 ```julia
-@report_call annotate_types=true sum("julia")
+@report_call fullpath=true sum("julia")
 ```
 or equivalently:
 ```julia
-report_call(sum, (String,); annotate_types=true)
+report_call(sum, (String,); fullpath=true)
 ```
 Similarly you can analyze a top-level script `path/to/file.jl` with specifying [`target_defined_modules` configuration](@ref toplevel-config) as follows:
 ```julia

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -121,7 +121,6 @@ function JETInterface.print_report_message(io::IO, (; g)::UnstableAPI)
     msg = lazy"usage of unstable API `$mod.$name` found"
     print(io, "usage of unstable API `", mod, '.', name, "` found")
 end
-JETInterface.print_signature(::UnstableAPI) = false
 JETInterface.report_color(::UnstableAPI) = :yellow
 
 function (::UnstableAPIAnalysisPass)(::Type{UnstableAPI}, analyzer::UnstableAPIAnalyzer, sv, @nospecialize(e))

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -570,47 +570,47 @@ julia> function foo(a)
 # by default, JET will print all the collected reports:
 julia> @report_call foo("julia")
 ═════ 3 possible errors found ═════
-┌ @ REPL[1]:2 r1 = sum(a)
-│┌ @ reduce.jl:549 Base.:(var"#sum#281")(pairs(NamedTuple()), #self#, a)
-││┌ @ reduce.jl:549 sum(identity, a)
-│││┌ @ reduce.jl:520 Base.:(var"#sum#280")(pairs(NamedTuple()), #self#, f, a)
-││││┌ @ reduce.jl:520 mapreduce(f, Base.add_sum, a)
-│││││┌ @ reduce.jl:294 Base.:(var"#mapreduce#277")(pairs(NamedTuple()), #self#, f, op, itr)
-││││││┌ @ reduce.jl:294 mapfoldl(f, op, itr)
-│││││││┌ @ reduce.jl:162 Base.:(var"#mapfoldl#273")(Base._InitialValue(), #self#, f, op, itr)
-││││││││┌ @ reduce.jl:162 Base.mapfoldl_impl(f, op, init, itr)
-│││││││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
-││││││││││┌ @ reduce.jl:48 v = Base._foldl_impl(op, nt, itr)
-│││││││││││┌ @ reduce.jl:62 v = op(v, y[1])
-││││││││││││┌ @ reduce.jl:81 op.rf(acc, x)
-│││││││││││││┌ @ reduce.jl:24 x + y
-││││││││││││││ no matching method found for `+(::Char, ::Char)`: (x::Char + y::Char)::Union{}
-│││││││││││││└────────────────
-││││││││││┌ @ reduce.jl:49 Base.reduce_empty_iter(op, itr)
-│││││││││││┌ @ reduce.jl:370 Base.reduce_empty_iter(op, itr, Base.IteratorEltype(itr))
-││││││││││││┌ @ reduce.jl:371 Base.reduce_empty(op, eltype(itr))
-│││││││││││││┌ @ reduce.jl:347 Base.reduce_empty(op.rf, T)
-││││││││││││││┌ @ reduce.jl:339 Base.reduce_empty(+, T)
-│││││││││││││││┌ @ reduce.jl:330 zero(T)
-││││││││││││││││ no matching method found for `zero(::Type{Char})`: zero(T::Type{Char})::Union{}
-│││││││││││││││└─────────────────
-┌ @ REPL[1]:3 r2 = undefsum(a)
-│ `undefsum` is not defined
-└─────────────
+┌ foo(a::String) @ Main ./REPL[14]:2
+│┌ sum(a::String) @ Base ./reduce.jl:564
+││┌ sum(a::String; kw::@Kwargs{}) @ Base ./reduce.jl:564
+│││┌ sum(f::typeof(identity), a::String) @ Base ./reduce.jl:535
+││││┌ sum(f::typeof(identity), a::String; kw::@Kwargs{}) @ Base ./reduce.jl:535
+│││││┌ mapreduce(f::typeof(identity), op::typeof(Base.add_sum), itr::String) @ Base ./reduce.jl:307
+││││││┌ mapreduce(f::typeof(identity), op::typeof(Base.add_sum), itr::String; kw::@Kwargs{}) @ Base ./reduce.jl:307
+│││││││┌ mapfoldl(f::typeof(identity), op::typeof(Base.add_sum), itr::String) @ Base ./reduce.jl:175
+││││││││┌ mapfoldl(f::typeof(identity), op::typeof(Base.add_sum), itr::String; init::Base._InitialValue) @ Base ./reduce.jl:175
+│││││││││┌ mapfoldl_impl(f::typeof(identity), op::typeof(Base.add_sum), nt::Base._InitialValue, itr::String) @ Base ./reduce.jl:44
+││││││││││┌ foldl_impl(op::Base.BottomRF{typeof(Base.add_sum)}, nt::Base._InitialValue, itr::String) @ Base ./reduce.jl:48
+│││││││││││┌ _foldl_impl(op::Base.BottomRF{typeof(Base.add_sum)}, init::Base._InitialValue, itr::String) @ Base ./reduce.jl:62
+││││││││││││┌ (::Base.BottomRF{typeof(Base.add_sum)})(acc::Char, x::Char) @ Base ./reduce.jl:86
+│││││││││││││┌ add_sum(x::Char, y::Char) @ Base ./reduce.jl:24
+││││││││││││││ no matching method found `+(::Char, ::Char)`: (x::Char + y::Char)
+│││││││││││││└────────────────────
+││││││││││┌ foldl_impl(op::Base.BottomRF{typeof(Base.add_sum)}, nt::Base._InitialValue, itr::String) @ Base ./reduce.jl:49
+│││││││││││┌ reduce_empty_iter(op::Base.BottomRF{typeof(Base.add_sum)}, itr::String) @ Base ./reduce.jl:383
+││││││││││││┌ reduce_empty_iter(op::Base.BottomRF{typeof(Base.add_sum)}, itr::String, ::Base.HasEltype) @ Base ./reduce.jl:384
+│││││││││││││┌ reduce_empty(op::Base.BottomRF{typeof(Base.add_sum)}, ::Type{Char}) @ Base ./reduce.jl:360
+││││││││││││││┌ reduce_empty(::typeof(Base.add_sum), ::Type{Char}) @ Base ./reduce.jl:352
+│││││││││││││││┌ reduce_empty(::typeof(+), ::Type{Char}) @ Base ./reduce.jl:343
+││││││││││││││││ no matching method found `zero(::Type{Char})`: zero(T::Type{Char})
+│││││││││││││││└────────────────────
+┌ foo(a::String) @ Main ./REPL[14]:3
+│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+└────────────────────
 
 # with `target_modules=(@__MODULE__,)`, JET will only report the problems detected within the `@__MODULE__` module:
 julia> @report_call target_modules=(@__MODULE__,) foo("julia")
-════ 1 possible error found ═════
-┌ @ REPL[1]:3 r2 = undefsum(a)
-│ `undefsum` is not defined
-└─────────────
+═════ 1 possible error found ═════
+┌ foo(a::String) @ Main ./REPL[14]:3
+│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+└────────────────────
 
 # with `ignored_modules=(Base,)`, JET will ignore the errors detected within the `Base` module:
 julia> @report_call ignored_modules=(Base,) foo("julia")
-════ 1 possible error found ═════
-┌ @ REPL[1]:3 r2 = undefsum(a)
-│ `undefsum` is not defined
-└─────────────
+═════ 1 possible error found ═════
+┌ foo(a::String) @ Main ./REPL[14]:3
+│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+└────────────────────
 ```
 ---
 """

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -1295,7 +1295,7 @@ const GENERAL_CONFIGURATIONS = Set{Symbol}((
     # toplevel
     :context, :analyze_from_definitions, :concretization_patterns, :virtualize, :toplevel_logger,
     # ui
-    :print_toplevel_success, :print_inference_success, :annotate_types, :fullpath, :vscode_console_output,
+    :print_toplevel_success, :print_inference_success, :fullpath, :vscode_console_output,
     # watch
     :revise_all, :revise_modules))
 for (Params, Func) = ((InferenceParams, JETInferenceParams),
@@ -1355,13 +1355,13 @@ include("analyzers/optanalyzer.jl")
 using PrecompileTools
 @setup_workload let
     @compile_workload let
-        result = @report_call annotate_types=true sum("julia")
+        result = @report_call sum("julia")
         show(IOContext(devnull, :color=>true), result)
-        result = @report_call annotate_types=true rand(String)
+        result = @report_call rand(String)
         show(IOContext(devnull, :color=>true), result)
-        result = @report_opt annotate_types=true sum("julia")
+        result = @report_opt sum("julia")
         show(IOContext(devnull, :color=>true), result)
-        result = @report_opt annotate_types=true rand(String)
+        result = @report_opt rand(String)
         show(IOContext(devnull, :color=>true), result)
     end
 end

--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -531,18 +531,16 @@ identical as far as they're collected at the same file and line.
 aggregation_policy(::AbstractAnalyzer) = default_aggregation_policy
 function default_aggregation_policy(@nospecialize(report::InferenceErrorReport))
     return DefaultReportIdentity(
-        typeof(Base.inferencebarrier(report))::DataType,
+        typeof(Base.inferencebarrier(report)),
         report.sig,
         # VirtualFrameNoLinfo(first(report.vst)),
-        VirtualFrameNoLinfo(last(report.vst)),
-        )
+        VirtualFrameNoLinfo(last(report.vst)))
 end
 @withmixedhash struct VirtualFrameNoLinfo
     file::Symbol
     line::Int
-    sig::Signature
     # linfo::MethodInstance # ignore the identity of `MethodInstance`
-    VirtualFrameNoLinfo(vf::VirtualFrame) = new(vf.file, vf.line, vf.sig)
+    VirtualFrameNoLinfo(vf::VirtualFrame) = new(vf.file, vf.line)
 end
 @withmixedhash struct DefaultReportIdentity
     T::DataType

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1554,15 +1554,15 @@ julia> @testset "check errors" begin
            @test_call g(ref)             # fail
            @test_call broken=true f(ref) # annotated as broken, thus still "pass"
        end
-check errors: JET-test failed at REPL[9]:3
-  Expression: #= REPL[9]:3 =# JET.@test_call f(ref)
+check errors: JET-test failed at REPL[21]:3
+  Expression: #= REPL[21]:3 =# JET.@test_call f(ref)
   ═════ 1 possible error found ═════
-  ┌ @ REPL[7]:1 sin(ref[])
-  │ no matching method found for `sin(::Nothing)` (1/2 union split): sin((ref::Base.RefValue{Union{Nothing, Int64}})[]::Union{Nothing, Int64})::Union{}
-  └─────────────
+  ┌ f(ref::Base.RefValue{Union{Nothing, Int64}}) @ Main ./REPL[19]:1
+  │ no matching method found `sin(::Nothing)` (1/2 union split): sin((ref::Base.RefValue{Union{Nothing, Int64}})[]::Union{Nothing, Int64})
+  └────────────────────
 
-Test Summary: | Pass  Fail  Broken  Total
-check errors  |    1     1       1      3
+Test Summary: | Pass  Fail  Broken  Total  Time
+check errors  |    1     1       1      3  0.2s
 ERROR: Some tests did not pass: 1 passed, 1 failed, 0 errored, 1 broken.
 ```
 """

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -33,30 +33,29 @@ that are specific to the optimization analysis.
   # and those within non-concrete calls (`fill_twos!(a)`) are not reported
   julia> @report_opt strange_twos(3)
   ═════ 2 possible errors found ═════
-  ┌ @ REPL[2]:2 %45(Main.undef, n)
-  │ runtime dispatch detected: %45::Type{Vector{_A}} where _A(Main.undef, n::Int64)
-  └─────────────
-  ┌ @ REPL[2]:3 Main.fill_twos!(%46)
-  │ runtime dispatch detected: Main.fill_twos!(%46::Vector)
-  └─────────────
+  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:2
+  │ runtime dispatch detected: %33::Type{Vector{_A}} where _A(undef, n::Int64)::Vector
+  └────────────────────
+  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
+  │ runtime dispatch detected: fill_twos!(%34::Vector)::Any
+  └────────────────────
 
   # we can get reports from non-concrete calls with `skip_noncompileable_calls=false`
   julia> @report_opt skip_noncompileable_calls=false strange_twos(3)
-  ═════ 4 possible errors found ═════
-  ┌ @ REPL[2]:3 Main.fill_twos!(a)
-  │┌ @ REPL[1]:3 a[%14] = 2
-  ││ runtime dispatch detected: Base.setindex!(a::Vector, 2, %14::Int64)
-  │└─────────────
-  │┌ @ REPL[1]:3 a[i] = 2
-  ││┌ @ array.jl:877 Base.convert(_, x)
-  │││ runtime dispatch detected: Base.convert(_::Any, x::Int64)
-  ││└────────────────
-  ┌ @ REPL[2]:2 %45(Main.undef, n)
-  │ runtime dispatch detected: %45::Type{Vector{_A}} where _A(Main.undef, n::Int64)
-  └─────────────
-  ┌ @ REPL[2]:3 Main.fill_twos!(%46)
-  │ runtime dispatch detected: Main.fill_twos!(%46::Vector)
-  └─────────────
+  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
+  │┌ fill_twos!(a::Vector) @ Main ./REPL[22]:3
+  ││┌ setindex!(A::Vector, x::Int64, i1::Int64) @ Base ./array.jl:1014
+  │││ runtime dispatch detected: convert(%5::Any, x::Int64)::Any
+  ││└────────────────────
+  │┌ fill_twos!(a::Vector) @ Main ./REPL[22]:3
+  ││ runtime dispatch detected: ((a::Vector)[%13::Int64] = 2::Any)
+  │└────────────────────
+  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:2
+  │ runtime dispatch detected: %33::Type{Vector{_A}} where _A(undef, n::Int64)::Vector
+  └────────────────────
+  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
+  │ runtime dispatch detected: fill_twos!(%34::Vector)::Any
+  └────────────────────
   ```
 
   !!! note "Non-compileable calls"
@@ -85,9 +84,9 @@ that are specific to the optimization analysis.
                  end
              end
       ═════ 1 possible error found ═════
-      ┌ @ REPL[3]:7 maybesin(%19)
+      ┌ (::var"#3#4")(xs::Vector{Any}) @ Main ./REPL[3]:7
       │ runtime dispatch detected: maybesin(%19::Any)::Any
-      └─────────────
+      └────────────────────
 
       julia> function maybesin(@nospecialize x) # mark `x` with `@nospecialize`
                  if isa(x, Number)
@@ -108,10 +107,10 @@ that are specific to the optimization analysis.
                  end
              end
       ═════ 1 possible error found ═════
-      ┌ @ REPL[5]:7 s = maybesin(x)
-      │┌ @ REPL[4]:3 sin(%3)
+      ┌ (::var"#5#6")(xs::Vector{Any}) @ Main ./REPL[5]:7
+      │┌ maybesin(x::Any) @ Main ./REPL[4]:3
       ││ runtime dispatch detected: sin(%3::Number)::Any
-      │└─────────────
+      │└────────────────────
       ```
 
 ---

--- a/src/ui/print.jl
+++ b/src/ui/print.jl
@@ -24,73 +24,6 @@ Configurations for report printing.
 The configurations below will be active whenever `show`ing [JET's analysis result](@ref analysis-result) within REPL.
 
 ---
-- `annotate_types::Bool = false` \\
-  When set to `true`, annotates types when printing analyzed call stack.
-
-  > Examples:
-  * with `annotate_types = false` (default):
-    ```julia-repl
-    julia> @report_call sum("julia")
-    ═════ 2 possible errors found ═════
-    ┌ @ reduce.jl:549 Base.:(var"#sum#281")(pairs(NamedTuple()), #self#, a)
-    │┌ @ reduce.jl:549 sum(identity, a)
-    ││┌ @ reduce.jl:520 Base.:(var"#sum#280")(pairs(NamedTuple()), #self#, f, a)
-    │││┌ @ reduce.jl:520 mapreduce(f, Base.add_sum, a)
-    ││││┌ @ reduce.jl:294 Base.:(var"#mapreduce#277")(pairs(NamedTuple()), #self#, f, op, itr)
-    │││││┌ @ reduce.jl:294 mapfoldl(f, op, itr)
-    ││││││┌ @ reduce.jl:162 Base.:(var"#mapfoldl#273")(Base._InitialValue(), #self#, f, op, itr)
-    │││││││┌ @ reduce.jl:162 Base.mapfoldl_impl(f, op, init, itr)
-    ││││││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
-    │││││││││┌ @ reduce.jl:48 v = Base._foldl_impl(op, nt, itr)
-    ││││││││││┌ @ reduce.jl:62 v = op(v, y[1])
-    │││││││││││┌ @ reduce.jl:81 op.rf(acc, x)
-    ││││││││││││┌ @ reduce.jl:24 x + y
-    │││││││││││││ no matching method found for `+(::Char, ::Char)`: (x::Char + y::Char)::Union{}
-    ││││││││││││└────────────────
-    │││││││││┌ @ reduce.jl:49 Base.reduce_empty_iter(op, itr)
-    ││││││││││┌ @ reduce.jl:370 Base.reduce_empty_iter(op, itr, Base.IteratorEltype(itr))
-    │││││││││││┌ @ reduce.jl:371 Base.reduce_empty(op, eltype(itr))
-    ││││││││││││┌ @ reduce.jl:347 Base.reduce_empty(op.rf, T)
-    │││││││││││││┌ @ reduce.jl:339 Base.reduce_empty(+, T)
-    ││││││││││││││┌ @ reduce.jl:330 zero(T)
-    │││││││││││││││ no matching method found for `zero(::Type{Char})`: zero(T::Type{Char})::Union{}
-    ││││││││││││││└─────────────────
-    ```
-  * with `annotate_types = true`
-    ```julia-repl
-    julia> @report_call annotate_types = true sum("julia")
-    ═════ 2 possible errors found ═════
-    ┌ @ reduce.jl:549 Base.:(var"#sum#281")(pairs(NamedTuple()::NamedTuple{(), Tuple{}})::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, #self#::typeof(sum), a::String)::Union{}
-    │┌ @ reduce.jl:549 sum(identity, a::String)::Union{}
-    ││┌ @ reduce.jl:520 Base.:(var"#sum#280")(pairs(NamedTuple()::NamedTuple{(), Tuple{}})::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, #self#::typeof(sum), f::typeof(identity), a::String)::Union{}
-    │││┌ @ reduce.jl:520 mapreduce(f::typeof(identity), Base.add_sum, a::String)::Union{}
-    ││││┌ @ reduce.jl:294 Base.:(var"#mapreduce#277")(pairs(NamedTuple()::NamedTuple{(), Tuple{}})::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, #self#::typeof(mapreduce), f::typeof(identity), op::typeof(Base.add_sum), itr::String)::Union{}
-    │││││┌ @ reduce.jl:294 mapfoldl(f::typeof(identity), op::typeof(Base.add_sum), itr::String)::Union{}
-    ││││││┌ @ reduce.jl:162 Base.:(var"#mapfoldl#273")(Base._InitialValue()::Base._InitialValue, #self#::typeof(mapfoldl), f::typeof(identity), op::typeof(Base.add_sum), itr::String)::Union{}
-    │││││││┌ @ reduce.jl:162 Base.mapfoldl_impl(f::typeof(identity), op::typeof(Base.add_sum), init::Base._InitialValue, itr::String)::Union{}
-    ││││││││┌ @ reduce.jl:44 Base.foldl_impl(op′::Union{}, nt::Base._InitialValue, itr′::Union{})::Union{}
-    │││││││││┌ @ reduce.jl:48 v = Base._foldl_impl(op::Base.BottomRF{typeof(Base.add_sum)}, nt::Base._InitialValue, itr::String)::Union{}
-    ││││││││││┌ @ reduce.jl:62 v = op::Base.BottomRF{typeof(Base.add_sum)}(v::Char, (y::Tuple{Char, Int64})[1]::Char)::Union{}
-    │││││││││││┌ @ reduce.jl:81 (op::Base.BottomRF{typeof(Base.add_sum)}).rf::typeof(Base.add_sum)(acc::Char, x::Char)::Union{}
-    ││││││││││││┌ @ reduce.jl:24 (x::Char + y::Char)::Union{}
-    │││││││││││││ no matching method found for `+(::Char, ::Char)`: (x::Char + y::Char)::Union{}
-    ││││││││││││└────────────────
-    │││││││││┌ @ reduce.jl:49 Base.reduce_empty_iter(op::Base.BottomRF{typeof(Base.add_sum)}, itr::String)::Union{}
-    ││││││││││┌ @ reduce.jl:370 Base.reduce_empty_iter(op::Base.BottomRF{typeof(Base.add_sum)}, itr::String, Base.IteratorEltype(itr::String)::Base.HasEltype)::Union{}
-    │││││││││││┌ @ reduce.jl:371 Base.reduce_empty(op::Base.BottomRF{typeof(Base.add_sum)}, eltype(itr::String)::Type{Char})::Union{}
-    ││││││││││││┌ @ reduce.jl:347 Base.reduce_empty((op::Base.BottomRF{typeof(Base.add_sum)}).rf::typeof(Base.add_sum), T::Type{Char})::Union{}
-    │││││││││││││┌ @ reduce.jl:339 Base.reduce_empty(+, T::Type{Char})::Union{}
-    ││││││││││││││┌ @ reduce.jl:330 zero(T::Type{Char})::Union{}
-    │││││││││││││││ no matching method found for `zero(::Type{Char})`: zero(T::Type{Char})::Union{}
-    ││││││││││││││└─────────────────
-    ```
-
-  !!! note
-      JET always annotates types when printing the error point, e.g. in the example above,
-      the error points below are always type-annotated regardless of this configuration:
-      - `no matching method found for call signature: Base.zero(_::Type{Char})`
-      - `no matching method found for call signature: Base.+(x::Char, y::Char)`
----
 - `fullpath::Bool = false` \\
   Controls whether or not expand a file path to full path when printing analyzed call stack.
   Note that paths of Julia's `Base` files will also be expanded when set to `true`.
@@ -105,16 +38,13 @@ The configurations below will be active whenever `show`ing [JET's analysis resul
 struct PrintConfig
     print_toplevel_success::Bool
     print_inference_success::Bool
-    annotate_types::Bool
     fullpath::Bool
     function PrintConfig(; print_toplevel_success::Bool  = false,
                            print_inference_success::Bool = true,
-                           annotate_types::Bool          = false,
                            fullpath::Bool                = false,
                            __jetconfigs...)
         return new(print_toplevel_success,
                    print_inference_success,
-                   annotate_types,
                    fullpath)
     end
 end
@@ -357,7 +287,7 @@ function print_report(io::IO, report::InferenceErrorReport)
     printstyled(io, msg; color)
     if print_signature(report)
         printstyled(io, ": "; color)
-        print_signature(io, report.sig, (; annotate_types=true); bold=true)
+        print_signature(io, report.sig, (;); bold=true)
     end
 end
 
@@ -368,17 +298,13 @@ function print_signature(io, sig::Signature, config; kwargs...)
 end
 function _print_signature(io, @nospecialize(x), config; kwargs...)
     if isa(x, Type)
-        if config.annotate_types
-            if x !== Union{}
-                printstyled(io, "::", x; color = TYPE_ANNOTATION_COLOR, kwargs...)
-            end
+        if x !== Union{}
+            printstyled(io, "::", x; color = TYPE_ANNOTATION_COLOR, kwargs...)
         end
     elseif isa(x, Repr)
         printstyled(io, sprint(show, x.val); kwargs...)
     elseif isa(x, AnnotationMaker)
-        if config.annotate_types
-            printstyled(io, x.switch ? '(' : ')'; kwargs...)
-        end
+        printstyled(io, x.switch ? '(' : ')'; kwargs...)
     elseif isa(x, ApplyTypeResult)
         printstyled(io, x.typ; kwargs...)
     elseif isa(x, IgnoreMarker)

--- a/src/ui/vscode.jl
+++ b/src/ui/vscode.jl
@@ -3,14 +3,14 @@ module VSCode
 import ..JET:
     gen_postprocess,
     tofullpath,
-    print_signature,
     AbstractAnalyzer,
     JETToplevelResult,
     ToplevelErrorReport,
     JETCallResult,
     InferenceErrorReport,
     get_reports,
-    print_report
+    print_report,
+    print_frame_sig
 
 # common
 # ======
@@ -102,8 +102,7 @@ function vscode_diagnostics(analyzer::Analyzer,
                             line = showpoint.line,
                             severity = 1, # 0: Error, 1: Warning, 2: Information, 3: Hint
                             relatedInformation = map((order ? identity : reverse)(report.vst)) do frame
-                                sig = sprint(print_signature, frame.sig, (; annotate_types = true))
-                                return (; msg = postprocess(sig),
+                                return (; msg = postprocess(sprint(print_frame_sig, frame)),
                                           path = tovscodepath(frame.file),
                                           line = frame.line,
                                           )

--- a/test/self_check.jl
+++ b/test/self_check.jl
@@ -6,27 +6,20 @@ let target_modules = (JET,)
     JETAnalyzerT   = typeof(JET.JETAnalyzer())
     OptAnalyzerT   = typeof(JET.OptAnalyzer())
     InferenceState = Core.Compiler.InferenceState
-    annotate_types = true
 
     # error analysis
     # ==============
 
     # JETAnalyzer
-    test_call(JET.analyze_frame!, (JETAnalyzerT, InferenceState);
-                target_modules, annotate_types)
+    test_call(JET.analyze_frame!, (JETAnalyzerT, InferenceState); target_modules)
     # OptAnalyzer
-    test_call(JET.analyze_frame!, (OptAnalyzerT, InferenceState);
-                target_modules, annotate_types)
+    test_call(JET.analyze_frame!, (OptAnalyzerT, InferenceState); target_modules)
     # top-level
-    test_call(JET.virtual_process, (String, String, Nothing, JETAnalyzerT, JET.ToplevelConfig{Vector{Expr}});
-                target_modules, annotate_types)
-    test_call(JET.virtual_process, (String, String, Base.PkgId, JETAnalyzerT, JET.ToplevelConfig{Vector{Expr}});
-                target_modules, annotate_types)
+    test_call(JET.virtual_process, (String, String, Nothing, JETAnalyzerT, JET.ToplevelConfig{Vector{Expr}}); target_modules)
+    test_call(JET.virtual_process, (String, String, Base.PkgId, JETAnalyzerT, JET.ToplevelConfig{Vector{Expr}}); target_modules)
     # entries
-    test_call(JET.report_file, (String,);
-                target_modules, annotate_types)
-    test_call(JET.report_package, (Union{String,Module,Nothing},);
-                target_modules, annotate_types)
+    test_call(JET.report_file, (String,); target_modules)
+    test_call(JET.report_package, (Union{String,Module,Nothing},); target_modules)
 
     # optimization analysis
     # =====================
@@ -53,13 +46,9 @@ let target_modules = (JET,)
         return true
     end
     # JETAnalyzer
-    test_opt(JET.analyze_frame!, (JETAnalyzerT, InferenceState);
-                target_modules,
-                function_filter, annotate_types)
+    test_opt(JET.analyze_frame!, (JETAnalyzerT, InferenceState); function_filter, target_modules)
     # OptAnalyzer
-    test_opt(JET.analyze_frame!, (OptAnalyzerT, InferenceState);
-                target_modules,
-                function_filter, annotate_types)
+    test_opt(JET.analyze_frame!, (OptAnalyzerT, InferenceState); function_filter, target_modules)
 end
 
 end # module self_check

--- a/test/ui/test_print.jl
+++ b/test/ui/test_print.jl
@@ -40,26 +40,23 @@ end
         @test !iszero(print_reports(io, res.res.inference_error_reports))
         let s = String(take!(io))
             @test occursin("2 possible errors found", s)
-            @test occursin(Regex("@ $(escape_string(@__FILE__)):$((@__LINE__)-7)"), s) # toplevel call signature
+            @test occursin("$(escape_string(@__FILE__)):$((@__LINE__)-7)", s) # toplevel call site
         end
     end #=== LINE SENSITIVITY END ===#
 
-    @testset "special case splat call signature" begin
-        let #=== LINE SENSITIVITY START ===#
-            res = @analyze_toplevel begin
-                foo(args...) = args_typo # typo
-                foo(rand(Char, 1000000000)...)
-            end
+    let #=== LINE SENSITIVITY START ===#
+        res = @analyze_toplevel begin
+            foo(args...) = args_typo # typo
+            foo(rand(Char, 1000000000)...)
+        end
 
-            io = IOBuffer()
-            @test !iszero(print_reports(io, res.res.inference_error_reports, JET.gen_postprocess(res.res.actual2virtual)))
-            let s = String(take!(io))
-                @test occursin("1 possible error found", s)
-                @test occursin(Regex("@ $(escape_string(@__FILE__)):$((@__LINE__)-8)"), s) # toplevel call signature
-                @test occursin("foo(rand(Char, 1000000000)...)", s)
-            end
-        end #=== LINE SENSITIVITY END ===#
-    end
+        io = IOBuffer()
+        @test !iszero(print_reports(io, res.res.inference_error_reports, JET.gen_postprocess(res.res.actual2virtual)))
+        let s = String(take!(io))
+            @test occursin("1 possible error found", s)
+            @test occursin("$(escape_string(@__FILE__)):$((@__LINE__)-8)", s) # toplevel call site
+        end
+    end #=== LINE SENSITIVITY END ===#
 end
 
 @testset "repr" begin


### PR DESCRIPTION
Since the stacktrace view shown by Julia Base upon exception is more
familiar to general users, it would be better to use the same view for
showing JET's abstract stacktrace.

Previously JET tries to "infer" the textual code representation of the
call-sites of each stack-frame, but now JET does not need to do so, and
JET can show the method signature of each abstract stack-frame from
their `MethodInstance` that is already available. Therefore, this commit
may result in some performance improvement.

Note that JET still computes the textual code representation with type
annotations for each error point. We may replace that part with
TypedSyntax.jl in the future since it would be more robust and nicer.

## Examples: `@report_call sum([])`

> Before
```julia
═════ 1 possible error found ═════
┌ @ reducedim.jl:996 Base.:(var"#sum#821")(:, pairs(NamedTuple()), #self#, a)
│┌ @ reducedim.jl:996 Base._sum(a, dims)
││┌ @ reducedim.jl:1000 Base.:(var"#_sum#823")(pairs(NamedTuple()), #self#, a, _3)
│││┌ @ reducedim.jl:1000 Base._sum(identity, a, :)
││││┌ @ reducedim.jl:1001 Base.:(var"#_sum#824")(pairs(NamedTuple()), #self#, f, a, _4)
│││││┌ @ reducedim.jl:1001 mapreduce(f, Base.add_sum, a)
││││││┌ @ reducedim.jl:357 Base.:(var"#mapreduce#814")(:, Base._InitialValue(), #self#, f, op, A)
│││││││┌ @ reducedim.jl:357 Base._mapreduce_dim(f, op, init, A, dims)
││││││││┌ @ reducedim.jl:365 Base._mapreduce(f, op, IndexStyle(A), A)
│││││││││┌ @ reduce.jl:432 Base.mapreduce_empty_iter(f, op, A, Base.IteratorEltype(A))
││││││││││┌ @ reduce.jl:380 Base.reduce_empty_iter(Base.MappingRF(f, op), itr, ItrEltype)
│││││││││││┌ @ reduce.jl:384 Base.reduce_empty(op, eltype(itr))
││││││││││││┌ @ reduce.jl:361 Base.mapreduce_empty(op.f, op.rf, T)
│││││││││││││┌ @ reduce.jl:372 Base.reduce_empty(op, T)
││││││││││││││┌ @ reduce.jl:352 Base.reduce_empty(+, T)
│││││││││││││││┌ @ reduce.jl:343 zero(T)
││││││││││││││││┌ @ missing.jl:106 Base.throw(Base.MethodError(zero, tuple(Base.Any)))
│││││││││││││││││ MethodError: no method matching zero(::Type{Any}): Base.throw(Base.MethodError(zero, tuple(Base.Any)::Tuple{DataType})::MethodError)
││││││││││││││││└──────────────────
```
> After
```julia
═════ 1 possible error found ═════
┌ sum(a::Vector{Any}) @ Base ./reducedim.jl:996
│┌ sum(a::Vector{Any}; dims::Colon, kw::Base.@kwargs{}) @ Base ./reducedim.jl:996
││┌ _sum(a::Vector{Any}, ::Colon) @ Base ./reducedim.jl:1000
│││┌ _sum(a::Vector{Any}, ::Colon; kw::Base.@kwargs{}) @ Base ./reducedim.jl:1000
││││┌ _sum(f::typeof(identity), a::Vector{Any}, ::Colon) @ Base ./reducedim.jl:1001
│││││┌ _sum(f::typeof(identity), a::Vector{Any}, ::Colon; kw::Base.@kwargs{}) @ Base ./reducedim.jl:1001
││││││┌ mapreduce(f::typeof(identity), op::typeof(Base.add_sum), A::Vector{Any}) @ Base ./reducedim.jl:357
│││││││┌ mapreduce(f::typeof(identity), op::typeof(Base.add_sum), A::Vector{Any}; dims::Colon, init::Base._InitialValue) @ Base ./reducedim.jl:357
││││││││┌ _mapreduce_dim(f::typeof(identity), op::typeof(Base.add_sum), ::Base._InitialValue, A::Vector{Any}, ::Colon) @ Base ./reducedim.jl:365
│││││││││┌ _mapreduce(f::typeof(identity), op::typeof(Base.add_sum), ::IndexLinear, A::Vector{Any}) @ Base ./reduce.jl:432
││││││││││┌ mapreduce_empty_iter(f::typeof(identity), op::typeof(Base.add_sum), itr::Vector{Any}, ItrEltype::Base.HasEltype) @ Base ./reduce.jl:380
│││││││││││┌ reduce_empty_iter(op::Base.MappingRF{typeof(identity), typeof(Base.add_sum)}, itr::Vector{Any}, ::Base.HasEltype) @ Base ./reduce.jl:384
││││││││││││┌ reduce_empty(op::Base.MappingRF{typeof(identity), typeof(Base.add_sum)}, ::Type{Any}) @ Base ./reduce.jl:361
│││││││││││││┌ mapreduce_empty(::typeof(identity), op::typeof(Base.add_sum), T::Type{Any}) @ Base ./reduce.jl:372
││││││││││││││┌ reduce_empty(::typeof(Base.add_sum), ::Type{Any}) @ Base ./reduce.jl:352
│││││││││││││││┌ reduce_empty(::typeof(+), ::Type{Any}) @ Base ./reduce.jl:343
││││││││││││││││┌ zero(::Type{Any}) @ Base ./missing.jl:106
│││││││││││││││││ MethodError: no method matching zero(::Type{Any}): Base.throw(Base.MethodError(zero, tuple(Base.Any)::Tuple{DataType})::MethodError)
││││││││││││││││└────────────────────
```

## Example 2
```julia
getprop(x) = x.nonexist;

report_call((Regex,)) do r
    getprop(r)
end
```

> Before
```julia
═════ 1 possible error found ═════
┌ @ REPL[30]:2 getprop(r)
│┌ @ REPL[29]:1 x.nonexist
││┌ @ Base.jl:37 Base.getfield(x, f)
│││ type Regex has no field nonexist
││└──────────────
```
> After
```julia
═════ 1 possible error found ═════
┌ (::var"https://github.com/aviatesk/JET.jl/pull/3#4")(r::Regex) @ Main ./REPL[12]:2
│┌ getprop(x::Regex) @ Main ./REPL[11]:1
││┌ getproperty(x::Regex, f::Symbol) @ Base ./Base.jl:37
│││ type Regex has no field nonexist: Base.getfield(x::Regex, f::Symbol)
││└────────────────────
```