### PR TITLE
`OptAnalyzer`: make sure to get reports from non-"compileable" but "inlineable" frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,21 @@ Note that, because JET relies on Julia's type inference, if a chain of inference
 
 ```julia
 julia> @report_opt foldl(+, Any[]; init=0)
-═════ 1 possible error found ═════
-┌ @ reduce.jl:198 Base.:(var"#foldl#291")(kw..., _3, op, itr)
+═════ 2 possible errors found ═════
+┌ @ reduce.jl:198 Base.:(var"#foldl#295")(kw..., _3, op, itr)
 │┌ @ reduce.jl:198 Core.kwcall(merge(Base.NamedTuple(), kw), mapfoldl, identity, op, itr)
-││┌ @ reduce.jl:175 Base.:(var"#mapfoldl#290")(_8, _3, f, op, itr)
+││┌ @ reduce.jl:175 Base.:(var"#mapfoldl#294")(_8, _3, f, op, itr)
 │││┌ @ reduce.jl:175 Base.mapfoldl_impl(f, op, init, itr)
 ││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
 │││││┌ @ reduce.jl:48 v = Base._foldl_impl(op, nt, itr)
-││││││┌ @ reduce.jl:62 op(%20, %37)
-│││││││ runtime dispatch detected: op::Base.BottomRF{typeof(+)}(%20::Any, %37::Any)::Any
-││││││└────────────────
+││││││┌ @ reduce.jl:58 v = op(init, y[1])
+│││││││┌ @ reduce.jl:86 +(acc, x)
+││││││││ runtime dispatch detected: +(acc::Int64, x::Any)::Any
+│││││││└────────────────
+││││││┌ @ reduce.jl:62 v = op(v, y[1])
+│││││││┌ @ reduce.jl:86 +(acc, x)
+││││││││ runtime dispatch detected: +(acc::Any, x::Any)::Any
+│││││││└────────────────
 ```
 
 ### Detect type errors with `@report_call`

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -68,7 +68,7 @@ using Core:
     IntrinsicFunction, Intrinsics, LineInfoNode, MethodInstance, MethodMatch, MethodTable,
     ReturnNode, SSAValue, SimpleVector, SlotNumber, svec
 
-using .CC:
+using .CC: ⊑,
     AbstractInterpreter, ArgInfo, BasicBlock, Bottom, CFG, CachedMethodTable, CallMeta,
     ConstCallInfo, InferenceResult, InternalMethodTable, InvokeCallInfo, LimitedAccuracy,
     MethodCallResult, MethodLookupResult, MethodMatchInfo, MethodMatches, NOT_FOUND,
@@ -76,10 +76,9 @@ using .CC:
     VarTable, WorldRange, WorldView,
     argextype, argtype_by_index, argtype_tail, argtypes_to_type, compute_basic_blocks,
     get_compileable_sig, hasintersect, has_free_typevars, ignorelimited, inlining_enabled,
-    instanceof_tfunc, is_throw_call, isType, isconstType, issingletontype, istopfunction,
-    may_invoke_generator, singleton_type, slot_id, specialize_method, switchtupleunion,
-    tmerge, widenconst,
-    ⊑
+    instanceof_tfunc, is_inlineable, is_throw_call, isType, isconstType, issingletontype,
+    istopfunction, may_invoke_generator, singleton_type, slot_id, specialize_method,
+    switchtupleunion, tmerge, widenconst
 
 using Base:
     @invoke, @invokelatest, IdSet, default_tt, destructure_callex, parse_input_line,

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -279,7 +279,13 @@ function CC.finish!(analyzer::OptAnalyzer, frame::InferenceState)
 
     ret = @invoke CC.finish!(analyzer::AbstractAnalyzer, frame::InferenceState)
 
-    if popfirst!(analyzer.__analyze_frame)
+    analyze = popfirst!(analyzer.__analyze_frame)
+    if !analyze && isa(ret, CodeInfo)
+        # if this inferred source is not "compileable" but still is going to be inlined,
+        # we should add report runtime dispatches within it
+        analyze = CC.is_inlineable(ret)
+    end
+    if analyze
         ReportPass(analyzer)(OptimizationFailureReport, analyzer, caller)
 
         if src isa OptimizationState{typeof(analyzer)}

--- a/test/analyzers/test_optanalyzer.jl
+++ b/test/analyzers/test_optanalyzer.jl
@@ -306,4 +306,23 @@ let result = report_opt() do
     @test isempty(get_reports_with_test(result))
 end
 
+# report runtime dispatches within "noncompileable" but inlineable frames
+@inline noncompileable_inlined1(a, b) = a + b
+let result = report_opt((Any,Any)) do a, b
+        noncompileable_inlined1(a, b)
+    end
+    @test any(get_reports_with_test(result)) do @nospecialize report
+        report isa RuntimeDispatchReport
+    end
+end
+
+noncompileable_inlined2(a, b) = a + b
+let result = report_opt((Any,Any)) do a, b
+        @inline noncompileable_inlined2(a, b)
+    end
+    @test_broken any(get_reports_with_test(result)) do @nospecialize report
+        report isa RuntimeDispatchReport
+    end
+end
+
 end # module test_optanalyzer


### PR DESCRIPTION
`OptAnalyzer` has overlooked the runtime dispatch within "non-compileable" but "inlineable" frame.
```julia
julia> @inline foo(a, b) = a + b

julia> report_opt((Any,Any)) do a, b
           foo(a, b) # JET should report runtime dispatch here
       end
No errors detected
```

This commit fixes it up.