### PR TITLE
JETAnalyzer: ignore `x::Any == y::Concrete` potentially returning `missing` within `analyze_from_definition`

### DIFF
--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -522,13 +522,9 @@ function analyze_from_definitions!(analyzer::AbstractAnalyzer, res::VirtualProce
     start = time()
     n = length(res.toplevel_signatures)
     state = AnalyzerState(analyzer)
-    inf_params, world = state.inf_params, state.world
-    # XXX make these tweaks analyzer-agnostic?
-    new_inf_params = analyzer isa JETAnalyzer ?
-                     JETInferenceParams(inf_params; max_methods=1) :
-                     inf_params
+    oldworld = state.world
     new_world = get_world_counter()
-    state.inf_params, state.world = new_inf_params, new_world
+    state.world = new_world
     if analyzer isa JETAnalyzer && analyzer.report_pass === BasicPass()
         analyzer = JETAnalyzer(state, DefinitionAnalysisPass())
     else
@@ -557,7 +553,7 @@ function analyze_from_definitions!(analyzer::AbstractAnalyzer, res::VirtualProce
             println(io, "couldn't find a single method matching the signature `", tt, "`")
         end
     end
-    state.inf_params, state.world = inf_params, world
+    state.world = oldworld
     with_toplevel_logger(config) do @nospecialize(io)
         sec = round(time() - start; digits = 3)
         println(io, "analyzed $(succeeded[]) top-level definitions (took $sec sec)")


### PR DESCRIPTION
In the `analyze_from_definitions` mode, the analysis begins with the method signature. However, these signatures can often be abstract, leading to situations where, in the case of `x == y`, one side might be concretely inferred, while the other side is not. This can lead to scenarios where the analysis might proceed while considering the possibility that `x == y` could return `missing`, and subsequently result in an error report, which, as discussed in #542, is usually an undesired false positive.

`analyze_from_definitions` was initially designed as an entry point for easy analysis, even at the cost of accuracy. Therefore, it might be better to simply widen the inferred return type
`(x == y)::Union{Bool,Missing}` to `::Any`, thereby reducing potential errors. This should not apply to interactive entry points where the input concrete argument types are given at the analysis starting point. In these cases, the possibility of `missing` being returned should still be considered.

A bit off-topic, but while making this change, I realized that the current design of `ReportPass` might not be functioning as effectively as hoped. Originally, `ReportPass` was meant to allow users well-versed in JET internals to completely ignore specific reports, thereby deleting associated calculations (which can not be achieved by filtering out reports after the analysis has been completed). However, there seems to be a lack of such advanced users at present, and this is inadvertently increasing the complexity of the code base, potentially discouraging potential contributors. It might be beneficial to shift towards a simpler configuration style that can control specific behaviors of the analysis with in the short term.

fix #542