### PR TITLE
remove unnecessary overload of `const_prop_entry_heuristic`

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -22,7 +22,6 @@ JET.islineage
 JET.bail_out_toplevel_call
 JET.bail_out_call
 JET.add_call_backedges!
-JET.const_prop_entry_heuristic
 JET.analyze_task_parallel_code!
 ```
 

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -45,7 +45,7 @@ import .CC:
     abstract_call_known, abstract_call_gf_by_type, abstract_call_method,
     abstract_call_method_with_const_args, abstract_eval_value_expr, abstract_eval_special_value,
     abstract_eval_statement, abstract_eval_value, abstract_invoke, add_call_backedges!,
-    concrete_eval_call, concrete_eval_eligible, const_prop_entry_heuristic, from_interprocedural!,
+    concrete_eval_call, concrete_eval_eligible, from_interprocedural!,
     #= typeinfer.jl =#
     _typeinf, finish!, finish, transform_result_for_cache, typeinf, typeinf_edge,
     #= optimize.jl =#

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -276,20 +276,6 @@ function CC.add_call_backedges!(
         sv::InferenceState)
 end
 
-@doc """
-    const_prop_entry_heuristic(analyzer::JETAnalyzer, result::MethodCallResult, sv::InferenceState)
-
-This overload forces constant prop' even if an inference result can't be improved
-anymore _with respect to the return type_, e.g. when `result.rt` is already `Const`.
-Especially, this overload implements an heuristic to force constant prop' when any error points
-have been reported while the previous abstract method call without constant arguments.
-The reason we want much more aggressive constant propagation by that heuristic is that it's
-highly possible constant prop' can produce more accurate analysis result, by throwing away
-false positive error reports by cutting off the unreachable control flow or detecting
-must-reachable `throw` calls.
-"""
-CC.const_prop_entry_heuristic(::JETAnalyzer, result::MethodCallResult, si::StmtInfo, sv::InferenceState) = true
-
 # TODO Reasons about error found by [semi-]concrete evaluation:
 # For now JETAnalyzer allows the regular constant-prop' only,
 # unless the analyzed effects are proven to be `:nothrow`.


### PR DESCRIPTION
`JETAnalyzer` already sets `aggressive_constant_propagation=true`, so `const_prop_entry_heuristic` wouldn't be called anyway.