### PR TITLE
enable precompilation cache

### DIFF
--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -64,7 +64,7 @@ struct JETAnalyzer{RP<:ReportPass} <: AbstractAnalyzer
     end
     function JETAnalyzer(state::AnalyzerState, report_pass::ReportPass,
                          config::JETAnalyzerConfig)
-        if (@ccall jl_generating_output()::Cint) != 0
+        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && !iszero(@ccall jl_generating_output()::Cint))
             # XXX Avoid storing analysis results into a cache that persists across the
             #     precompilation, as pkgimage currently doesn't support serializing
             #     externally created `CodeInstance`. Otherwise, `CodeInstance`s created by

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -181,7 +181,7 @@ struct OptAnalyzer{RP<:ReportPass,FF} <: AbstractAnalyzer
                          function_filter::FF,
                          skip_noncompileable_calls::Bool,
                          skip_unoptimized_throw_blocks::Bool) where {RP<:ReportPass,FF}
-        if (@ccall jl_generating_output()::Cint) != 0
+        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && !iszero(@ccall jl_generating_output()::Cint))
             # XXX Avoid storing analysis results into a cache that persists across the
             #     precompilation, as pkgimage currently doesn't support serializing
             #     externally created `CodeInstance`. Otherwise, `CodeInstance`s created by


### PR DESCRIPTION
With the introduction of `CodeInstance` serialization support in JuliaLang/julia#52852, it's now reasonable to experiment with persisting the analysis cache during precompilation.

There's an important consideration: the `codeinst.max_world` might occasionally be set to `WORLD_AGE_REVALIDATION_SENTINEL` on the C side under certain conditions. This assignment should ideally be reserved for proper `CodeInstance`s (but it is not currently) and supposed to be fixed up by a subsequent serialization pass. To address this, this commit also adds an `__init__` hook that overrides such `max_world`s at package loading time.