### PR TITLE
virtualprocess: skip concrete-interpretation of `jl_extern_c`

### DIFF
--- a/test/fixtures/JET597/Project.toml
+++ b/test/fixtures/JET597/Project.toml
@@ -1,0 +1,4 @@
+name = "JET597"
+uuid = "4ca48d18-89c2-426a-bed1-3230a526f9a7"
+authors = ["Shuhei Kadowaki <aviatesk@gmail.com>"]
+version = "0.1.0"

--- a/test/fixtures/JET597/src/JET597.jl
+++ b/test/fixtures/JET597/src/JET597.jl
@@ -1,0 +1,22 @@
+module JET597
+
+export increment32, increment64
+
+function increment(count)
+    count += 1
+    return count
+end
+
+Base.@ccallable function increment32(count::Cint)::Cint
+    count = increment(count)
+    println("Incremented count: $count (Cint)")
+    return count
+end
+
+Base.@ccallable function increment64(count::Clong)::Clong
+    count = increment(count)
+    println("Incremented count: $count (Clong)")
+    return count
+end
+
+end # module JET597

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -13,7 +13,7 @@ function get_reports_with_test(res::JET.AnyJETResult)
     return reports
 end
 
-const FIXTURE_DIR = normpath(@__DIR__, "fixtures")
+const FIXTURES_DIR = normpath(@__DIR__, "fixtures")
 
 const ERROR_REPORTS_FROM_SUM_OVER_STRING = let
     result = report_call(sum, (String,))

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -516,8 +516,8 @@ end
 
 @testset "handle `include`" begin
     let
-        f1 = normpath(FIXTURE_DIR, "include1.jl")
-        f2 = normpath(FIXTURE_DIR, "include2.jl")
+        f1 = normpath(FIXTURES_DIR, "include1.jl")
+        f2 = normpath(FIXTURES_DIR, "include2.jl")
 
         context = gen_virtual_module(@__MODULE__)
         res = report_file2(f1; context, virtualize = false)
@@ -530,7 +530,7 @@ end
     end
 
     let
-        f = normpath(FIXTURE_DIR, "nonexistinclude.jl")
+        f = normpath(FIXTURES_DIR, "nonexistinclude.jl")
         res = report_file2(f)
 
         @test f in res.res.included_files
@@ -541,7 +541,7 @@ end
     end
 
     let
-        f = normpath(FIXTURE_DIR, "selfrecursiveinclude.jl")
+        f = normpath(FIXTURES_DIR, "selfrecursiveinclude.jl")
         res = report_file2(f)
 
         @test f in res.res.included_files
@@ -550,8 +550,8 @@ end
     end
 
     let
-        f1 = normpath(FIXTURE_DIR, "chainrecursiveinclude1.jl")
-        f2 = normpath(FIXTURE_DIR, "chainrecursiveinclude2.jl")
+        f1 = normpath(FIXTURES_DIR, "chainrecursiveinclude1.jl")
+        f2 = normpath(FIXTURES_DIR, "chainrecursiveinclude2.jl")
         res = report_file2(f1)
 
         @test f1 in res.res.included_files
@@ -568,8 +568,8 @@ end
     end
 
     let
-        f1 = normpath(FIXTURE_DIR, "includetwice.jl")
-        f2 = normpath(FIXTURE_DIR, "include2.jl")
+        f1 = normpath(FIXTURES_DIR, "includetwice.jl")
+        f2 = normpath(FIXTURES_DIR, "include2.jl")
         res = report_file2(f1)
 
         @test f1 in res.res.included_files
@@ -578,8 +578,8 @@ end
     end
 
     let
-        modf = normpath(FIXTURE_DIR, "modinclude.jl")
-        inc2 = normpath(FIXTURE_DIR, "include2.jl")
+        modf = normpath(FIXTURES_DIR, "modinclude.jl")
+        inc2 = normpath(FIXTURES_DIR, "include2.jl")
 
         context = gen_virtual_module(@__MODULE__)
         res = report_file2(modf; context, virtualize=false)
@@ -2066,7 +2066,7 @@ end
 # produce (false positive) top-level errors (e.g., by actually running test code, etc.)
 # NOTE this could be very fragile ...
 @testset "test file targets" begin
-    TARGET_DIR = normpath(FIXTURE_DIR, "targets")
+    TARGET_DIR = normpath(FIXTURES_DIR, "targets")
 
     let res = report_file2(normpath(TARGET_DIR, "error.jl"))
         @test isempty(res.res.toplevel_error_reports)
@@ -2141,7 +2141,7 @@ end
 using Pkg
 function test_report_package(test_func, (pkgname, code);
                              base_setup=function ()
-                                Pkg.develop(; path=normpath(FIXTURE_DIR, "PkgAnalysisDep"), io=devnull)
+                                Pkg.develop(; path=normpath(FIXTURES_DIR, "PkgAnalysisDep"), io=devnull)
                              end,
                              additional_setup=()->nothing,
                              jetconfigs...)
@@ -2481,6 +2481,21 @@ end
         base_setup=()->Pkg.add("LinearAlgebra", io=devnull)) do res
         @test isempty(res.res.toplevel_error_reports)
         @test isempty(res.res.inference_error_reports)
+    end
+end
+
+# aviatesk/JET.jl#597: don't try to concrete-interpret `:jl_extern_c`
+let old = Pkg.project().path
+    try
+        Pkg.activate(; temp=true, io=devnull)
+        Pkg.develop(; path=normpath(FIXTURES_DIR, "JET597"), io=devnull)
+
+        using JET597
+
+        res = report_package(JET597; toplevel_logger=nothing)
+        @test isempty(res.res.toplevel_error_reports)
+    finally
+        Pkg.activate(old; io=devnull)
     end
 end
 


### PR DESCRIPTION
fixes #597