### PR TITLE
JETAnalyzer: discard sources always

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -125,6 +125,18 @@ __init__() = foreach(@nospecialize(f)->f(), INIT_HOOKS)
 # compat
 # ------
 
+@static if VERSION ≥ v"1.11.0-DEV.439"
+    using Base: generating_output
+else
+    function generating_output(incremental::Union{Bool,Nothing}=nothing)
+        ccall(:jl_generating_output, Cint, ()) == 0 && return false
+        if incremental !== nothing
+            JLOptions().incremental == incremental || return false
+        end
+        return true
+    end
+end
+
 @static if VERSION ≥ v"1.11.0-DEV.1498"
     import .CC: get_inference_world
     using Base: get_world_counter

--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -550,8 +550,11 @@ CC.InferenceParams(analyzer::AbstractAnalyzer) = get_inf_params(analyzer)
 CC.OptimizationParams(analyzer::AbstractAnalyzer) = get_opt_params(analyzer)
 #=CC.=#get_inference_world(analyzer::AbstractAnalyzer) = get_world(analyzer)
 
-CC.may_compress(analyzer::AbstractAnalyzer) = false
-CC.may_discard_trees(analyzer::AbstractAnalyzer) = false
+# allow compression during precompilation only
+CC.may_compress(::AbstractAnalyzer) = generating_output()
+
+# this overload is necessary to avoid caching with the const ABI
+CC.may_discard_trees(::AbstractAnalyzer) = false
 
 let # overload `inlining_policy`
     @static if isdefined(CC, :InliningInfo)

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -64,7 +64,7 @@ struct JETAnalyzer{RP<:ReportPass} <: AbstractAnalyzer
     end
     function JETAnalyzer(state::AnalyzerState, report_pass::ReportPass,
                          config::JETAnalyzerConfig)
-        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && !iszero(@ccall jl_generating_output()::Cint))
+        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && generating_output())
             # XXX Avoid storing analysis results into a cache that persists across the
             #     precompilation, as pkgimage currently doesn't support serializing
             #     externally created `CodeInstance`. Otherwise, `CodeInstance`s created by
@@ -79,6 +79,9 @@ struct JETAnalyzer{RP<:ReportPass} <: AbstractAnalyzer
         return JETAnalyzer(state, analysis_cache, report_pass, config)
     end
 end
+
+# JETAnalyzer does not need any sources, so discard them always
+CC.maybe_compress_codeinfo(::JETAnalyzer, ::MethodInstance, ::CodeInfo) = nothing
 
 # JETAnalyzer hooks on abstract interpretation only,
 # and so the cost of running the optimization passes is just unnecessary

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -181,7 +181,7 @@ struct OptAnalyzer{RP<:ReportPass,FF} <: AbstractAnalyzer
                          function_filter::FF,
                          skip_noncompileable_calls::Bool,
                          skip_unoptimized_throw_blocks::Bool) where {RP<:ReportPass,FF}
-        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && !iszero(@ccall jl_generating_output()::Cint))
+        if ((@static VERSION < v"1.11.0-DEV.1255" && true) && generating_output())
             # XXX Avoid storing analysis results into a cache that persists across the
             #     precompilation, as pkgimage currently doesn't support serializing
             #     externally created `CodeInstance`. Otherwise, `CodeInstance`s created by


### PR DESCRIPTION
Might be more memory efficient.