### PR TITLE
move Revise dep to an weakdep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -32,6 +31,12 @@ Revise = "3.3"
 StaticArrays = "1.7.0"
 Test = "1.10"
 julia = "1.10"
+
+[weakdeps]
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+
+[extensions]
+ReviseExt = "Revise"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/ext/ReviseExt.jl
+++ b/ext/ReviseExt.jl
@@ -1,0 +1,70 @@
+module ReviseExt
+
+using Revise
+using JET: JET, WatchConfig, InsufficientWatches
+import JET: watch_file_with_func
+
+function JET.watch_file_with_func(func, args...; jetconfigs...)
+    local included_files::Set{String}
+
+    config = JET.WatchConfig(; jetconfigs...)
+
+    included_files = let res = func(args...; jetconfigs...)
+        display(res)
+        res.res.included_files
+    end
+
+    interrupted = false
+    while !interrupted
+        try
+            Revise.entr(collect(included_files), config.revise_modules;
+                        postpone = true, all = config.revise_all) do
+                next_included_files = let res = func(args...; jetconfigs...)
+                    display(res)
+                    res.res.included_files
+                end
+                if any(∉(included_files), next_included_files)
+                    # refresh watch files
+                    throw(InsufficientWatches(next_included_files))
+                end
+                return nothing
+            end
+            interrupted = true # `InterruptException` was gracefully handled within `entr`, shutdown watch mode
+        catch err
+            # handle "expected" errors, keep running
+
+            if isa(err, InsufficientWatches)
+                included_files = err.included_files
+                continue
+            elseif (isa(err, LoadError) ||
+                    (isa(err, ErrorException) && startswith(err.msg, "lowering returned an error")) ||
+                    isa(err, Revise.ReviseEvalException))
+                continue
+
+            # async errors
+            elseif isa(err, CompositeException)
+                errs = err.exceptions
+                i = findfirst(@nospecialize(e)->isa(e, TaskFailedException), errs)
+                if !isnothing(i)
+                    tfe = errs[i]::TaskFailedException
+                    let res = tfe.task.result
+                        if isa(res, InsufficientWatches)
+                            included_files = res.included_files
+                            continue
+                        elseif (isa(res, LoadError) ||
+                                (isa(res, ErrorException) && startswith(res.msg, "lowering returned an error")) ||
+                                isa(res, Revise.ReviseEvalException))
+                            continue
+                        end
+                    end
+                end
+            end
+
+            # fatal uncaught error happened in Revise.jl
+            rethrow(err)
+        end
+    end
+end
+
+
+end

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -928,75 +928,8 @@ struct WatchConfig
     end
 end
 
-function watch_file_with_func(func, args...; jetconfigs...)
-    @isdefined(Revise) || init_revise!()
-    @invokelatest _watch_file_with_func(func, args...; jetconfigs...)
-end
-
-# HACK to avoid Revise loading overhead when just using interactive entry points like `@report_call`
-init_revise!() = @eval (@__MODULE__) using Revise
-
-function _watch_file_with_func(func, args...; jetconfigs...)
-    local included_files::Set{String}
-
-    config = WatchConfig(; jetconfigs...)
-
-    included_files = let res = func(args...; jetconfigs...)
-        display(res)
-        res.res.included_files
-    end
-
-    interrupted = false
-    while !interrupted
-        try
-            Revise.entr(collect(included_files), config.revise_modules;
-                        postpone = true, all = config.revise_all) do
-                next_included_files = let res = func(args...; jetconfigs...)
-                    display(res)
-                    res.res.included_files
-                end
-                if any(∉(included_files), next_included_files)
-                    # refresh watch files
-                    throw(InsufficientWatches(next_included_files))
-                end
-                return nothing
-            end
-            interrupted = true # `InterruptException` was gracefully handled within `entr`, shutdown watch mode
-        catch err
-            # handle "expected" errors, keep running
-
-            if isa(err, InsufficientWatches)
-                included_files = err.included_files
-                continue
-            elseif (isa(err, LoadError) ||
-                    (isa(err, ErrorException) && startswith(err.msg, "lowering returned an error")) ||
-                    isa(err, Revise.ReviseEvalException))
-                continue
-
-            # async errors
-            elseif isa(err, CompositeException)
-                errs = err.exceptions
-                i = findfirst(@nospecialize(e)->isa(e, TaskFailedException), errs)
-                if !isnothing(i)
-                    tfe = errs[i]::TaskFailedException
-                    let res = tfe.task.result
-                        if isa(res, InsufficientWatches)
-                            included_files = res.included_files
-                            continue
-                        elseif (isa(res, LoadError) ||
-                                (isa(res, ErrorException) && startswith(res.msg, "lowering returned an error")) ||
-                                isa(res, Revise.ReviseEvalException))
-                            continue
-                        end
-                    end
-                end
-            end
-
-            # fatal uncaught error happened in Revise.jl
-            rethrow(err)
-        end
-    end
-end
+# Stub to be filled out by loading the Revise extension
+function watch_file_with_func end
 
 struct InsufficientWatches <: Exception
     included_files::Set{String}

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1718,4 +1718,4 @@ See [watch configurations](@ref watch-config) for more details.
 
 See also [`report_file`](@ref).
 """
-watch_file(args...; jetconfigs...) = watch_file_with_func(report_file, args...; jetconfigs...)
+watch_file(args...; jetconfigs...) = @invokelatest watch_file_with_func(report_file, args...; jetconfigs...)


### PR DESCRIPTION
This makes Revise a proper pkgextension/weakdep. This should
have no impact to functionality, compiletime, or runtime.
Though it should reduce direct dependency count at precompile time.
