### PR TITLE
virtualprocess: implement a better control flow selection logic

### DIFF
--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1956,7 +1956,7 @@ end
                 flush(io)
                 read(path, String)
             end
-            @test_broken isempty(s) # TODO add_control_flow!
+            @test isempty(s)
         end
     end
 


### PR DESCRIPTION
The goal of this commit is to refine `add_control_flow!`, which requests
concretization of the minimal necessary control flow to evaluate
statements whose concretization have already been requested.

The basic approach is to check if there are any active successors for
each basic block, and if there is an active successor and the terminator
is not a fall-through, then request the concretization of that terminator.
Additionally, for conditional terminators, a simple optimization using
post-domination analysis is also performed: we can ignore the control
flow of a conditional terminator and treat it as a fall-through if only
one of its successors is active and the active block post-dominates the
inactive one, since the post-domination ensures that the active basic
block will be reached regardless of the control flow.