### PR TITLE
run CI only on interesting platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,31 @@ jobs:
     strategy:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:
-        version:
-          - '1.10.0'       # lowest version supported
-          - '1'            # current stable
-          - '1.11-nightly' # next stable
-          - 'nightly'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
-          - x86
-        exclude:
-          - os: macOS-latest
+        include:
+          - version: '1' # current stable
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.10.0' # lowerest version supported
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.11-nightly' # next release
+            os: ubuntu-latest
+            arch: x64
+          - version: 'nightly' # dev
+            os: ubuntu-latest
+            arch: x64
+          - version: '1' # x86 ubuntu
+            os: ubuntu-latest
             arch: x86
+          - version: '1' # x86 windows
+            os: windows-latest
+            arch: x86
+          - version: '1' # x64 windows
+            os: windows-latest
+            arch: x64
+          - version: '1' # x64 macOS
+            os: macos-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Like JuliaInterpreter, I'd change the `matrix` to a list format to run CI more sparsely. There is little need to test exhaustively with a full `matrix`, and simply listing the platforms of actual interest will make CI finish faster and be more environmentally friendly.