### PR TITLE
OptAnalyzer: fix #643, ignore reports from callee on `throw` path

### DIFF
--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -74,9 +74,6 @@ end
 a global cache maintained by `AbstractAnalyzer`. That means,
 `codeinf::CodeInstance = Core.Compiler.code_cache(analyzer::AbstractAnalyzer)[mi::MethodInstance])`
 is expected to have its field `codeinf.inferred::CachedAnalysisResult`.
-
-[`InferenceErrorReport`](@ref)s found within already-analyzed `result::InferenceResult`
-can be accessed with `get_cached_reports(analyzer, result)`.
 """
 struct CachedAnalysisResult
     src
@@ -130,7 +127,7 @@ mutable struct AnalyzerState
 
     # the temporal stash to keep track of the context of caller inference/optimization and
     # the caller itself, to which reconstructed cached reports will be appended
-    cache_target::Union{Nothing,Pair{Symbol,InferenceResult}}
+    cache_target::Union{Nothing,Pair{Symbol,InferenceState}}
 
     ## abstract toplevel execution ##
 
@@ -179,7 +176,7 @@ function AnalyzerState(world::UInt  = get_world_counter();
                          #=opt_params::OptimizationParams=# opt_params,
                          #=results::IdDict{InferenceResult,AnyAnalysisResult}=# results,
                          #=report_stash::Vector{InferenceErrorReport}=# report_stash,
-                         #=cache_target::Union{Nothing,InferenceResult}=# nothing,
+                         #=cache_target::Union{Nothing,Pair{Symbol,InferenceState}}=# nothing,
                          #=concretized::BitVector=# concretized,
                          #=toplevelmod::Module=# toplevelmod,
                          #=global_slots::Dict{Int,Symbol}=# global_slots,

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -251,6 +251,23 @@ function CC.const_prop_call(analyzer::OptAnalyzer,
         nothing::Nothing)
 end
 
+function collect_callee_reports!(analyzer::OptAnalyzer, sv::InferenceState)
+    if analyzer.skip_unoptimized_throw_blocks && CC.is_stmt_throw_block(CC.get_curr_ssaflag(sv))
+        empty!(get_report_stash(analyzer))
+        return nothing
+    end
+    @invoke collect_callee_reports!(analyzer::AbstractAnalyzer, sv::InferenceState)
+    return nothing
+end
+function collect_cached_callee_reports!(analyzer::OptAnalyzer, reports::Vector{InferenceErrorReport},
+                                        caller::InferenceState, origin_mi::MethodInstance)
+    if !(analyzer.skip_unoptimized_throw_blocks && CC.is_stmt_throw_block(CC.get_curr_ssaflag(caller)))
+        @invoke collect_cached_callee_reports!(analyzer::AbstractAnalyzer, reports::Vector{InferenceErrorReport},
+                                               caller::InferenceState, origin_mi::MethodInstance)
+    end
+    return nothing
+end
+
 # TODO better to work only `CC.finish!`
 function CC.finish(frame::InferenceState, analyzer::OptAnalyzer)
     ret = @invoke CC.finish(frame::InferenceState, analyzer::AbstractAnalyzer)

--- a/test/analyzers/test_optanalyzer.jl
+++ b/test/analyzers/test_optanalyzer.jl
@@ -325,4 +325,14 @@ const issue560μ = zeros(Issue560Vec3, 2, 3, 4, 5)
 issue560f(μ) = reinterpret(reshape, Float64, μ)
 @test_opt issue560f(issue560μ)
 
+f_issue643_1(x) = throw("$x <- dynamic dispatches from this interpolation should be ignored")
+@noinline _f_issue643_2(x) = "$x <- dynamic dispatches from this interpolation should be ignored"
+f_issue643_2(x) = throw(_f_issue643_2(x))
+test_opt(f_issue643_1, (Any,))
+test_opt(f_issue643_1, (Any,)) # check cached case
+test_opt(f_issue643_2, (Any,))
+test_opt(f_issue643_2, (Any,)) # check cached case
+# the dynamic dispatch should be reported if the method is analyzed standalone
+@test !isempty(get_reports(report_opt(_f_issue643_2, (Any,))))
+
 end # module test_optanalyzer


### PR DESCRIPTION
In the analysis performed by `OptAnalyzer`, when the `skip_unoptimized_throw_blocks` configuration is enabled, dynamic dispatch on `throw` code path is supposed to be ignored. However, cached reports of non-inlined callees on the `throw` code path were not ignored, leading to confusion (#643). This commit addresses the issue by overloading the propagation of reports from callees in abstract interpretation.

While the issue has been resolved, the resulting code is quite hacky, and improvements to these interfaces are certainly desirable.