### PR TITLE
mv the reference material added in #652 to the `Analysis Result` section

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -48,6 +48,14 @@ JET.JETToplevelResult
 JET.JETCallResult
 ```
 
+### [Splitting and filtering reports](@id optanalysis-splitting)
+
+Both `JETToplevelResult` and `JETCallResult` can be split into individual failures for integration with tools like Cthulhu:
+```@docs
+JET.get_reports
+JET.reportkey
+```
+
 ## Error Report Interface
 
 ```@docs

--- a/docs/src/optanalysis.md
+++ b/docs/src/optanalysis.md
@@ -237,14 +237,6 @@ JET.@test_opt
 JET.test_opt
 ```
 
-### [Splitting and filtering reports](@id optanalysis-splitting)
-
-The output of `JET.@report_opt` can be split into individual failures for integration with tools like Cthulhu:
-```@docs
-JET.get_reports
-JET.reportkey
-```
-
 ### [Top-level Entry Points](@id optanalysis-toplevel-entry)
 
 By default, JET doesn't offer top-level entry points for the optimization analysis, because it's usually used for only a


### PR DESCRIPTION
Since `get_reports` is intended to be the general interface to get reports.