### PR TITLE
show multiple parse errors if exist

### DIFF
--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -13,8 +13,26 @@ include("../setup.jl")
 
         res = report_text(s)
         report = only(res.res.toplevel_error_reports)
-        @test report isa SyntaxErrorReport
+        @test report isa ParseErrorReport
         @test report.line == 5
+    end
+
+    # report multiple syntax errors if exist
+    let s = """
+        function f(W,X,Y)
+            s = 0
+            for i = 1:10
+                s += g(W[i]*f(X[end-1] + Y[end÷2+]),
+                    W[i+1]*f(X[end-2] + Y[end÷2]) +,
+                    W[i+2]*f(X[end-3] + Y[end÷2-3]))
+            end
+            return s
+        end
+        """ |> strip
+
+        res = report_text(s)
+        @test length(res.res.toplevel_error_reports) == 2
+        @test all(r -> r isa ParseErrorReport, res.res.toplevel_error_reports)
     end
 end
 

--- a/test/ui/test_print.jl
+++ b/test/ui/test_print.jl
@@ -19,17 +19,19 @@ end
         res = report_text(src, @__FILE__)
         print_reports(io, res.res.toplevel_error_reports)
         let s = String(take!(io))
-            @test occursin("1 toplevel error found", s)
+            @test occursin("2 toplevel errors found", s)
             @test occursin(Regex("@ $(@__FILE__):\\d"), s)
             @test occursin("invalid identifier", s)
+            @test occursin("Expected `end`", s)
         end
 
         res = report_text(src, "foo")
         print_reports(io, res.res.toplevel_error_reports)
         let s = String(take!(io))
-            @test occursin("1 toplevel error found", s)
+            @test occursin("2 toplevel errors found", s)
             @test occursin(r"@ foo:\d", s)
             @test occursin("invalid identifier", s)
+            @test occursin("Expected `end`", s)
         end
     end
 end


### PR DESCRIPTION
> multisyntaxerrors.jl
```julia
function f(W,X,Y)
    s = 0
    for i = 1:10
        s += g(W[i]*f(X[end-1] + Y[end÷2+]),
               W[i+1]*f(X[end-2] + Y[end÷2]) +,
               W[i+2]*f(X[end-3] + Y[end÷2-3]))
    end
    return s
end
```
```julia
julia> report_file("../JETLS/multisyntaxerrors.jl")
[...]
═════ 2 toplevel errors found ═════
┌ @ multisyntaxerrors.jl:4
│ # Error @ multisyntaxerrors.jl:4:42
│     for i = 1:10
│         s += g(W[i]*f(X[end-1] + Y[end÷2+]),
│ #                                        ╙ ── unexpected `]`
└──────────────────────
┌ @ multisyntaxerrors.jl:5
│ # Error @ multisyntaxerrors.jl:5:47
│         s += g(W[i]*f(X[end-1] + Y[end÷2+]),
│                W[i+1]*f(X[end-2] + Y[end÷2]) +,
│ #                                             ╙ ── unexpected `,`
└──────────────────────
```