### PR TITLE
allow PkgEval to try to load JET always

### DIFF
--- a/src/JET.jl
+++ b/src/JET.jl
@@ -4,7 +4,9 @@ using Preferences: Preferences
 
 const JET_DEV_MODE = Preferences.@load_preference("JET_DEV_MODE", false)
 
-const JET_LOADABLE = JET_DEV_MODE || (get(VERSION.prerelease, 1, "") != "DEV")
+const PKG_EVAL = Base.get_bool_env("JULIA_PKGEVAL", false)
+
+const JET_LOADABLE = JET_DEV_MODE || PKG_EVAL || (get(VERSION.prerelease, 1, "") != "DEV")
 
 # exports
 # =======


### PR DESCRIPTION
PkgEval uses pre-release Julia builds, although JET currently rejects them.
