### PR TITLE
introduce `ToplevelAbstractAnalyzer` interface specialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowing external packages to subtype it and customize the behavior of `virtual_process(interp::JET.ConcreteInterpreter, ...)`.
   Please note that this is still undocumented and is a highly experimental interface.
   Currently, it is being experimentally used in the [JETLS](https://github.com/aviatesk/JETLS.jl) project. (aviatesk/JET.jl#721).
+- Introduced `ToplevelAbstractAnalyzer` interface type that extends `AbstractAnalyzer` to provide
+  clear separation between analyzers that support top-level analysis and those that don't.
+  This architectural improvement ensures type safety by restricting `virtual_process` usage to
+  analyzers that explicitly extend `ToplevelAbstractAnalyzer`, while keeping non-toplevel 
+  analyzers like `OptAnalyzer` free from toplevel-specific logic (aviatesk/JET.jl#722).
 
 ## [0.10.6]
 ### Changed

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -39,7 +39,7 @@ using JET: CC            # to inject a customized report pass
 # First off, we define `UnstableAPIAnalyzer`, which is a new [`AbstractAnalyzer`](@ref) and will
 # implement the customized report pass
 
-struct UnstableAPIAnalyzer{T} <: AbstractAnalyzer
+struct UnstableAPIAnalyzer{T} <: ToplevelAbstractAnalyzer
     state::AnalyzerState
     analysis_token::AnalysisToken
     is_target_module::T
@@ -69,7 +69,7 @@ function CC.abstract_eval_special_value(analyzer::UnstableAPIAnalyzer, @nospecia
     end
 
     ## recurse into JET's default abstract interpretation routine
-    return @invoke CC.abstract_eval_special_value(analyzer::AbstractAnalyzer, e, vtypes::CC.VarTable, sv::CC.InferenceState)
+    return @invoke CC.abstract_eval_special_value(analyzer::ToplevelAbstractAnalyzer, e, vtypes::CC.VarTable, sv::CC.InferenceState)
 end
 
 function CC.builtin_tfunction(analyzer::UnstableAPIAnalyzer, @nospecialize(f), argtypes::Vector{Any}, sv::CC.InferenceState)
@@ -88,7 +88,7 @@ function CC.builtin_tfunction(analyzer::UnstableAPIAnalyzer, @nospecialize(f), a
     end
 
     ## recurse into JET's default abstract interpretation routine
-    return @invoke CC.builtin_tfunction(analyzer::AbstractAnalyzer, f, argtypes::Vector{Any}, sv::CC.InferenceState)
+    return @invoke CC.builtin_tfunction(analyzer::ToplevelAbstractAnalyzer, f, argtypes::Vector{Any}, sv::CC.InferenceState)
 end
 
 # Additionally, we can cut off the performance cost involved with Julia's native compiler's optimizations passes:

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -906,7 +906,7 @@ function analyze_and_report_text!(interp::ConcreteInterpreter, text::AbstractStr
                                   filename::AbstractString = "top-level",
                                   pkgid::Union{Nothing,PkgId} = nothing;
                                   jetconfigs...)
-    analyzer = AbstractAnalyzer(interp)
+    analyzer = ToplevelAbstractAnalyzer(interp)
     validate_configs(analyzer, jetconfigs)
     config = ToplevelConfig(pkgid; jetconfigs...)
     res = virtual_process(interp, text, filename, config)
@@ -919,7 +919,7 @@ function analyze_and_report_expr!(interp::ConcreteInterpreter, x::Union{JS.Synta
                                   filename::AbstractString = "top-level",
                                   pkgid::Union{Nothing,PkgId} = nothing;
                                   jetconfigs...)
-    analyzer = AbstractAnalyzer(interp)
+    analyzer = ToplevelAbstractAnalyzer(interp)
     validate_configs(analyzer, jetconfigs)
     config = ToplevelConfig(pkgid; jetconfigs...)
     if x isa Expr
@@ -1192,7 +1192,7 @@ end
 
 reexport_as_api!(JETInterface,
     # AbstractAnalyzer API
-    AbstractAnalyzer, AnalyzerState, ReportPass, AnalysisToken,
+    AbstractAnalyzer, AnalyzerState, AnalysisToken, ReportPass, ToplevelAbstractAnalyzer,
     valid_configurations, aggregation_policy, VSCode.vscode_diagnostics_order,
     # ErrorReport API
     InferenceErrorReport, ToplevelErrorReport, copy_report, print_report,


### PR DESCRIPTION
This commit introduces a new interface type `ToplevelAbstractAnalyzer` that
extends `AbstractAnalyzer` to provide clear separation between analyzers
that support top-level analysis and those that don't.

Key benefits:
- Type safety: Only analyzers that explicitly extend 
  `ToplevelAbstractAnalyzer` can be used with `virtual_process`, making it
  clear which analyzers support top-level analysis capabilities
- Responsibility separation: Analyzers like `OptAnalyzer` that don't 
  perform top-level analysis no execute top-level specific code paths,
  reducing complexity and analysis performance a bit
- Interface clarity: The type system now explicitly documents which 
  analyzers are designed to work with JET's virtual process system

Implementation changes:
- Add `ToplevelAbstractAnalyzer` abstract type with comprehensive docs
- Update `JETAnalyzer` to inherit from `ToplevelAbstractAnalyzer`
- Refactor method signatures to use `ToplevelAbstractAnalyzer` for 
  top-level specific functionality (global bindings, const declarations,
  module-level constructs)
- Update `ConcreteInterpreter` interface accordingly
- Move toplevel-specific constructor from `AbstractAnalyzer`

This architectural improvement ensures that only analyzers explicitly
designed for top-level analysis can participate in `virtual_process`,
while keeping non-toplevel analyzers free from toplevel-specific logic.
