### PR TITLE
Attempt to fix compatibility with `Base.@deprecate_binding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- links end -->
 
 ## [Unreleased]
+### Changed
+- Fixed compatibility with `Base.@deprecate_binding` macro, which before
+  could trigger an internal error in packages using it.
 
 ## [0.10.7]
 ### Changed

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -1640,6 +1640,12 @@ function _to_simple_module_usages(x::Expr)
         return Expr[Expr(x.head, arg) for arg in x.args]
     end
     arg = only(x.args)
+    if isexpr(arg, :escape) && isa(only(arg.args), Symbol)
+        # Base.@deprecate_binding produces expressions of
+        # the form  :(export $(Expr(:escape, :a)))
+        arg = only(arg.args)
+        return Expr[Expr(x.head, arg)]
+    end
     if isa(arg, Symbol)
         # `export a`, `public a`
         return Expr[x]

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -118,6 +118,8 @@ end
         Expr[:(export a), :(export b)]
     @test JET.to_simple_module_usages(:(export a)) ==
         Expr[:(export a)]
+    @test JET.to_simple_module_usages(:(export $(Expr(:escape, :a)))) ==
+        Expr[:(export a)]
     @test JET.to_simple_module_usages(:(import Pkg as P)) ==
         Expr[:(import Pkg as P)]
     @test JET.to_simple_module_usages(:(using A)) ==


### PR DESCRIPTION
This attempts to fix #733 but doesn't quite work. I am not sure why: the error itself is addressed, but I think the `export` statements are still not handled right. So I guess one has to better understand what `Base.@deprecate_binding` does and why it causes the problems in JET that it does...