### PR TITLE
module filtering: include submodules by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Revise with `using Revise` before use.
 - Enabled the [ad-hoc concrete evaluation](https://github.com/JuliaLang/julia/pull/59908)
   in `JETAnalyzer` for Julia v1.13 and higher, reducing false positives in more general cases
+- **Module filtering behavior change**: `target_modules` and `ignored_modules`
+  now include submodules by default (aviatesk/JET.jl#628):
+  - **Submodule-inclusive filtering**: When a `Module` object is passed to
+    `target_modules` or `ignored_modules`, JET now matches not only that exact
+    module but also all of its submodules. This provides more intuitive
+    filtering behavior in most use cases.
+  - **Breaking change**: This changes the filtering behavior when
+    `target_modules` or `ignored_modules` accept an iterator of modules.
+    To preserve the previous exact-match behavior (matching only the specified
+    module without its submodules), wrap the module with `LastFrameModuleExact`
+    or `AnyFrameModuleExact`:
+    ```julia
+    # New default (v0.11+): matches MyPackage and all its submodules
+    report_call(f, args...; target_modules=(MyPackage,))
+
+    # Previous behavior (v0.10): matched only MyPackage exactly
+    # To preserve this in v0.11+, use:
+    report_call(f, args...; target_modules=(LastFrameModuleExact(MyPackage),))
+    ```
+  - New matcher types:
+    - `ReportMatcher`: abstract interface type for `JET.match_report`
+    - `LastFrameModuleExact`: exact match in last frame only
+    - `AnyFrameModuleExact`: exact match in any frame
 
 ### Deprecated
 - `report_package(::AbstractString)`, `report_package([::Nothing])`:

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -21,7 +21,7 @@ const exports = Set{Symbol}((
     # optanalyzer
     Symbol("@report_opt"), :report_opt, Symbol("@test_opt"), :test_opt,
     # configurations
-    :LastFrameModule, :AnyFrameModule
+    :ReportMatcher, :LastFrameModule, :AnyFrameModule, :LastFrameModuleExact, :AnyFrameModuleExact
 ))
 
 for exported_name in exports

--- a/test/analyzers/test_jetanalyzer.jl
+++ b/test/analyzers/test_jetanalyzer.jl
@@ -852,42 +852,6 @@ end
     end
 end
 
-@testset "configured_reports" begin
-    M = Module()
-    @eval M begin
-        function foo(a)
-            r1 = sum(a)       # => Base: MethodError(+(::Char, ::Char)), MethodError(zero(::Type{Any}))
-            r2 = undefsum(a)  # => @__MODULE__: UndefVarError(:undefsum)
-            return r1, r2
-        end
-    end
-
-    let result = @report_call M.foo("julia")
-        test_sum_over_string(result)
-        @test any(r->is_global_undef_var(r, :undefsum), get_reports_with_test(result))
-    end
-
-    let result = @report_call target_modules=(M,) M.foo("julia")
-        r = only(get_reports_with_test(result))
-        @test is_global_undef_var(r, :undefsum)
-    end
-
-    let result = @report_call target_modules=(AnyFrameModule(M),) M.foo("julia")
-        test_sum_over_string(result)
-        @test any(r->is_global_undef_var(r, :undefsum), get_reports_with_test(result))
-    end
-
-    let result = @report_call ignored_modules=(Base,) M.foo("julia")
-        r = only(get_reports_with_test(result))
-        @test is_global_undef_var(r, :undefsum)
-    end
-
-    let result = @report_call ignored_modules=(M,) M.foo("julia")
-        test_sum_over_string(result)
-        @test !any(r->is_global_undef_var(r, :undefsum), get_reports_with_test(result))
-    end
-end
-
 issue363(f, args...) = f(args...)
 func_report_entry(a::Int) = "hello"
 


### PR DESCRIPTION
This commit changes the behavior of `target_modules` and `ignored_modules` configurations to include submodules by default when given `Module` objects. This provides more intuitive filtering behavior for most use cases.

Key changes:
- Introduced `ReportMatcher` abstract type and concrete matcher types: `LastFrameModule`, `AnyFrameModule`, `LastFrameModuleExact`, and `AnyFrameModuleExact`
- Bare `Module` objects are automatically wrapped in `LastFrameModule`, which matches the module and all its submodules
- Implemented `issubmodule()` helper function to check module hierarchy
- Updated `configured_reports()` to use the new matcher system
- Exported new matcher types for fine-grained filtering control

Breaking change: Users who need exact module matching (previous behavior) should wrap modules with `LastFrameModuleExact` or `AnyFrameModuleExact`.

Fixes aviatesk/JET.jl#628