### PR TITLE
module filtering: add Symbol-based filtering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled the [ad-hoc concrete evaluation](https://github.com/JuliaLang/julia/pull/59908)
   in `JETAnalyzer` for Julia v1.13 and higher, reducing false positives in more general cases
 - **Module filtering behavior change**: `target_modules` and `ignored_modules`
-  now include submodules by default (aviatesk/JET.jl#628):
+  now include submodules by default (aviatesk/JET.jl#628, aviatesk/JET.jl#772):
   - **Submodule-inclusive filtering**: When a `Module` object is passed to
     `target_modules` or `ignored_modules`, JET now matches not only that exact
     module but also all of its submodules. This provides more intuitive
@@ -109,6 +109,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `ReportMatcher`: abstract interface type for `JET.match_report`
     - `LastFrameModuleExact`: exact match in last frame only
     - `AnyFrameModuleExact`: exact match in any frame
+
+### Added
+- **Symbol-based module filtering**: `target_modules` and `ignored_modules` now
+  accept `Symbol` in addition to `Module` objects (aviatesk/JET.jl#602, aviatesk/JET.jl#773).
+  This allows filtering by module name without requiring the module as a dependency:
+  ```julia
+  # Filter by module name without loading CUDA package
+  report_call(f, args...; ignored_modules=(:CUDA,))
+
+  # Equivalent to passing the Module object (if CUDA is loaded)
+  report_call(f, args...; ignored_modules=(CUDA,))
+  ```
+  All matcher types (`LastFrameModule`, `AnyFrameModule`, `LastFrameModuleExact`,
+  `AnyFrameModuleExact`) now accept `Union{Module,Symbol}`.
 
 ### Deprecated
 - `report_package(::AbstractString)`, `report_package([::Nothing])`:

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -421,9 +421,13 @@ These configurations are always active.
   either of the data types below that match [`report::InferenceErrorReport`](@ref InferenceErrorReport)'s
   context module as follows:
   - `m::Module` or `JET.LastFrameModule(m::Module)`: matches if the module context of `report`'s innermost stack frame is `m` or any of its submodules
-  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
+  - `name::Symbol` or `JET.LastFrameModule(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is `name` or any of its parent modules is named `name`
   - `JET.AnyFrameModule(m::Module)`: matches if the module context of any of `report`'s stack frames is `m` or any of its submodules
+  - `JET.AnyFrameModule(name::Symbol)`: matches if the module name of any of `report`'s stack frames is `name` or any of its parent modules is named `name`
+  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
+  - `JET.LastFrameModuleExact(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is exactly `name`
   - `JET.AnyFrameModuleExact(m::Module)`: matches if the module context of any of `report`'s stack frames is exactly `m`, excluding submodules
+  - `JET.AnyFrameModuleExact(name::Symbol)`: matches if the module name of any of `report`'s stack frames is exactly `name`
   - user-type `T <: JET.ReportMatcher`: matches according to user-definition overload `match_report(::T, report::InferenceErrorReport)`
 ---
 - `ignored_modules = nothing` \\
@@ -435,9 +439,13 @@ These configurations are always active.
   either of the data types below that match [`report::InferenceErrorReport`](@ref InferenceErrorReport)'s
   context module as follows:
   - `m::Module` or `JET.LastFrameModule(m::Module)`: matches if the module context of `report`'s innermost stack frame is `m` or any of its submodules
-  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
+  - `name::Symbol` or `JET.LastFrameModule(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is `name` or any of its parent modules is named `name`
   - `JET.AnyFrameModule(m::Module)`: matches if the module context of any of `report`'s stack frames is `m` or any of its submodules
+  - `JET.AnyFrameModule(name::Symbol)`: matches if the module name of any of `report`'s stack frames is `name` or any of its parent modules is named `name`
+  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
+  - `JET.LastFrameModuleExact(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is exactly `name`
   - `JET.AnyFrameModuleExact(m::Module)`: matches if the module context of any of `report`'s stack frames is exactly `m`, excluding submodules
+  - `JET.AnyFrameModuleExact(name::Symbol)`: matches if the module name of any of `report`'s stack frames is exactly `name`
   - user-type `T <: JET.ReportMatcher`: matches according to user-definition overload `match_report(::T, report::InferenceErrorReport)`
 ---
 - `report_config = nothing` \\
@@ -501,6 +509,13 @@ julia> @report_call ignored_modules=(Base,) foo("julia")
 ┌ foo(a::String) @ Main ./REPL[14]:3
 │ `Main.undefsum` is not defined: r2 = undefsum(a::String)
 └────────────────────
+
+# alternatively, you can use Symbol to specify the module name without requiring it as a dependency:
+julia> @report_call ignored_modules=(:Base,) foo("julia")
+═════ 1 possible error found ═════
+┌ foo(a::String) @ Main ./REPL[14]:3
+│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+└────────────────────
 ```
 ---
 """
@@ -521,16 +536,16 @@ end
 abstract type ReportMatcher end
 
 struct LastFrameModule <: ReportMatcher
-    mod::Module
+    mod::Union{Module,Symbol}
 end
 struct AnyFrameModule <: ReportMatcher
-    mod::Module
+    mod::Union{Module,Symbol}
 end
 struct LastFrameModuleExact <: ReportMatcher
-    mod::Module
+    mod::Union{Module,Symbol}
 end
 struct AnyFrameModuleExact <: ReportMatcher
-    mod::Module
+    mod::Union{Module,Symbol}
 end
 
 function issubmodule(child::Module, parent::Module)
@@ -540,22 +555,45 @@ function issubmodule(child::Module, parent::Module)
     return issubmodule(pm, parent)
 end
 
+function issubmoduleof(mod::Module, name::Symbol)
+    nameof(mod) === name && return true
+    pm = parentmodule(mod)
+    pm === mod && return false
+    return issubmoduleof(pm, name)
+end
+
 function match_report(matcher::LastFrameModule, @nospecialize(report::InferenceErrorReport))
     m = linfomod(last(report.vst).linfo)
-    return issubmodule(m, matcher.mod)
+    mod = matcher.mod
+    return mod isa Module ? issubmodule(m, mod) : issubmoduleof(m, mod)
 end
 function match_report(matcher::AnyFrameModule, @nospecialize(report::InferenceErrorReport))
-    return any(report.vst) do vsf
-        issubmodule(linfomod(vsf.linfo), matcher.mod)
+    mod = matcher.mod
+    if mod isa Module
+        return any(report.vst) do vsf
+            issubmodule(linfomod(vsf.linfo), mod)
+        end
+    else
+        return any(report.vst) do vsf
+            issubmoduleof(linfomod(vsf.linfo), mod)
+        end
     end
 end
 function match_report(matcher::LastFrameModuleExact, @nospecialize(report::InferenceErrorReport))
     m = linfomod(last(report.vst).linfo)
-    return m === matcher.mod
+    mod = matcher.mod
+    return matcher.mod isa Module ? m === mod : nameof(m) === mod
 end
 function match_report(matcher::AnyFrameModuleExact, @nospecialize(report::InferenceErrorReport))
-    return any(report.vst) do vsf
-        linfomod(vsf.linfo) === matcher.mod
+    mod = matcher.mod
+    if mod isa Module
+        return any(report.vst) do vsf
+            linfomod(vsf.linfo) === mod
+        end
+    else
+        return any(report.vst) do vsf
+            nameof(linfomod(vsf.linfo)) === mod
+        end
     end
 end
 @noinline match_report(x::ReportMatcher, @nospecialize(_::InferenceErrorReport)) =

--- a/test/abstractinterpret/test_typeinfer.jl
+++ b/test/abstractinterpret/test_typeinfer.jl
@@ -674,6 +674,38 @@ end
             @test any(r->is_global_undef_var(r, :undefined_var), reports)
         end
     end
+
+    @testset "Symbol-based filtering" begin
+        let result = @report_call target_modules=(:BasicFiltering,) BasicFiltering.foo([1,2,3])
+            reports = get_reports_with_test(result)
+            @test length(reports) == 1
+            @test any(r->is_global_undef_var(r, :undefsum), reports)
+        end
+
+        let result = @report_call ignored_modules=(:Base,) BasicFiltering.foo([1,2,3])
+            reports = get_reports_with_test(result)
+            @test length(reports) == 1
+            @test any(r->is_global_undef_var(r, :undefsum), reports)
+        end
+
+        let result = @report_call target_modules=(LastFrameModule(:SubmoduleFiltering),) SubmoduleFiltering.parent_func("42")
+            reports = get_reports_with_test(result)
+            @test !isempty(reports)
+            @test any(r->is_global_undef_var(r, :undefined_var), reports)
+        end
+
+        let result = @report_call target_modules=(LastFrameModuleExact(:SubMod),) SubmoduleFiltering.parent_func("42")
+            reports = get_reports_with_test(result)
+            @test length(reports) == 1
+            @test any(r->is_global_undef_var(r, :undefined_var), reports)
+        end
+
+        let result = @report_call ignored_modules=(LastFrameModuleExact(:SubmoduleFiltering),) SubmoduleFiltering.parent_func("42")
+            reports = get_reports_with_test(result)
+            @test !isempty(reports)
+            @test any(r->is_global_undef_var(r, :undefined_var), reports)
+        end
+    end
 end
 
 end # module test_typeinfer


### PR DESCRIPTION
This commit adds support for Symbol-based module filtering in `target_modules` and `ignored_modules` configurations. Users can now filter reports by module name without requiring the module as a dependency.

Key changes:
- Updated all matcher types (`LastFrameModule`, `AnyFrameModule`, `LastFrameModuleExact`, `AnyFrameModuleExact`) to accept `Union{Module,Symbol}` instead of just `Module`
- Updated `match_report` functions to handle both Module and Symbol types, using `issubmoduleof()` for Symbol-based submodule matching and `nameof()` for exact name matching
- Updated documentation to reflect the new Symbol-based filtering capability with examples
- Added comprehensive test suite for Symbol-based filtering
- Updated CHANGELOG.md with feature description and usage examples

This solves the workflow problem where users had to add transitive dependencies to their Project.toml just to ignore reports from those modules (e.g., CUDA in indirect dependencies).

Fixes aviatesk/JET.jl#602