### PR TITLE
Adjustments for incoming Julia v1.12.7

### DIFF
--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -1,6 +1,9 @@
 # inter-procedural
 # ================
 
+const ABSTRACT_CALL_USES_VTYPES = hasmethod(CC.abstract_call_known,
+    Tuple{AbstractInterpreter,Any,ArgInfo,StmtInfo, Union{VarTable,Nothing},InferenceState,Int})
+
 function collect_callee_reports!(analyzer::AbstractAnalyzer, sv::InferenceState)
     reports = get_report_stash(analyzer)
     if !isempty(reports)
@@ -75,10 +78,26 @@ function CC.concrete_eval_call(analyzer::AbstractAnalyzer,
     return ret
 end
 
+@static if ABSTRACT_CALL_USES_VTYPES
+function CC.abstract_call_known(analyzer::AbstractAnalyzer,
+    @nospecialize(f), arginfo::ArgInfo, si::StmtInfo, vtypes::Union{VarTable,Nothing},
+    sv::InferenceState, max_methods::Int)
+    ret = @invoke CC.abstract_call_known(analyzer::AbstractInterpreter,
+        f::Any, arginfo::ArgInfo, si::StmtInfo, vtypes::Union{VarTable,Nothing},
+        sv::InferenceState, max_methods::Int)
+    return postprocess_abstract_call_known!(analyzer, ret, f, arginfo, sv)
+end
+else
 function CC.abstract_call_known(analyzer::AbstractAnalyzer,
     @nospecialize(f), arginfo::ArgInfo, si::StmtInfo, sv::InferenceState, max_methods::Int)
     ret = @invoke CC.abstract_call_known(analyzer::AbstractInterpreter,
         f::Any, arginfo::ArgInfo, si::StmtInfo, sv::InferenceState, max_methods::Int)
+    return postprocess_abstract_call_known!(analyzer, ret, f, arginfo, sv)
+end
+end
+
+function postprocess_abstract_call_known!(analyzer::AbstractAnalyzer, ret::Future,
+    @nospecialize(f), arginfo::ArgInfo, sv::InferenceState)
     f′ = Ref{Any}(f)
     function after_call_known(analyzer′::AbstractAnalyzer, sv′::InferenceState)
         analyze_task_parallel_code!(analyzer′, f′[], arginfo, sv′)

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -188,11 +188,28 @@ function CC.finish!(analyzer::JETAnalyzer, caller::InferenceState, validation_wo
     return @invoke CC.finish!(analyzer::ToplevelAbstractAnalyzer, caller::InferenceState, validation_world::UInt, time_before::UInt64)
 end
 
+@static if ABSTRACT_CALL_USES_VTYPES
 function CC.abstract_call_gf_by_type(analyzer::JETAnalyzer,
-    @nospecialize(func), arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype), sv::InferenceState,
-    max_methods::Int)
+    @nospecialize(func), arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
+    vtypes::Union{VarTable,Nothing}, sv::InferenceState, max_methods::Int)
     ret = @invoke CC.abstract_call_gf_by_type(analyzer::ToplevelAbstractAnalyzer,
-        func::Any, arginfo::ArgInfo, si::StmtInfo, atype::Any, sv::InferenceState, max_methods::Int)
+        func::Any, arginfo::ArgInfo, si::StmtInfo, atype::Any,
+        vtypes::Union{VarTable,Nothing}, sv::InferenceState, max_methods::Int)
+    return postprocess_abstract_call_gf_by_type!(analyzer, ret, arginfo, atype, sv)
+end
+else
+function CC.abstract_call_gf_by_type(analyzer::JETAnalyzer,
+    @nospecialize(func), arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
+    sv::InferenceState, max_methods::Int)
+    ret = @invoke CC.abstract_call_gf_by_type(analyzer::ToplevelAbstractAnalyzer,
+        func::Any, arginfo::ArgInfo, si::StmtInfo, atype::Any, sv::InferenceState,
+        max_methods::Int)
+    return postprocess_abstract_call_gf_by_type!(analyzer, ret, arginfo, atype, sv)
+end
+end
+
+function postprocess_abstract_call_gf_by_type!(analyzer::JETAnalyzer, ret::Future,
+    arginfo::ArgInfo, @nospecialize(atype), sv::InferenceState)
     atype′ = Ref{Any}(atype)
     function after_abstract_call_gf_by_type(analyzer′::JETAnalyzer, sv′::InferenceState)
         ret′ = ret[]
@@ -208,10 +225,25 @@ function CC.abstract_call_gf_by_type(analyzer::JETAnalyzer,
     return ret
 end
 
+@static if ABSTRACT_CALL_USES_VTYPES
+function CC.from_interprocedural!(analyzer::JETAnalyzer,
+    @nospecialize(rt), sv::InferenceState, arginfo::ArgInfo,
+    @nospecialize(maybecondinfo), vtypes::Union{VarTable,Nothing})
+    ret = @invoke CC.from_interprocedural!(analyzer::ToplevelAbstractAnalyzer,
+        rt::Any, sv::InferenceState, arginfo::ArgInfo, maybecondinfo::Any,
+        vtypes::Union{VarTable,Nothing})
+    return postprocess_from_interprocedural(analyzer, ret)
+end
+else
 function CC.from_interprocedural!(analyzer::JETAnalyzer,
     @nospecialize(rt), sv::InferenceState, arginfo::ArgInfo, @nospecialize(maybecondinfo))
     ret = @invoke CC.from_interprocedural!(analyzer::ToplevelAbstractAnalyzer,
         rt::Any, sv::InferenceState, arginfo::ArgInfo, maybecondinfo::Any)
+    return postprocess_from_interprocedural(analyzer, ret)
+end
+end
+
+function postprocess_from_interprocedural(analyzer::JETAnalyzer, @nospecialize(ret))
     if JETAnalyzerConfig(analyzer).ignore_missing_comparison
         # Widen the return type of comparison operator calls to ignore the possibility of
         # they returning `missing` when analyzing from top-level.
@@ -303,8 +335,24 @@ function concrete_eval_eligible_ignoring_overlay(result::MethodCallResult, argin
 end
 end # @static if VERSION ≥ v"1.13.0-DEV.1350" || VERSION ≥ v"1.12.2"
 
-function CC.abstract_invoke(analyzer::JETAnalyzer, arginfo::ArgInfo, si::StmtInfo, sv::InferenceState)
-    ret = @invoke CC.abstract_invoke(analyzer::ToplevelAbstractAnalyzer, arginfo::ArgInfo, si::StmtInfo, sv::InferenceState)
+@static if ABSTRACT_CALL_USES_VTYPES
+function CC.abstract_invoke(analyzer::JETAnalyzer, arginfo::ArgInfo, si::StmtInfo,
+    vtypes::Union{VarTable,Nothing}, sv::InferenceState)
+    ret = @invoke CC.abstract_invoke(analyzer::ToplevelAbstractAnalyzer,
+        arginfo::ArgInfo, si::StmtInfo, vtypes::Union{VarTable,Nothing}, sv::InferenceState)
+    return postprocess_abstract_invoke!(analyzer, ret, arginfo, sv)
+end
+else
+function CC.abstract_invoke(analyzer::JETAnalyzer, arginfo::ArgInfo, si::StmtInfo,
+    sv::InferenceState)
+    ret = @invoke CC.abstract_invoke(analyzer::ToplevelAbstractAnalyzer,
+        arginfo::ArgInfo, si::StmtInfo, sv::InferenceState)
+    return postprocess_abstract_invoke!(analyzer, ret, arginfo, sv)
+end
+end
+
+function postprocess_abstract_invoke!(analyzer::JETAnalyzer, ret::Future, arginfo::ArgInfo,
+    sv::InferenceState)
     function after_abstract_invoke(analyzer′::JETAnalyzer, sv′::InferenceState)
         ret′ = ret[]
         report_invalid_invoke!(analyzer′, sv′, ret′, arginfo.argtypes)


### PR DESCRIPTION
Adapt JET analyzer hooks to the Compiler.jl API that threads slot VarTable state through abstract-call helpers.

Detect the loaded Compiler.jl API shape so manifest-provided Compiler checkouts work even when Julia VERSION does not encode the change.