### PR TITLE
virtualprocess: Avoid latestworld-driven loop concretization

### DIFF
--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -1434,8 +1434,7 @@ function select_direct_requirement!(concretize, stmts, edges)
             LoweredCodeUtils.istypedef(stmt) ||   # don't abstract away type definitions
             (isexpr(stmt, :call) && length(stmt.args) ≥ 1 && stmt.args[1] == GlobalRef(Core, :_defaultctors)) ||
             ismoduleusage(stmt) || # module usages are handled by `ConcreteInterpreter`
-            isexpr(stmt, :globaldecl) ||
-            isexpr(stmt, :latestworld))
+            isexpr(stmt, :globaldecl))
             concretize[idx] = true
             continue
         end
@@ -1561,6 +1560,10 @@ function select_dependencies!(concretize::BitVector, src::CodeInfo, edges, cl)
         changed |= add_required_inplace!(concretize, src, edges, cl)
         changed |= add_ssa_preds!(concretize, src, edges, ())
 
+        # `:latestworld` only matters when concrete execution is already needed in the
+        # same block. By itself, it should not activate an otherwise abstract branch.
+        changed |= add_required_latestworld!(concretize, src, cfg)
+
         # Mark necessary control flows.
         changed |= LoweredCodeUtils.add_control_flow!(concretize, src, cfg, postdomtree)
         changed |= add_ssa_preds!(concretize, src, edges, ())
@@ -1572,6 +1575,25 @@ function select_dependencies!(concretize::BitVector, src::CodeInfo, edges, cl)
     LoweredCodeUtils.add_active_gotos!(concretize, src, cfg, postdomtree)
 
     nothing
+end
+
+islatestworld(@nospecialize stmt) = isexpr(stmt, :latestworld)
+
+function add_required_latestworld!(concretize::BitVector, src::CodeInfo, cfg::CC.CFG)
+    changed = false
+    for bb in cfg.blocks
+        stmts = bb.stmts
+        any(stmts) do idx::Int
+            return concretize[idx] && !islatestworld(src.code[idx])
+        end || continue
+        for idx in stmts
+            if islatestworld(src.code[idx]) && !concretize[idx]
+                concretize[idx] = true
+                changed = true
+            end
+        end
+    end
+    return changed
 end
 
 # TODO use proper world age for the lookups

--- a/test/toplevel/test_toplevel_inference.jl
+++ b/test/toplevel/test_toplevel_inference.jl
@@ -289,6 +289,24 @@ let res = @analyze_toplevel begin
     @test isempty(res.res.inference_error_reports)
 end
 
+@testset "top-level closure in abstract loop (aviatesk/JETLS.jl#555)" begin
+    res = @analyze_toplevel begin
+        function calc_kite_pos(turn_angle)
+            return [cos(turn_angle), sin(turn_angle), 0.0]
+        end
+
+        const THETA = [30, 45, 60, 75]
+        turn_angles = 0:1:360
+        ys_all = Vector{Vector{Float64}}()
+
+        for θ in THETA
+            push!(ys_all, [calc_kite_pos(deg2rad(ta))[2] for ta in turn_angles])
+        end
+    end
+    @test isempty(res.res.toplevel_error_reports)
+    @test isempty(res.res.inference_error_reports)
+end
+
 @testset "MissingConcretizationErrorReport" begin
     let res = @analyze_toplevel begin
             RandomType = rand((Bool,Int))

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1884,6 +1884,29 @@ end
             @test isconcrete(res, vmod, :isbar)
             @test isconcrete(res, vmod, :isbaz)
         end
+
+        # xref: https://github.com/aviatesk/JETLS.jl/issues/555
+        # An in-loop `:latestworld` (here emitted into the comprehension closure's `for` body)
+        # must not, on its own, force the loop's control flow (and thus `THETA`'s value)
+        # to be concretized. E2E counterpart in test/toplevel/test_toplevel_inference.jl.
+        let src = @src for θ in THETA
+                push!(ys_all, [calc_kite_pos(deg2rad(ta))[2] for ta in turn_angles])
+            end
+            slice = JET.select_statements(@__MODULE__, src)
+            found_def = found_iterate = false
+            for (i, stmt) in enumerate(src.code)
+                rhs = JET.isexpr(stmt, :(=)) ? stmt.args[2] : stmt
+                if JET.LoweredCodeUtils.ismethod(stmt) || JET.LoweredCodeUtils.istypedef(stmt)
+                    found_def = true
+                    @test slice[i]  # closure definition is concretized
+                elseif JET.is_known_call(rhs, :iterate, src.code)
+                    found_iterate = true
+                    @test !slice[i] # loop control flow stays abstract
+                end
+            end
+            @test found_def
+            @test found_iterate
+        end
     end
 
     @testset "concretize inplace operations" begin


### PR DESCRIPTION
Top-level loops that contain compiler-inserted `:latestworld` statements could force JET to concretize the loop iterator even when the loop body should otherwise stay abstract. For example:

```julia
const THETA = [30, 45, 60]
for theta in THETA
    [sin(x) for x in 1:3]
end
```

The comprehension creates a top-level closure method. JET selected the nearby `:latestworld` statement as a direct concretization requirement, then pulled in the loop control flow and tried to read the concrete value of `THETA`. Since top-level `const` assignments are normally represented abstractly, this produced a false
`MissingConcretizationErrorReport`.

Do not select `:latestworld` as a direct requirement. Instead, select it only when another statement in the same basic block already needs concrete execution, preserving world-age updates for selected method definitions without activating otherwise abstract loop bodies.

Added a regression test covering aviatesk/JETLS.jl#555. The change keeps the default policy of not eagerly evaluating arbitrary top-level `const` assignments.