### PR TITLE
config: Hide compiler parameter settings from users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- links start -->
-[Unreleased]: https://github.com/aviatesk/JET.jl/compare/v0.11.6...HEAD
+[Unreleased]: https://github.com/aviatesk/JET.jl/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/aviatesk/JET.jl/compare/v0.11.6...v0.12.0
 [0.11.6]: https://github.com/aviatesk/JET.jl/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/aviatesk/JET.jl/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/aviatesk/JET.jl/compare/v0.11.3...v0.11.4
@@ -59,6 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- links end -->
 
 ## [Unreleased]
+
+## [0.12.0]
+
+### Changed
+- **Breaking**: JET no longer accepts Julia compiler parameter keywords such as
+  `max_methods` and `inlining` as user-facing configuration options for analysis
+  entry points or `.JET.toml`; such keywords now throw `JETConfigError`.
 
 ## [0.11.6]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JET"
 uuid = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-version = "0.11.6"
+version = "0.12.0"
 authors = ["Shuhei Kadowaki <aviatesk@gmail.com>"]
 
 [workspace]

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -36,14 +36,6 @@ JET.configured_reports
 JET.ToplevelConfig
 ```
 
-## [Configurations for Abstract Interpretation](@id abstractinterpret-config)
-
-```@docs
-JET.JETInferenceParams
-JET.CC.InferenceParams
-JET.CC.OptimizationParams
-```
-
 ## [Print Configurations](@id print-config)
 
 ```@docs

--- a/examples/dispatch_analysis.jl
+++ b/examples/dispatch_analysis.jl
@@ -250,9 +250,6 @@ end
 # heuristic to intentionally _disable_ inference (and so succeeding optimizations too) in
 # order to ease [the latency problem, a.k.a. "first-time-to-plot"](https://julialang.org/blog/2020/08/invalidations/).
 # The report trace certainly suggests a dispatch was detected where `ArgumentError` can be thrown.
-# We can turn off the heuristic by turning off [the `unoptimize_throw_blocks::Bool` configuration](@ref abstractinterpret-config),
-# and this time any runtime dispatch won't be reported:
-@report_dispatch unoptimize_throw_blocks=false rand(1:1000) # nothing should be reported
 
 # Finally, let's see an example of very "type-instable" code maintained within `Base`.
 # Typically, anything involving I/O is written in a very dynamic way for good reasons,

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -185,7 +185,7 @@ function UnstableAPIAnalyzer(world::UInt = Base.get_world_counter();
     is_target_module = ==(@__MODULE__),
     jetconfigs...)
     state = AnalyzerState(world; jetconfigs...)
-    ## use a globalized code cache (, which is separated by `InferenceParams` configurations)
+    ## use a globalized code cache keyed by the analyzer's compiler parameters
     cache_key = JET.compute_hash(state.inf_params)
     analysis_token = get!(AnalysisToken, UNSTABLE_API_ANALYZER_CACHE, cache_key)
     return UnstableAPIAnalyzer(state, analysis_token, is_target_module)

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -929,7 +929,7 @@ When found, the configurations specified in the file will be applied.
 
 A configuration file can specify configurations like:
 ```toml
-aggressive_constant_propagation = false # turn off aggressive constant propagation
+analyze_from_definitions = true # analyze methods from their declared signatures
 ... # other configurations
 ```
 
@@ -1509,10 +1509,6 @@ const GENERAL_CONFIGURATIONS = Set{Symbol}((
     :vscode_console_output,
     # watch
     :revise_all, :revise_modules))
-for (Params, Func) = ((InferenceParams, JETInferenceParams),
-                      (OptimizationParams, JETOptimizationParams))
-    push!(GENERAL_CONFIGURATIONS, Base.kwarg_decl(only(methods(Func, (Params,))))...)
-end
 
 # interface
 # =========

--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -118,9 +118,9 @@ The mutable object that holds various states that are consumed by all [`Abstract
 If `NewAnalyzer` implements the `AbstractAnalyzer` interface, `NewAnalyzer` should implement
 this `AnalyzerState(analyzer::NewAnalyzer) -> AnalyzerState` interface.
 
-A new `AnalyzerState` is supposed to be constructed using the [general configurations](@ref) passed
-as keyword arguments `jetconfigs` of the [`NewAnalyzer(; jetconfigs...)`](@ref AbstractAnalyzer)
-constructor, and the constructed `AnalyzerState` is usually kept within `NewAnalyzer` itself:
+A new `AnalyzerState` is supposed to be constructed by the
+[`NewAnalyzer(; jetconfigs...)`](@ref AbstractAnalyzer) constructor, and the constructed
+`AnalyzerState` is usually kept within `NewAnalyzer` itself:
 ```julia
 function NewAnalyzer(world::UInt=Base.get_world_counter(); jetconfigs...)
     ...
@@ -170,10 +170,11 @@ set_cache_target!(analyzer::AbstractAnalyzer, target::Union{Nothing,Pair{Symbol,
 set_entry!(analyzer::AbstractAnalyzer, entry::Union{Nothing,MethodInstance}) = setfield!(AnalyzerState(analyzer), :entry, entry)
 
 # The main constructor used at analysis entries
-function AnalyzerState(world::UInt  = get_world_counter();
+function AnalyzerState(world::UInt = get_world_counter();
+                       inf_params::InferenceParams = InferenceParams(),
+                       opt_params::OptimizationParams = OptimizationParams(),
                        jetconfigs...)
-    inf_params = JETInferenceParams(; jetconfigs...)
-    opt_params = JETOptimizationParams(; jetconfigs...)
+    reject_abstract_interpretation_configs(jetconfigs)
     return AnalyzerState(#=world::UInt=# world,
                          #=inf_cache::Vector{InferenceResult}=# InferenceResult[],
                          #=inf_params::InferenceParams=# inf_params,
@@ -215,88 +216,20 @@ end
 # dummies for non-toplevel analysis
 const non_toplevel_concretized  = BitVector()
 
-"""
-Configurations for abstract interpretation performed by JET.
-These configurations will be active for all the entries.
+const ABSTRACT_INTERPRETATION_CONFIGURATIONS = Set{Symbol}((
+    fieldnames(InferenceParams)...,
+    fieldnames(OptimizationParams)...))
 
-You can configure any of the keyword parameters that [`$CC.InferenceParams`](@ref)
-or [`$CC.OptimizationParams`](@ref) can take, e.g. `max_methods`:
-```julia
-julia> methods(==, (Any,Nothing))
-# 3 methods for generic function "==" from Base:
- [1] ==(::Missing, ::Any)
-     @ missing.jl:75
- [2] ==(w::WeakRef, v)
-     @ gcutils.jl:4
- [3] ==(x, y)
-     @ Base.jl:127
-
-julia> report_call((Any,)) do x
-           # when we account for all the possible matching method candidates,
-           # `(::Missing == ::Nothing)::Missing` leads to an `NonBooleanCondErrorReport`
-           x == nothing ? :nothing : :some
-       end
-═════ 1 possible error found ═════
-┌ @ none:4 goto %4 if not x == nothing
-│ non-boolean `Missing` found in boolean context (1/2 union split): goto %4 if not (x::Any == nothing)::Union{Missing, Bool}
-└──────────
-
-julia> report_call((Any,); max_methods=1) do x
-           # since we limit `max_methods=1`, JET gives up analysis on `(x::Any == nothing)`
-           # and thus we won't get any error report
-           x == nothing ? :nothing : :some
-       end
-No errors detected
-```
-
-See also [`$CC.InferenceParams`](@ref) and [`$CC.OptimizationParams`](@ref).
-
-Listed below are selections of those parameters that can have a potent influence on JET analysis.
-
----
-- `ipo_constant_propagation::Bool = true` \\
-  Enables constant propagation in abstract interpretation.
-  It is _**highly**_ recommended that you keep this configuration `true` to get reasonable analysis result,
-  because constant propagation can cut off lots of false positive errorenous code paths and
-  thus produce more accurate and useful analysis results.
----
-- `aggressive_constant_propagation::Bool = true` \\
-  If `true`, JET will try to do constant propagation more "aggressively".
-  It can lead to more accurate analysis as explained above, but also it may incur a performance cost.
-  JET by default enables this configuration to get more accurate analysis result.
----
-"""
-function JETInferenceParams end
-function JETOptimizationParams end
-
-# define wrappers of `InferenceParams(...)` and `OptimizationParams(...)` that can accept JET configurations
-for (Params, Func) = ((InferenceParams, JETInferenceParams),
-                      (OptimizationParams, JETOptimizationParams))
-    params = Params()
-    param = Expr(:kw, Expr(:(::), :params, Params), CC.quoted(params))
-    kwargs = Expr[]
-    parameters = Symbol[]
-    for i = 1:nfields(params)
-        fname, ftype = fieldname(Params, i), fieldtype(Params, i)
-        push!(parameters, fname)
-        arg = Expr(:(::), fname, ftype)
-        default = Expr(:., :params, QuoteNode(fname))
-        push!(kwargs, Expr(:kw, arg, default))
+function reject_abstract_interpretation_configs(jetconfigs)
+    for (key, val) in jetconfigs
+        if key in ABSTRACT_INTERPRETATION_CONFIGURATIONS
+            valrepr = LazyPrinter(io::IO->show(io, val))
+            throw(JETConfigError(
+                lazy"Given unexpected configuration: `$key = $valrepr`", key, val))
+        end
     end
-    sig = Expr(:call, nameof(Func), Expr(:parameters, kwargs..., :(__jetconfigs...)), param)
-    call = Expr(:call, nameof(Params), parameters...)
-    body = Expr(:block, LineNumberNode(@__LINE__, @__FILE__), call)
-    def = Expr(:(=), sig, body)
-    Core.eval(@__MODULE__, def)
+    return nothing
 end
-
-# assert that the wrappers create same objects as the original constructors
-for (Params, Func) = ((InferenceParams, JETInferenceParams),
-                      (OptimizationParams, JETOptimizationParams))
-    @assert Params() == Func()
-end
-@assert JETInferenceParams(InferenceParams(); max_methods=1).max_methods == 1
-@assert !JETOptimizationParams(OptimizationParams(); inlining=false).inlining
 
 Base.show(io::IO, state::AnalyzerState) = print(io, typeof(state), "(...)")
 
@@ -394,15 +327,19 @@ Returns a set of names that are valid as a configuration for `analyzer`.
 `names` should be an iterator of `Symbol`.
 No validations are performed if `nothing` is returned.
 """
-valid_configurations(analyzer::AbstractAnalyzer) = nothing
+valid_configurations(::AbstractAnalyzer) = nothing
 
 function validate_configs(analyzer::AbstractAnalyzer, jetconfigs)
-    valid_keys = valid_configurations(analyzer)
+    return validate_configs(valid_configurations(analyzer), jetconfigs)
+end
+
+function validate_configs(valid_keys, jetconfigs)
     isnothing(valid_keys) && return nothing
     for (key, val) in jetconfigs
         if key ∉ valid_keys
             valrepr = LazyPrinter(io::IO->show(io,val))
-            throw(JETConfigError(lazy"Given unexpected configuration: `$key = $valrepr`", key, val))
+            throw(JETConfigError(
+                lazy"Given unexpected configuration: `$key = $valrepr`", key, val))
         end
     end
     return nothing

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1435,14 +1435,16 @@ function JETAnalyzer(world::UInt = Base.get_world_counter();
                      __cache_hash__::Any = nothing,
                      jetconfigs...)
     jetconfigs = kwargs_dict(jetconfigs)
-    set_if_missing!(jetconfigs, :aggressive_constant_propagation, true)
+    validate_configs(JET_ANALYZER_VALID_CONFIGURATIONS, jetconfigs)
     # Enable the `assume_bindings_static` option to terminate analysis a bit earlier when
     # there are undefined bindings detected. Note that this option will cause inference
     # cache inconsistency until JuliaLang/julia#40399 is merged. But the analysis cache of
     # JETAnalyzer has the same problem already anyway, so enabling this option does not
     # make the situation worse.
-    jetconfigs[:assume_bindings_static] = true
-    state = AnalyzerState(world; jetconfigs...)
+    inf_params = InferenceParams(;
+        aggressive_constant_propagation = true,
+        assume_bindings_static = true)
+    state = AnalyzerState(world; inf_params)
     config = JETAnalyzerConfig(; jetconfigs...)
     method_table = CachedMethodTable(OverlayMethodTable(state.world, JET_METHOD_TABLE))
 
@@ -1466,10 +1468,10 @@ end
 
 const JET_ANALYZER_CONFIGURATIONS = Set{Symbol}((
     :mode, :ignore_missing_comparison, :ignore_throws, :__cache_hash__))
+const JET_ANALYZER_VALID_CONFIGURATIONS =
+    GENERAL_CONFIGURATIONS ∪ JET_ANALYZER_CONFIGURATIONS
 
-let valid_keys = GENERAL_CONFIGURATIONS ∪ JET_ANALYZER_CONFIGURATIONS
-    @eval JETInterface.valid_configurations(::JETAnalyzer) = $valid_keys
-end
+JETInterface.valid_configurations(::JETAnalyzer) = JET_ANALYZER_VALID_CONFIGURATIONS
 
 # interactive
 # -----------

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -366,7 +366,9 @@ function OptAnalyzer(world::UInt = Base.get_world_counter();
     skip_noncompileable_calls::Bool = true,
     __cache_hash__::Any = nothing,
     jetconfigs...)
-    state = AnalyzerState(world; jetconfigs...)
+    jetconfigs = kwargs_dict(jetconfigs)
+    validate_configs(OPT_ANALYZER_VALID_CONFIGURATIONS, jetconfigs)
+    state = AnalyzerState(world)
     cache_key = compute_hash(state.inf_params, state.opt_params, OptAnalyzer,
                              skip_noncompileable_calls, __cache_hash__)
     cache_key = @invoke hash(function_filter::Any, cache_key::UInt) # HACK avoid dynamic dispatch
@@ -380,10 +382,10 @@ end
 
 const OPT_ANALYZER_CONFIGURATIONS = Set{Symbol}((
     :function_filter, :skip_noncompileable_calls, :__cache_hash__))
+const OPT_ANALYZER_VALID_CONFIGURATIONS =
+    GENERAL_CONFIGURATIONS ∪ OPT_ANALYZER_CONFIGURATIONS
 
-let valid_keys = GENERAL_CONFIGURATIONS ∪ OPT_ANALYZER_CONFIGURATIONS
-    @eval JETInterface.valid_configurations(::OptAnalyzer) = $valid_keys
-end
+JETInterface.valid_configurations(::OptAnalyzer) = OPT_ANALYZER_VALID_CONFIGURATIONS
 
 """
     report_opt(f, [types]; jetconfigs...) -> JETCallResult

--- a/test/analyzers/test_jetanalyzer.jl
+++ b/test/analyzers/test_jetanalyzer.jl
@@ -4,6 +4,9 @@ include("../setup.jl")
 
 @testset "configurations" begin
     @test_throws JET.JETConfigError report_call(function () end; mode=:badmode)
+    @test_throws JET.JETConfigError report_call(function () end; max_methods=1)
+    @test_throws JET.JETConfigError report_call(function () end; inlining=false)
+    @test_throws JET.JETConfigError JETAnalyzer(; max_methods=1)
 
     # cache key should be same for the same configurations
     let cache1 = JET.AnalysisToken(JETAnalyzer()),
@@ -11,15 +14,15 @@ include("../setup.jl")
         @test cache1 === cache2
     end
 
-    # cache key should be different for different configurations
-    let analyzer1 = JETAnalyzer(; max_methods=3),
-        analyzer2 = JETAnalyzer(; max_methods=4)
+    # cache key should be different for analyzer-specific configurations
+    let analyzer1 = JETAnalyzer(; ignore_throws=false),
+        analyzer2 = JETAnalyzer(; ignore_throws=true)
         cache1 = JET.AnalysisToken(analyzer1)
         cache2 = JET.AnalysisToken(analyzer2)
         @test cache1 !== cache2
     end
 
-    # configurations other than `InferenceParams` and analyzer mode
+    # configurations other than analyzer-specific configurations
     # shouldn't affect the cache key identity
     let analyzer1 = JETAnalyzer(; toplevel_logger=nothing),
         analyzer2 = JETAnalyzer(; toplevel_logger=IOBuffer())
@@ -37,37 +40,12 @@ include("../setup.jl")
     end
 
     # end to end test
-    let m = Module()
-        @eval m begin
-            foo(a::Val{1}) = 1
-            foo(a::Val{2}) = 2
-            foo(a::Val{3}) = 3
-            foo(a::Val{4}) = undefvar
-        end
-
-        # run first analysis and cache
-        result = @eval m $report_call((Int,); max_methods=3) do a
-            foo(Val(a))
-        end
-        @test isempty(get_reports_with_test(result))
-
-        # should use the cached result
-        result = @eval m $report_call((Int,); max_methods=3) do a
-            foo(Val(a))
-        end
-        @test isempty(get_reports_with_test(result))
-
-        # should re-run analysis, and should get a report
-        result = @eval m $report_call((Int,); max_methods=4) do a
-            foo(Val(a))
-        end
-        @test any(r->is_global_undef_var(r, :undefvar), get_reports_with_test(result))
-
-        # should run the cached previous result
-        result = @eval m $report_call((Int,); max_methods=4) do a
-            foo(Val(a))
-        end
-        @test any(r->is_global_undef_var(r, :undefvar), get_reports_with_test(result))
+    let result = report_call(()->throw("foo"); ignore_throws=false)
+        @test !isempty(get_reports_with_test(result))
+        @test first(get_reports_with_test(result)) isa UncaughtExceptionReport
+    end
+    let result = report_call(()->throw("foo"); ignore_throws=true)
+        @test isempty(get_reports(result))
     end
 end
 

--- a/test/analyzers/test_optanalyzer.jl
+++ b/test/analyzers/test_optanalyzer.jl
@@ -85,8 +85,6 @@ end
     end
 
     # real-world targets
-    # the `unoptimize_throw_blocks` configuration disables optimizations on "throw blocks" by default,
-    # but `DispatchAnalyzer` ignores problems from them, so we don't get error reports here
     @test_opt sin(10)
 end
 
@@ -195,6 +193,10 @@ function target_modules_compute(x)
 end
 
 @testset "OptAnalyzer configurations" begin
+    @test_throws JET.JETConfigError report_opt(identity, (Any,); max_methods=1)
+    @test_throws JET.JETConfigError report_opt(identity, (Any,); inlining=false)
+    @test_throws JET.JETConfigError JET.OptAnalyzer(; max_methods=1)
+
     @testset "function_filter" begin
         @assert JET.InferenceParams(JET.OptAnalyzer()).max_union_splitting < 5
 


### PR DESCRIPTION
Compiler `InferenceParams` and `OptimizationParams` keywords are no longer accepted as public JET configurations. Calls such as `report_call(...; max_methods=1)` and `report_opt(...; inlining=false)` now fail with `JETConfigError` instead of mutating compiler internals through the user-facing config surface.

Remove those compiler parameters from `GENERAL_CONFIGURATIONS` and the documentation. Analyzer constructors now validate the public configuration set before building `AnalyzerState`, while `JETAnalyzer` keeps its internal compiler-parameter defaults explicitly.

This is part of the `0.12.0` minor version bump. `test_jetanalyzer` passed; `test_optanalyzer` was started but interrupted by the user before completion.