### PR TITLE
typeinfer: Drop redundant eager add of cached callee reports

### DIFF
--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -466,12 +466,6 @@ function add_new_report!(analyzer::AbstractAnalyzer, result::InferenceResult, @n
     return report
 end
 
-function add_cached_report!(analyzer::AbstractAnalyzer, caller::InferenceResult, @nospecialize(cached::InferenceErrorReport))
-    cached = copy_report_stable(cached)
-    push!(get_reports(analyzer, caller), cached)
-    return cached
-end
-
 stash_report!(analyzer::AbstractAnalyzer, @nospecialize(report::InferenceErrorReport)) = push!(get_report_stash(analyzer), report)
 stash_reports!(analyzer::AbstractAnalyzer, reports::Vector{InferenceErrorReport}) = append!(get_report_stash(analyzer), reports)
 

--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -17,15 +17,21 @@ function collect_callee_reports!(analyzer::AbstractAnalyzer, sv::InferenceState)
     return nothing
 end
 
-function collect_cached_callee_reports!(analyzer::AbstractAnalyzer, reports::Vector{InferenceErrorReport},
-                                        caller::InferenceState, origin_mi::MethodInstance)
+# Restore each cached report as a fresh copy — the cached report is shared on the callee's
+# `CodeInstance` and must not be mutated by the re-rooting `pushfirst!` in
+# `collect_callee_reports!` — and stash it. Insertion into the caller's result and re-rooting
+# onto the caller frame both happen there, uniformly with freshly inferred callee reports.
+function collect_cached_callee_reports!(
+        analyzer::AbstractAnalyzer, reports::Vector{InferenceErrorReport},
+        origin_mi::MethodInstance
+    )
     for cached in reports
-        restored = add_cached_report!(analyzer, caller.result, cached)
+        restored = copy_report_stable(cached)
         @static if JET_DEV_MODE
             actual, expected = first(restored.vst).linfo, origin_mi
             @assert actual === expected "invalid local cache restoration, expected $expected but got $actual"
         end
-        stash_report!(analyzer, restored) # should be updated in `abstract_call_method_with_const_args`
+        stash_report!(analyzer, restored)
     end
     return nothing
 end
@@ -258,7 +264,7 @@ function CC.get(wvc::WorldView{<:AbstractAnalyzerView}, mi::MethodInstance, defa
     # XXX move this logic into `typeinf_edge`?
     cache_target = get_cache_target(analyzer)
     if cache_target !== nothing
-        context, caller = cache_target
+        context, _ = cache_target
         if context === :typeinf_edge
             if isa(codeinst, CodeInstance)
                 # cache hit, now we need to append cached reports associated with this `MethodInstance`
@@ -266,7 +272,7 @@ function CC.get(wvc::WorldView{<:AbstractAnalyzerView}, mi::MethodInstance, defa
                     analysis_result isa CachedAnalysisResult ? analysis_result.reports : nothing
                 end
                 cached_reports !== nothing &&
-                    collect_cached_callee_reports!(analyzer, cached_reports, caller, mi)
+                    collect_cached_callee_reports!(analyzer, cached_reports, mi)
             end
         end
         set_cache_target!(analyzer, nothing)
@@ -321,7 +327,7 @@ function CC.cache_lookup(𝕃ᵢ::CC.AbstractLattice, mi::MethodInstance, given_
             analysis_result isa CachedAnalysisResult ? analysis_result.reports : nothing
         end
         cached_reports !== nothing &&
-            collect_cached_callee_reports!(analyzer, cached_reports, caller, mi)
+            collect_cached_callee_reports!(analyzer, cached_reports, mi)
     end
     return inf_result
 end


### PR DESCRIPTION
On a cache hit, `collect_cached_callee_reports!` restored each cached report into the caller's result via `add_cached_report!` and also stashed it for re-rooting. `collect_callee_reports!` then re-rooted that same object and added it again, so the report landed in the caller's result twice and relied on the `unique!` in `finish_frame!` to collapse the duplicate. This also made the cached and fresh paths asymmetric: at `collect_callee_reports!` time a cached report was already present in the caller's result, while a freshly inferred one was not.

Make `collect_cached_callee_reports!` only copy and stash, leaving `collect_callee_reports!` as the sole inserter for both paths. The copy is still required because the cached report is shared on the callee's `CodeInstance` and must not be mutated by the re-rooting `pushfirst!`. Drop the now-unused `caller` parameter and the `add_cached_report!` helper (its only caller).

Behavior is unchanged: the eager add was redundant from the commit that introduced it, since `collect_callee_reports!` already re-inserted and `unique!` removed the duplicate. The full test suite passes.