### PR TITLE
abstractinterpret: Preserve reports from distinct callsites

### DIFF
--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -78,7 +78,7 @@ function CC.concrete_eval_call(analyzer::AbstractAnalyzer,
     if ret isa ConstCallResult
         # this frame has been concretized, now we throw away reports collected
         # during the previous non-constant, abstract-interpretation
-        filter_lineages!(analyzer, sv.result, result.edge.def)
+        filter_lineages!(analyzer, sv, result.edge.def)
     end
     return ret
 end
@@ -321,7 +321,7 @@ function CC.cache_lookup(𝕃ᵢ::CC.AbstractLattice, mi::MethodInstance, given_
         # with the extended lattice elements, here we should throw-away the error reports
         # that are collected during the previous non-constant abstract-interpretation
         # (see the `CC.typeinf(::AbstractAnalyzer, ::InferenceState)` overload)
-        filter_lineages!(analyzer, caller.result, mi)
+        filter_lineages!(analyzer, caller, mi)
 
         cached_reports = CC.traverse_analysis_results(inf_result) do @nospecialize analysis_result
             analysis_result isa CachedAnalysisResult ? analysis_result.reports : nothing
@@ -347,7 +347,7 @@ function CC.typeinf(analyzer::AbstractAnalyzer, frame::InferenceState)
         # throw-away the error reports that are collected during the previous non-constant abstract-interpretation
         # NOTE that the `linfo` here is the exactly same object as the method instance used
         # for the previous non-constant abstract-interpretation
-        filter_lineages!(analyzer, parent.result, CC.frame_instance(frame))
+        filter_lineages!(analyzer, parent, CC.frame_instance(frame))
     end
 
     ret = @invoke CC.typeinf(analyzer::AbstractInterpreter, frame::InferenceState)
@@ -356,17 +356,17 @@ function CC.typeinf(analyzer::AbstractAnalyzer, frame::InferenceState)
 end
 
 """
-    islineage(parent::MethodInstance, current::MethodInstance) ->
+    islineage(parent_frame::VirtualFrame, current::MethodInstance) ->
         (report::InferenceErrorReport) -> Bool
 
 Returns a function that checks if a given `InferenceErrorReport`
 - is generated from `current`, and
-- is "lineage" of `parent` (i.e. entered from it).
+- is "lineage" of `parent_frame` (i.e. entered from it).
 
-This function is supposed to be used when additional analysis with extended lattice information
-happens in order to filter out reports collected from `current` by analysis without
-using that extended information. When a report should be filtered out, the first virtual
-stack frame represents `parent` and the second does `current`.
+This function is supposed to be used when additional analysis with extended lattice
+information happens in order to filter out reports collected from `current` by analysis
+without using that extended information. When a report should be filtered out, the first
+virtual stack frame should match `parent_frame` and the second should represent `current`.
 
 Example:
 ```
@@ -377,26 +377,29 @@ entry
    │  └─ linfo2 (report2: linfo2)
    └─ linfo3′ (~~report2: linfo3->linfo2~~)
 ```
-In the example analysis above, `report2` should be filtered out on re-entering into `linfo3′`
-(i.e. when we're analyzing `linfo3` with constant arguments), nevertheless `report1` shouldn't
-because it is not detected within `linfo3` but within `linfo1` (so it's not a "lineage of `linfo3`"):
-- `islineage(linfo1, linfo3)(report2) === true`
-- `islineage(linfo1, linfo3)(report1) === false`
+In the example analysis above, `report2` should be filtered out on re-entering into
+`linfo3′` (i.e. when we're analyzing `linfo3` with constant arguments), nevertheless
+`report1` shouldn't because it is not detected within `linfo3` but within `linfo1`
+(so it's not a "lineage of `linfo3`"):
+- `islineage(vf1, linfo3)(report2) === true`, where `vf1` is `linfo1`'s frame at
+  the callsite of `linfo3`
+- `islineage(vf1, linfo3)(report1) === false`
 """
-function islineage(parent::MethodInstance, current::MethodInstance)
+function islineage(parent_frame::VirtualFrame, current::MethodInstance)
     function (report::InferenceErrorReport)
         @nospecialize report
-        @inbounds begin
-            vst = report.vst
-            length(vst) > 1 || return false
-            vst[1].linfo === parent || return false
-            return vst[2].linfo === current
-        end
+        vst = report.vst
+        return length(vst) > 1 && vst[1] == parent_frame && vst[2].linfo === current
     end
 end
 
-function filter_lineages!(analyzer::AbstractAnalyzer, caller::InferenceResult, current::MethodInstance)
-     filter!(!islineage(caller.linfo, current), get_reports(analyzer, caller))
+function filter_lineages!(
+        analyzer::AbstractAnalyzer, caller::InferenceState, current::MethodInstance
+    )
+    reports = get_reports(analyzer, caller.result)
+    isempty(reports) && return
+    parent_frame = get_virtual_frame(caller)
+    filter!(!islineage(parent_frame, current), reports)
 end
 
 function contains_edge(edges::Vector{Any}, edge::MethodInstance)

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -175,7 +175,7 @@ function CC.const_prop_call(analyzer::OptAnalyzer,
     if concrete_eval_result !== nothing
         # HACK disable the whole `OptAnalyzer` analysis as far as the frame has been concretized
         # (otherwise we may end up with useless reports from recursive calls)
-        filter_lineages!(analyzer, sv.result, result.edge.def)
+        filter_lineages!(analyzer, sv, result.edge.def)
     end
     return ret
 end

--- a/test/abstractinterpret/test_typeinfer.jl
+++ b/test/abstractinterpret/test_typeinfer.jl
@@ -300,6 +300,35 @@ end
         @test any(r->isa(r,MethodErrorReport), get_reports_with_test(result))
     end
 
+    # The `foo(x)` report should survive const-prop filtering for `foo(1)`.
+    # Filtering only by `linfo` would discard reports from both callsites.
+    let result = Core.eval(Module(), quote
+            foo(a) = a < 0 ? a + string(a) : a
+            function bar(x)
+                r1 = foo(x)
+                r2 = foo(1)
+                return r1, r2
+            end
+            $report_call(bar, (Int,))
+        end)
+        reports = get_reports_with_test(result)
+        @test length(reports) === 1
+        report = only(reports)
+        @test report isa MethodErrorReport
+        @test report.t === Tuple{typeof(+), Int, String}
+    end
+
+    # FIXME Same-line callsites of the same callee can't be distinguished by the
+    # (file, line, linfo) key: const-prop filtering for `foo(1)` still discards
+    # the report from `foo(x)` written on the same line.
+    let result = Core.eval(Module(), quote
+            foo(a) = a < 0 ? a + string(a) : a
+            bar(x) = (foo(x), foo(1))
+            $report_call(bar, (Int,))
+        end)
+        @test_broken length(get_reports_with_test(result)) === 1
+    end
+
     let result = Core.eval(Module(), quote
             foo(a) = a<0 ? a+string(a) : a
             function bar(b)


### PR DESCRIPTION
Filtering const-prop reports only by caller `MethodInstance` can drop reports from another callsite in the same caller when both invoke the same callee.

Use the caller current virtual frame when filtering lineages so the filter matches the specific callsite being re-analyzed, not every callsite in that method.

A regression test covers distinct-line callsites, and a broken test documents the remaining same-line callsite limitation.