### PR TITLE
lineinfo: Avoid `_get_lin` vector allocation

### DIFF
--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -214,12 +214,54 @@ get_stmt((sv, pc)::StateAtPC) = sv.src.code[pc]
 get_lin((sv, pc)::StateAtPC) = _get_lin(sv, pc)
 _get_lin(sv, pc) = _get_lin(sv.linfo, sv.src, pc)
 function _get_lin(mi::MethodInstance, src::CodeInfo, pc::Int)
-    # TODO optimize the allocation here for un-optimized debuginfo
-    lins = CC.IRShow.buildLineInfoNode(src.debuginfo, mi, pc)
-    if isempty(lins)
-        return LineInfoNode(mi, src.debuginfo.def::Symbol, mi.def.line)
+    lin = _first_lin(src.debuginfo, mi, pc)
+    lin === nothing || return lin
+    return LineInfoNode(mi, src.debuginfo.def::Symbol, mi.def.line)
+end
+function _first_lin(debuginfo::Core.DebugInfo, @nospecialize(def), pc::Int)
+    lin, doupdate = _first_lin_impl(nothing, debuginfo, def, pc)
+    return doupdate ? lin : nothing
+end
+function _first_lin_impl(firstlin::Union{Nothing,LineInfoNode},
+                         debuginfo::Core.DebugInfo, @nospecialize(def), pc::Int)
+    doupdate = true
+    while true
+        debuginfo.def isa Symbol || (def = debuginfo.def)
+        codeloc = CC.getdebugidx(debuginfo, pc)
+        line = Int(codeloc[1])
+        inl_to = Int(codeloc[2])
+        doupdate &= line != 0 || inl_to != 0
+        if debuginfo.linetable === nothing || pc <= 0 || line < 0
+            if line < 0
+                doupdate = false
+                line = 0
+            end
+            if firstlin === nothing
+                firstlin = LineInfoNode(def, _debuginfo_file1(debuginfo), Int32(line))
+            end
+        else
+            firstlin, linetable_update = _first_lin_impl(firstlin,
+                debuginfo.linetable::Core.DebugInfo, def, line)
+            doupdate = linetable_update && doupdate
+        end
+        inl_to == 0 && return firstlin, doupdate
+        def = :var"macro expansion"
+        debuginfo = debuginfo.edges[inl_to]::Core.DebugInfo
+        pc = Int(codeloc[3])
     end
-    return first(lins)
+end
+function _debuginfo_file1(debuginfo::Core.DebugInfo)
+    def = debuginfo.def
+    if def isa MethodInstance
+        def = def.def
+    end
+    if def isa Method
+        def = def.file
+    end
+    if def isa Symbol
+        return def
+    end
+    return :var"<unknown>"
 end
 function get_lins((sv, pc)::StateAtPC)
     return CC.IRShow.buildLineInfoNode(sv.src.debuginfo, sv.linfo, pc)

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -2,6 +2,75 @@ module test_misc
 
 using JET, Test
 
+function lineinfo_codelocs(locs::NTuple{3,Int32}...; firstline::Int32=Int32(0))
+    data = Vector{Int32}(undef, 3length(locs))
+    for (i, loc) in pairs(locs)
+        data[3i - 2] = loc[1]
+        data[3i - 1] = loc[2]
+        data[3i] = loc[3]
+    end
+    return ccall(:jl_compress_codelocs, Any,
+        (Int32, Any, Int), firstline, data, length(locs))::String
+end
+lineinfo_loc(line::Int, to::Int=0, pc::Int=0) =
+    (Int32(line), Int32(to), Int32(pc))
+
+function reference_get_lin(mi::Core.MethodInstance, src::Core.CodeInfo, pc::Int)
+    lins = JET.CC.IRShow.buildLineInfoNode(src.debuginfo, mi, pc)
+    if isempty(lins)
+        return JET.CC.IRShow.LineInfoNode(
+            mi, src.debuginfo.def::Symbol, mi.def.line)
+    end
+    return first(lins)
+end
+
+lineinfo_sample(x::Int) = x + 1
+function lineinfo_source(debuginfo::Core.DebugInfo)
+    src = copy(only(code_typed(lineinfo_sample, (Int,); optimize=false))[1])
+    mi = src.parent::Core.MethodInstance
+    src.debuginfo = debuginfo
+    return mi, src
+end
+
+@testset "line info" begin
+    direct = Core.DebugInfo(:direct_file, nothing, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(10), lineinfo_loc(20)))
+    let (mi, src) = lineinfo_source(direct)
+        @test JET._get_lin(mi, src, 1) == reference_get_lin(mi, src, 1)
+        @test JET._get_lin(mi, src, 2) == reference_get_lin(mi, src, 2)
+    end
+
+    empty = Core.DebugInfo(:empty_file, nothing, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(0)))
+    let (mi, src) = lineinfo_source(empty)
+        @test JET._get_lin(mi, src, 1) == reference_get_lin(mi, src, 1)
+    end
+
+    linetable = Core.DebugInfo(:linetable_file, nothing, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(42)))
+    indirect = Core.DebugInfo(:indirect_file, linetable, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(1)))
+    let (mi, src) = lineinfo_source(indirect)
+        @test JET._get_lin(mi, src, 1) == reference_get_lin(mi, src, 1)
+    end
+
+    edge = Core.DebugInfo(:edge_file, nothing, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(30)))
+    inlined = Core.DebugInfo(:inlined_file, nothing, Core.svec(edge),
+        lineinfo_codelocs(lineinfo_loc(10, 1, 1)))
+    let (mi, src) = lineinfo_source(inlined)
+        @test JET._get_lin(mi, src, 1) == reference_get_lin(mi, src, 1)
+    end
+
+    invalid_edge = Core.DebugInfo(:invalid_edge_file, nothing, Core.svec(),
+        lineinfo_codelocs(lineinfo_loc(30)))
+    invalid_inlined = Core.DebugInfo(:invalid_inlined_file, nothing,
+        Core.svec(invalid_edge), lineinfo_codelocs(lineinfo_loc(10, 1, 2)))
+    let (mi, src) = lineinfo_source(invalid_inlined)
+        @test JET._get_lin(mi, src, 1) == reference_get_lin(mi, src, 1)
+    end
+end
+
 @testset "report_call entry" begin
     @test_throws ErrorException("Could not find single target method for `sin(::String)`") report_call(sin, (String,))
     @test_throws ErrorException("Could not find single target method for `sin(::String)`") @report_call sin("julia")


### PR DESCRIPTION
JET locates report sites by asking `Compiler.IRShow.buildLineInfoNode` and taking the first entry. That helper always allocates a `Vector` even when `_get_lin` only needs a single LineInfoNode.

Walk `Core.DebugInfo` directly in JETBase and track the same update semantics as append_scopes!, including nested linetables, inlining edges, and fallback behavior.

Tests in test/test_misc.jl compare `_get_lin` against the old `buildLineInfoNode`-based behavior for direct, indirect, inlined, and invalid debuginfo cases.

---

The cost of merging this PR is of course the more dependency on the Compiler internals.