### PR TITLE
optanalyzer: Analyze runtime dispatches on `IRCode`

### DIFF
--- a/examples/dispatch_analysis.jl
+++ b/examples/dispatch_analysis.jl
@@ -44,58 +44,65 @@
 # we will inspect the optimized IR and look for `:call` expressions. `:call` expressions are
 # such calls that were not resolved statically and will be dispatched at runtime (as opposed
 # to [`:invoke`](https://docs.julialang.org/en/v1/devdocs/ast/#Expr-types) expressions, that
-# represent staticall resolved generic function calls).
+# represent statically resolved generic function calls).
 #
-# We will define `DispatchAnalyzer <: AbstractAnalyzer`, and overload some of `Base.Compiler` methods with it:
-# - `CC.finish(frame::CC.InferenceState, analyzer::DispatchAnalyzer)` to check if optimization will happen or not (the case 1.)
-# - `CC.finish!(analyzer::DispatchAnalyzer, caller::CC.InferenceResult)` to inspect an optimized IR (the case 2.)
+# We will define `DispatchAnalyzer <: AbstractAnalyzer` and overload two Julia
+# compiler methods:
+# - `CC.optimize` to inspect the final optimized IR (case 2)
+# - `CC.finish!` to check whether optimization happened (case 1)
 
 using JET.JETInterface
-using JET: JET, CC
+using JET: CC, JET
 
 struct DispatchAnalyzer{T} <: AbstractAnalyzer
     state::AnalyzerState
     analysis_token::AnalysisToken
-    opts::BitVector
-    frame_filter::T # a predicate, which takes `CC.InfernceState` and returns whether we want to analyze the call or not
+    frame_filter::T # a predicate over `Core.MethodInstance`
 end
 
 ## AbstractAnalyzer API requirements
 JETInterface.AnalyzerState(analyzer::DispatchAnalyzer) = analyzer.state
-JETInterface.AbstractAnalyzer(analyzer::DispatchAnalyzer, state::AnalyzerState) = DispatchAnalyzer(state, analyzer.analysis_token, analyzer.opts, analyzer.frame_filter)
+function JETInterface.AbstractAnalyzer(
+        analyzer::DispatchAnalyzer, state::AnalyzerState
+    )
+    return DispatchAnalyzer(state, analyzer.analysis_token, analyzer.frame_filter)
+end
 JETInterface.AnalysisToken(analyzer::DispatchAnalyzer) = analyzer.analysis_token
 
-function CC.finish!(analyzer::DispatchAnalyzer, frame::CC.InferenceState, validation_world::UInt, time_before::UInt64)
+function CC.optimize(
+        analyzer::DispatchAnalyzer, opt::CC.OptimizationState,
+        caller::CC.InferenceResult
+    )
+    ret = @invoke CC.optimize(
+        analyzer::CC.AbstractInterpreter, opt::CC.OptimizationState,
+        caller::CC.InferenceResult)
+    if analyzer.frame_filter(caller.linfo)
+        state = JET.OptimizedIRState(opt, JET.optimized_ir(opt))
+        report_runtime_dispatch!(analyzer, caller, state)
+    end
+    return ret
+end
+
+function CC.finish!(
+        analyzer::DispatchAnalyzer, frame::CC.InferenceState,
+        validation_world::UInt, time_before::UInt64
+    )
     caller = frame.result
-
-    ## get the source before running `finish!` to keep the reference to `OptimizationState`
-    src = caller.src
-    if src isa CC.OptimizationState
-        ## allow the following analysis passes to see the optimized `CodeInfo`
-        caller.src = CC.ir_to_codeinf!(src)
-        frame.edges = collect(Any, caller.src.edges)
+    if caller.src === nothing && analyzer.frame_filter(caller.linfo)
+        report_optimization_failure!(analyzer, caller)
     end
-
-    if analyzer.frame_filter(frame.linfo)
-        if isa(src, Core.Const) # the optimization was very successful, nothing to report
-        elseif isnothing(src) # means, compiler decides not to do optimization
-            report_optimization_failure!(analyzer, caller, src)
-        elseif isa(src, CC.OptimizationState) # the compiler optimized it, analyze it
-            report_runtime_dispatch!(analyzer, caller, src)
-        else # and thus this pass should never happen
-            ## as we should already report `OptimizationFailureReport` for this case
-            throw("got $src, unexpected source found")
-        end
-    end
-
-    return @invoke CC.finish!(analyzer::AbstractAnalyzer, frame::CC.InferenceState, validation_world::UInt, time_before::UInt64)
+    return @invoke CC.finish!(
+        analyzer::AbstractAnalyzer, frame::CC.InferenceState,
+        validation_world::UInt, time_before::UInt64)
 end
 
 @jetreport struct OptimizationFailureReport <: InferenceErrorReport end
 function JETInterface.print_report_message(io::IO, ::OptimizationFailureReport)
     print(io, "failed to optimize due to recursion")
 end
-function report_optimization_failure!(analyzer::DispatchAnalyzer, result::CC.InferenceResult, src)
+function report_optimization_failure!(
+        analyzer::DispatchAnalyzer, result::CC.InferenceResult
+    )
     add_new_report!(analyzer, result, OptimizationFailureReport(result.linfo))
 end
 
@@ -104,13 +111,17 @@ function JETInterface.print_report_message(io::IO, ::RuntimeDispatchReport)
     print(io, "runtime dispatch detected")
 end
 
-function report_runtime_dispatch!(analyzer::DispatchAnalyzer, caller::CC.InferenceResult, opt::CC.OptimizationState)
-    (; sptypes, slottypes) = opt
-    for (pc, x) in enumerate(opt.src.code)
-        if Base.Meta.isexpr(x, :call)
-            ft = CC.widenconst(CC.argextype(first(x.args), opt.src, sptypes, slottypes))
+function report_runtime_dispatch!(
+        analyzer::DispatchAnalyzer, caller::CC.InferenceResult,
+        state::JET.OptimizedIRState
+    )
+    ir = state.ir
+    for (pc, inst) in enumerate(ir.stmts)
+        stmt = inst[:stmt]
+        if Base.Meta.isexpr(stmt, :call)
+            ft = CC.widenconst(CC.argextype(first(stmt.args), ir))
             ft <: Core.Builtin && continue # ignore `:call`s of the builtin intrinsics
-            add_new_report!(analyzer, caller, RuntimeDispatchReport((opt, pc)))
+            add_new_report!(analyzer, caller, RuntimeDispatchReport((state, pc)))
         end
     end
 end
@@ -127,11 +138,11 @@ const global_analysis_token = AnalysisToken()
 ## the constructor for creating a new configured `DispatchAnalyzer` instance
 function DispatchAnalyzer(world::UInt = Base.get_world_counter();
     analysis_token::AnalysisToken = global_analysis_token,
-    frame_filter = x::Core.MethodInstance->true,
+    frame_filter = ::Core.MethodInstance->true,
     jetconfigs...)
     state = AnalyzerState(world; jetconfigs...)
     ## just for the sake of simplicity, create a fresh code cache for each `DispatchAnalyzer` instance (i.e. don't globalize the cache)
-    return DispatchAnalyzer(state, analysis_token, BitVector(), frame_filter)
+    return DispatchAnalyzer(state, analysis_token, frame_filter)
 end
 function report_dispatch(args...; jetconfigs...)
     @nospecialize args jetconfigs

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -51,43 +51,55 @@ JETInterface.AnalysisToken(analyzer::UnstableAPIAnalyzer) = analyzer.analysis_to
 
 const UNSTABLE_API_ANALYZER_CACHE = Dict{UInt, AnalysisToken}()
 
-# Next, we overload some of `Base.Compiler`'s [abstract interpretation](@ref abstractinterpret) methods.
+# Next, we overload some of the Julia compiler's
+# [abstract interpretation](@ref abstractinterpret) methods.
 # In this analysis, we are interested in whether a binding that appears in a target code is
 # an "unstable API" or not, and we can simply check if each abstract element appeared during
 # abstract interpretation meets our criteria of "unstable API".
-# For that purpose, it's suffice to overload `CC.abstract_eval_special_value`
-# and `CC.builtin_tfunction`.
+# For that purpose, it is sufficient to overload `CC.abstract_eval_special_value`
+# and `CC.abstract_eval_getglobal`.
 
-function CC.abstract_eval_special_value(analyzer::UnstableAPIAnalyzer, @nospecialize(e), vtypes::CC.VarTable, sv::CC.InferenceState)
+function CC.abstract_eval_special_value(
+        analyzer::UnstableAPIAnalyzer, @nospecialize(e), sstate::CC.StatementState,
+        sv::CC.InferenceState
+    )
     if analyzer.is_target_module(sv.mod) # we care only about what we wrote
         report_unstable_api!(analyzer, sv, e)
     end
 
     ## recurse into JET's default abstract interpretation routine
-    return @invoke CC.abstract_eval_special_value(analyzer::ToplevelAbstractAnalyzer, e, vtypes::CC.VarTable, sv::CC.InferenceState)
+    return @invoke CC.abstract_eval_special_value(
+        analyzer::ToplevelAbstractAnalyzer, e::Any, sstate::CC.StatementState,
+        sv::CC.InferenceState)
 end
 
-function CC.builtin_tfunction(analyzer::UnstableAPIAnalyzer, @nospecialize(f), argtypes::Vector{Any}, sv::CC.InferenceState)
-    if f === getfield
-        if length(argtypes) ≥ 2
-            a1, a2 = argtypes[1:2]
-            if isa(a1, Core.Const) && (v1 = a1.val; isa(v1, Module))
-                if isa(a2, Core.Const) && (v2 = a2.val; isa(v2, Symbol))
-                    if analyzer.is_target_module(sv.mod) || # we care only about what we wrote, but with relaxed filter
-                       (parent = sv.parent; isa(parent, CC.InferenceState) && analyzer.is_target_module(parent.mod))
-                        report_unstable_api!(analyzer, sv, GlobalRef(v1, v2))
-                    end
+function CC.abstract_eval_getglobal(
+        analyzer::UnstableAPIAnalyzer, sv::CC.InferenceState,
+        saw_latestworld::Bool, argtypes::Vector{Any}
+    )
+    if length(argtypes) ≥ 3
+        a1, a2 = argtypes[2:3]
+        if isa(a1, Core.Const) && (v1 = a1.val; isa(v1, Module))
+            if isa(a2, Core.Const) && (v2 = a2.val; isa(v2, Symbol))
+                if analyzer.is_target_module(sv.mod) || # relaxed filter
+                   (parent = CC.frame_parent(sv);
+                    parent isa CC.InferenceState &&
+                    analyzer.is_target_module(parent.mod))
+                    report_unstable_api!(analyzer, sv, GlobalRef(v1, v2))
                 end
             end
         end
     end
 
     ## recurse into JET's default abstract interpretation routine
-    return @invoke CC.builtin_tfunction(analyzer::ToplevelAbstractAnalyzer, f, argtypes::Vector{Any}, sv::CC.InferenceState)
+    return @invoke CC.abstract_eval_getglobal(
+        analyzer::ToplevelAbstractAnalyzer, sv::CC.InferenceState,
+        saw_latestworld::Bool, argtypes::Vector{Any})
 end
 
-# Additionally, we can cut off the performance cost involved with Julia's native compiler's optimizations passes:
-CC.may_optimize(analyzer::UnstableAPIAnalyzer) = false
+# Additionally, we can avoid the performance cost of Julia compiler optimization
+# passes:
+CC.may_optimize(::UnstableAPIAnalyzer) = false
 
 # Now we implement the body of our analysis.
 # We define "unstable API"s such that they're:
@@ -115,6 +127,7 @@ function report_unstable_api!(analyzer::UnstableAPIAnalyzer, sv, @nospecialize(e
         isdefined(mod, name) || return false # this global reference falls into the category 1, should be caught by `UndefVarErrorReport` instead
 
         mod = Base.binding_module(mod, name)
+        isdefinedglobal(mod, name) || return false
         analyzer.is_target_module(mod) && return # we don't care about what we defined ourselves
 
         if isunstable(mod, name)

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -206,14 +206,21 @@ end
 
 # state
 
-const State     = Union{InferenceState,OptimizationState}
+struct OptimizedIRState
+    opt::OptimizationState
+    ir::CC.IRCode
+end
+
+const State     = Union{InferenceState,OptimizedIRState}
 const StateAtPC = Tuple{State,Int}
 const LineTable = Union{Vector{Any},Vector{LineInfoNode}}
 
-get_stmt((sv, pc)::StateAtPC) = sv.src.code[pc]
+get_stmt((sv, pc)::Tuple{InferenceState,Int}) = sv.src.code[pc]
+get_stmt((sv, pc)::Tuple{OptimizedIRState,Int}) = sv.ir.stmts[pc][:stmt]
 get_lin((sv, pc)::StateAtPC) = _get_lin(sv, pc)
-_get_lin(sv, pc) = _get_lin(sv.linfo, sv.src, pc)
-function _get_lin(mi::MethodInstance, src::CodeInfo, pc::Int)
+_get_lin(sv::InferenceState, pc::Int) = _get_lin(sv.linfo, sv.src, pc)
+_get_lin(sv::OptimizedIRState, pc::Int) = _get_lin(sv.opt.linfo, sv.ir, pc)
+function _get_lin(mi::MethodInstance, src::Union{CodeInfo,CC.IRCode}, pc::Int)
     # TODO optimize the allocation here for un-optimized debuginfo
     lins = CC.IRShow.buildLineInfoNode(src.debuginfo, mi, pc)
     if isempty(lins)
@@ -221,24 +228,35 @@ function _get_lin(mi::MethodInstance, src::CodeInfo, pc::Int)
     end
     return first(lins)
 end
-function get_lins((sv, pc)::StateAtPC)
+function get_lins((sv, pc)::Tuple{InferenceState,Int})
     return CC.IRShow.buildLineInfoNode(sv.src.debuginfo, sv.linfo, pc)
 end
-get_ssavaluetype((sv, pc)::StateAtPC) = (sv.src.ssavaluetypes::Vector{Any})[pc]
+function get_lins((sv, pc)::Tuple{OptimizedIRState,Int})
+    return CC.IRShow.buildLineInfoNode(sv.ir.debuginfo, sv.opt.linfo, pc)
+end
+get_ssavaluetype((sv, pc)::Tuple{InferenceState,Int}) =
+    (sv.src.ssavaluetypes::Vector{Any})[pc]
+get_ssavaluetype((sv, pc)::Tuple{OptimizedIRState,Int}) = sv.ir.stmts[pc][:type]
 
 get_slottype(s::Union{StateAtPC,State}, slot) = get_slottype(s, slot_id(slot))
 get_slottype((sv, _pc)::StateAtPC, slot::Int) = get_slottype(sv, slot)
-get_slottype(sv::State, slot::Int) = sv.slottypes[slot]
+get_slottype(sv::InferenceState, slot::Int) = sv.slottypes[slot]
+get_slottype(sv::OptimizedIRState, slot::Int) = sv.ir.argtypes[slot]
 
 get_slotname(s::Union{StateAtPC,State}, slot) = get_slotname(s, slot_id(slot))
-get_slotname((sv, _pc)::StateAtPC, slot::Int) = sv.src.slotnames[slot]
-get_slotname(sv::State, slot::Int) = sv.src.slotnames[slot]
+get_slotname((sv, _pc)::StateAtPC, slot::Int) = get_slotname(sv, slot)
+get_slotname(sv::InferenceState, slot::Int) = sv.src.slotnames[slot]
+get_slotname(sv::OptimizedIRState, slot::Int) = sv.opt.src.slotnames[slot]
+
+get_sparamtype(sv::InferenceState, i::Int) = sv.sptypes[i].typ
+get_sparamtype(sv::OptimizedIRState, i::Int) = sv.ir.sptypes[i].typ
 
 # check if we're in a toplevel module
-function istoplevelframe(sv::State)
-    sv isa OptimizationState && error("OptimizationState is not supported at top-level")
+function istoplevelframe(sv::InferenceState)
     return istoplevelframe(CC.frame_instance(sv))
 end
+istoplevelframe(::OptimizedIRState) =
+    error("OptimizedIRState is not supported at top-level")
 istoplevelframe(mi::MethodInstance) = isa(mi.def, Module)
 
 # we can retrieve program-counter-level slottype during inference
@@ -261,7 +279,8 @@ function is_compileable_mi(mi::MethodInstance)
     return CC.get_compileable_sig(def, mi.specTypes, mi.sparam_vals) !== nothing
 end
 
-get_linfo(sv::State) = sv.linfo
+get_linfo(sv::InferenceState) = sv.linfo
+get_linfo(sv::OptimizedIRState) = sv.opt.linfo
 get_linfo(result::InferenceResult) = result.linfo
 get_linfo(linfo::MethodInstance) = linfo
 

--- a/src/abstractinterpret/inferenceerrorreport.jl
+++ b/src/abstractinterpret/inferenceerrorreport.jl
@@ -72,8 +72,7 @@ const INFERENCE_ERROR_REPORT_FIELD_DECLS = [
 # get location information at the given program counter (or a current counter if not specified)
 function get_virtual_frame(state::StateAtPC)
     file, line = get_file_line(state)
-    linfo = isa(state, MethodInstance) ? state : first(state).linfo
-    return VirtualFrame(file, line, linfo)
+    return VirtualFrame(file, line, get_linfo(first(state)))
 end
 get_virtual_frame(sv::InferenceState) = get_virtual_frame((sv, get_currpc(sv)))
 get_virtual_frame(caller::InferenceResult) = get_virtual_frame(get_linfo(caller))
@@ -318,8 +317,8 @@ end
 function handle_sig_static_parameter!(sig::Vector{Any}, s::StateAtPC, expr::Expr)
     i = first(expr.args)::Int
     sv = first(s)
-    name = sparam_name((sv.linfo.def::Method).sig::UnionAll, i)
-    typ = widenconst(sv.sptypes[i].typ)
+    name = sparam_name((get_linfo(sv).def::Method).sig::UnionAll, i)
+    typ = widenconst(get_sparamtype(sv, i))
     push!(sig, String(name), typ)
     return sig, nothing
 end
@@ -335,8 +334,8 @@ end
 
 function handle_sig!(sig::Vector{Any}, (sv, _)::StateAtPC, ssa::SSAValue)
     newstate = (sv, ssa.id)
-    if isa(sv, OptimizationState)
-        # when working on `OptimizationState`, the SSA traverse could be really long because
+    if !(sv isa InferenceState)
+        # when working on optimized IR, the SSA traverse could be really long because
         # of inlining, so just give up for such a case
         typ = safewidenconst(get_ssavaluetype(newstate))
         push!(sig, ssa, typ)
@@ -421,7 +420,8 @@ function typeof_arg(s::State, @nospecialize(f); callable::Bool=false)
     isa(f, Function) && return Core.Typeof(f)
     isa(f, Type) && return Type{f}
     isa(f, QuoteNode) && return Core.Typeof(f.value)
-    isexpr(f, :static_parameter) && return Core.Typeof(s.sptypes[first(f.args)::Int])
+    isexpr(f, :static_parameter) &&
+        return Core.Typeof(get_sparamtype(s, first(f.args)::Int))
     callable && error("f ", string(f)::String, " with type ", string(typeof(f)), " not supported")   # FIXME self check runtime dispatch
     return typeof(f)
 end

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -133,18 +133,6 @@ struct OptAnalyzer{FF} <: AbstractAnalyzer
     analysis_token::AnalysisToken
     function_filter::FF
     skip_noncompileable_calls::Bool
-    __analyze_frame::BitVector # temporary stash to keep per-frame analysis-skip configuration
-
-    function OptAnalyzer(state::AnalyzerState,
-                         analysis_token::AnalysisToken,
-                         function_filter::FF,
-                         skip_noncompileable_calls::Bool) where {FF}
-        return new{FF}(state,
-                       analysis_token,
-                       function_filter,
-                       skip_noncompileable_calls,
-                       #=__analyze_frame=# BitVector())
-    end
 end
 
 # AbstractAnalyzer API requirements
@@ -209,95 +197,83 @@ function CC.finishinfer!(frame::InferenceState, analyzer::OptAnalyzer, cycleid::
 end
 end
 
+function is_analysis_target(analyzer::OptAnalyzer, caller::InferenceResult)
+    analyzer.skip_noncompileable_calls || return true
+    mi = caller.linfo
+    return is_compileable_mi(mi) || is_entry(analyzer, mi)
+end
+
+function should_analyze_initial(analyzer::OptAnalyzer, caller::InferenceResult)
+    is_analysis_target(analyzer, caller) || return false
+    return !CC.is_result_constabi_eligible(caller)
+end
+
 function finishinfer!_overload(frame::InferenceState, analyzer::OptAnalyzer)
-    analyze = true
-    if analyzer.skip_noncompileable_calls
-        mi = frame.linfo
-        if !(is_compileable_mi(mi) || is_entry(analyzer, mi))
-            analyze = false
-        end
-    end
-    if analyze && CC.is_result_constabi_eligible(frame.result)
-        analyze = false
+    caller = frame.result
+    is_analysis_target(analyzer, caller) || return nothing
+    if CC.is_result_constabi_eligible(caller)
         # turn off optimization for this frame in order to achieve a minor perf gain,
         # similar to the effect of setting `may_discard_trees(::OptAnalyzer) = true`
-        frame.result.src = nothing
-    end
-
-    push!(analyzer.__analyze_frame, analyze)
-    if analyze
-        # report pass for captured variables
+        caller.src = nothing
+    else
         report_captured_variable!(analyzer, frame)
     end
+    return nothing
 end
 
 # analysis injections
 # ===================
+
+function optimized_ir(opt::OptimizationState)
+    @static if isdefinedglobal(CC, :compute_inlining_cost)
+        return (opt.optresult::CC.OptimizationResult).ir
+    else
+        return opt.ir::CC.IRCode
+    end
+end
+
+function is_inlineable_optimized(
+        analyzer::OptAnalyzer, caller::InferenceResult, opt::OptimizationState
+    )
+    @static if isdefinedglobal(CC, :compute_inlining_cost)
+        optresult = opt.optresult::CC.OptimizationResult
+        return CC.compute_inlining_cost(analyzer, caller, optresult) != CC.MAX_INLINE_COST
+    else
+        return CC.is_inlineable(opt.src)
+    end
+end
+
+function should_analyze_optimized(
+        analyzer::OptAnalyzer, caller::InferenceResult, opt::OptimizationState
+    )
+    CC.is_result_constabi_eligible(caller) && return false
+    is_analysis_target(analyzer, caller) && return true
+    return is_inlineable_optimized(analyzer, caller, opt)
+end
+
+function CC.optimize(
+        analyzer::OptAnalyzer, opt::OptimizationState, caller::InferenceResult
+    )
+    ret = @invoke CC.optimize(
+        analyzer::AbstractInterpreter, opt::OptimizationState, caller::InferenceResult)
+    if should_analyze_optimized(analyzer, caller, opt)
+        state = OptimizedIRState(opt, optimized_ir(opt))
+        report_runtime_dispatch!(analyzer, caller, state)
+    end
+    return ret
+end
 
 function CC.finish!(
         analyzer::OptAnalyzer, frame::InferenceState, validation_world::UInt,
         time_before::UInt64
     )
     caller = frame.result
-
-    # get the source before running `finish!` to keep the reference to `OptimizationState`
-    analyze = popfirst!(analyzer.__analyze_frame)
-    src = caller.src
-    inlining_cost = nothing
-    if src isa OptimizationState
-        @static if isdefinedglobal(CC, :compute_inlining_cost)
-            inlining_cost = CC.compute_inlining_cost(analyzer, caller)
-        end
-        # allow the following analysis passes to see the optimized `CodeInfo`
-        caller.src = CC.ir_to_codeinf!(src)
-        @static if isdefinedglobal(CC, :compute_inlining_cost)
-            caller.src.inlining_cost = inlining_cost
-        end
-        frame.edges = collect(Any, caller.src.edges)
-
-        if !analyze
-            # if this inferred source is not "compileable" but still is going to be inlined,
-            # we should add report runtime dispatches within it
-            analyze = CC.is_inlineable(src.src)
-        end
-    end
-
-    if analyze
+    if should_analyze_initial(analyzer, caller)
         report_optimization_failure!(analyzer, caller)
-
-        if src isa OptimizationState
-            report_runtime_dispatch!(analyzer, caller, src)
-        elseif (@static JET_DEV_MODE ? true : false)
-            if src === nothing # the optimization didn't happen
-            else # and this pass should never happen
-                # NOTE `src` never be `CodeInfo` since `CC.may_discard_trees(::OptAnalyzer) === false`
-                Core.eval(@__MODULE__, :(src = $src))
-                throw("unexpected state happened, inspect `$(@__MODULE__).src`")
-            end
-        end
     end
-
-    # Restore the cost that upstream `finish!` cannot compute from a `CodeInfo`.
-    ret = @invoke CC.finish!(
+    return @invoke CC.finish!(
         analyzer::AbstractAnalyzer, frame::InferenceState, validation_world::UInt,
-        time_before::UInt64
-    )
-    @static if isdefinedglobal(CC, :compute_inlining_cost)
-        if inlining_cost !== nothing && caller.src isa CodeInfo
-            caller.src.inlining_cost = inlining_cost
-        end
-    end
-    return ret
-end
-
-# Upstream asks for the inlining cost again after `OptAnalyzer.finish!` has converted
-# the `OptimizationState` to `CodeInfo`. Return the cost already stored in the
-# `CodeInfo`, since upstream can no longer recompute it from the optimized IR.
-@static if isdefinedglobal(CC, :compute_inlining_cost)
-function CC.compute_inlining_cost(analyzer::OptAnalyzer, result::InferenceResult)
-    result.src isa CodeInfo && return result.src.inlining_cost
-    return @invoke CC.compute_inlining_cost(analyzer::AbstractAnalyzer, result::InferenceResult)
-end
+        time_before::UInt64)
 end
 
 # analysis
@@ -352,27 +328,29 @@ end
 function JETInterface.print_report_message(io::IO, ::RuntimeDispatchReport)
     print(io, "runtime dispatch detected")
 end
-function report_runtime_dispatch!(analyzer::OptAnalyzer, caller::InferenceResult, opt::OptimizationState)
-    (; src, sptypes, slottypes) = opt
-
-    # TODO better to work on `opt.ir::IRCode` (with some updates on `handle_sig!`)
+function report_runtime_dispatch!(
+        analyzer::OptAnalyzer, caller::InferenceResult, state::OptimizedIRState
+    )
+    ir = state.ir
     local reported = false
-    for (pc, x) in enumerate(src.code)
-        if isexpr(x, :call)
-            ft = argextype(first(x.args), src, sptypes, slottypes)
+    for (pc, inst) in enumerate(ir.stmts)
+        stmt = inst[:stmt]
+        if isexpr(stmt, :call)
+            ft = argextype(first(stmt.args), ir)
             f = singleton_type(ft)
             if f !== nothing
                 f isa Builtin && continue # ignore `:call`s of language intrinsics
-                (isnothing(analyzer.function_filter) || @invokelatest(analyzer.function_filter(f))) || continue # ignore user-specified functions
+                isnothing(analyzer.function_filter) ||
+                    @invokelatest(analyzer.function_filter(f)) || continue
             end
-            lins = get_lins((opt, pc))
+            lins = get_lins((state, pc))
             isempty(lins) && continue # dead statement, just ignore it
             if length(lins) > 1
                 # this statement has been inlined, so ignore it as any problems within
                 # that callee should already have been reported
                 continue
             end
-            add_new_report!(analyzer, caller, RuntimeDispatchReport((opt, pc)))
+            add_new_report!(analyzer, caller, RuntimeDispatchReport((state, pc)))
             reported |= true
         end
     end

--- a/test/analyzers/test_optanalyzer.jl
+++ b/test/analyzers/test_optanalyzer.jl
@@ -170,6 +170,9 @@ WithRuntimeDispatch(::UInt32) = WithRuntimeDispatch(:UInt32)
 WithRuntimeDispatch(::UInt64) = WithRuntimeDispatch(:UInt64)
 WithRuntimeDispatch(::UInt128) = WithRuntimeDispatch(:UInt128)
 
+const FUNCTION_ARGUMENT_CALL_LINE = (@__LINE__) + 1
+@noinline function_argument_call(f, x) = f(x)
+
 const FNC_F1_DEF_LINE = (@__LINE__)+1
 skip_noncompileable_calls1(f, a) = f(a)
 const FNC_F2_DEF_LINE = (@__LINE__)+1
@@ -218,6 +221,27 @@ end
             test_opt((Vector{Any},); function_filter) do xs
                 WithRuntimeDispatch(xs[1])
             end
+        end
+
+        let reports = get_reports_with_test(report_opt(
+                function_argument_call, (typeof(with_runtime_dispatch), Any)))
+            @test length(reports) == 1
+            report = only(reports)
+            @test report isa RuntimeDispatchReport
+            @test report.sig isa JET.Signature
+            @test report.sig.tt === Tuple{typeof(with_runtime_dispatch), Any}
+            expected = "runtime dispatch detected: f::typeof(" *
+                       string(@__MODULE__) *
+                       ".with_runtime_dispatch)(x::Any)::Any"
+            @test get_msg(report) == expected
+            frame = only(report.vst)
+            @test frame.file === Symbol(@__FILE__)
+            @test frame.line == FUNCTION_ARGUMENT_CALL_LINE
+        end
+        let function_filter(@nospecialize f) = f !== with_runtime_dispatch
+            @test isempty(get_reports(report_opt(
+                function_argument_call, (typeof(with_runtime_dispatch), Any);
+                function_filter)))
         end
     end
 
@@ -284,16 +308,18 @@ end
 # don't report duplicated problems from inlined callees
 issue335_callf(f, args...) = f(args...)
 
+const ISSUE335_PROBLEMATIC_LINE = (@__LINE__) + 2
 @inline function issue335_problematic_callee(val)
     return issue335_undefined_call(val)
 end
 
 let result = @report_opt issue335_callf(issue335_problematic_callee, 42)
     report = only(get_reports_with_test(result))
-    @test any(report.vst) do vsf
-        vsf.line == (@__LINE__)-6 &&
-        vsf.linfo.def.name === :issue335_problematic_callee
-    end
+    @test report isa RuntimeDispatchReport
+    frame = last(report.vst)
+    @test frame.file === Symbol(@__FILE__)
+    @test frame.line == ISSUE335_PROBLEMATIC_LINE
+    @test frame.linfo.def.name === :issue335_problematic_callee
 end
 
 test_opt() do
@@ -306,13 +332,19 @@ test_opt() do
 end
 
 # report runtime dispatches within "noncompileable" but inlineable frames
+const NONCOMPILEABLE_INLINED_LINE = (@__LINE__) + 1
 @inline noncompileable_inlined1(a, b) = a + b
 let result = report_opt((Any,Any)) do a, b
         noncompileable_inlined1(a, b)
     end
-    @test any(get_reports_with_test(result)) do @nospecialize report
-        report isa RuntimeDispatchReport
-    end
+    reports = get_reports_with_test(result)
+    @test length(reports) == 1
+    report = only(reports)
+    @test report isa RuntimeDispatchReport
+    frame = last(report.vst)
+    @test frame.file === Symbol(@__FILE__)
+    @test frame.line == NONCOMPILEABLE_INLINED_LINE
+    @test frame.linfo.def.name === :noncompileable_inlined1
 end
 
 noncompileable_inlined2(a, b) = a + b
@@ -322,6 +354,46 @@ let result = report_opt((Any,Any)) do a, b
     @test_broken any(get_reports_with_test(result)) do @nospecialize report
         report isa RuntimeDispatchReport
     end
+end
+
+const CACHED_RUNTIME_DISPATCH_LINE = (@__LINE__) + 1
+cached_runtime_dispatch(xs::Vector{Any}) = getsomething(xs[1])
+
+@testset "cached runtime dispatch reports" begin
+    reports1 = get_reports_with_test(report_opt(cached_runtime_dispatch, (Vector{Any},)))
+    reports2 = get_reports_with_test(report_opt(cached_runtime_dispatch, (Vector{Any},)))
+    @test length(reports1) == length(reports2) == 1
+    report1, report2 = only(reports1), only(reports2)
+    @test report1 isa RuntimeDispatchReport
+    @test report2 isa RuntimeDispatchReport
+    @test report1.sig == report2.sig
+    @test report1.vst == report2.vst
+    @test get_msg(report1) == get_msg(report2)
+    frame = only(report1.vst)
+    @test frame.file === Symbol(@__FILE__)
+    @test frame.line == CACHED_RUNTIME_DISPATCH_LINE
+end
+
+const CYCLE_RUNTIME_DISPATCH_LINE = (@__LINE__) + 2
+function cycle_runtime_dispatch(xs::Vector{Any}, n::Int)
+    n == 0 && return getsomething(xs[1])
+    return cycle_runtime_dispatch_callee(xs, n - 1)
+end
+cycle_runtime_dispatch_callee(xs::Vector{Any}, n::Int) = cycle_runtime_dispatch(xs, n)
+
+no_optimization(::Int) = nothing
+
+@testset "cycle and no-optimization paths" begin
+    let reports = get_reports_with_test(report_opt(cycle_runtime_dispatch, (Vector{Any}, Int)))
+        report = only(reports)
+        @test report isa RuntimeDispatchReport
+        frame = only(report.vst)
+        @test frame.file === Symbol(@__FILE__)
+        @test frame.line == CYCLE_RUNTIME_DISPATCH_LINE
+        @test frame.linfo.def.name === :cycle_runtime_dispatch
+    end
+
+    @test isempty(get_reports(report_opt(no_optimization, (Int,))))
 end
 
 using StaticArrays


### PR DESCRIPTION
`OptAnalyzer` converted `OptimizationState` to `CodeInfo` before
Compiler cache transformation. This interfered with the Julia 1.13 inlining-cost lifecycle and required restoring the cost manually.

Analyze the final `IRCode` after `Compiler.optimize` instead. Use a lightweight state adapter for report signatures and locations, and recompute frame eligibility rather than maintaining FIFO state.

This preserves Julia 1.12 compatibility while allowing Compiler to own cache transformation and inlining-cost computation.
