### PR TITLE
release: Prepare JET v0.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   arch-test:
     name: Julia ${{ matrix.version }} / ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- links start -->
-[Unreleased]: https://github.com/aviatesk/JET.jl/compare/v0.11.6...HEAD
+[Unreleased]: https://github.com/aviatesk/JET.jl/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/aviatesk/JET.jl/compare/v0.11.6...v0.12.0
 [0.11.6]: https://github.com/aviatesk/JET.jl/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/aviatesk/JET.jl/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/aviatesk/JET.jl/compare/v0.11.3...v0.11.4
@@ -59,6 +60,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- links end -->
 
 ## [Unreleased]
+
+## [0.12.0]
+
+### Added
+- Added support for Julia v1.13.
+- Added `JET.JET_AVAILABLE` so test suites can skip JET checks when only
+  empty stubs are available. See the new
+  [Julia compatibility and versioning policy](README.md#julia-compatibility-and-versioning).
+
+### Changed
+- JET now loads empty stubs on unsupported future Julia versions while
+  remaining installable as a test dependency.
+- Improved the implementation of optimization analysis to make it more robust.
+
+### Fixed
+- Fixed a data race in shared top-level binding state (aviatesk/JET.jl#840,
+  thanks [@PatrickHaecker](https://github.com/PatrickHaecker)).
+- Fixed world-age issues in analysis and report printing.
 
 ## [0.11.6]
 
@@ -544,7 +563,7 @@ process, JET v0.10.0 was released despite its limitations:
 
 ## [0.9.3]
 ### Added
-- A simple logo badge for JET.jl is now available (thanks to @MilesCranmer!).
+- A simple logo badge for JET.jl is now available (thanks [@MilesCranmer](https://github.com/MilesCranmer)).
   You can add the line `[![](https://img.shields.io/badge/%F0%9F%9B%A9%EF%B8%8F_tested_with-JET.jl-233f9a)](https://github.com/aviatesk/JET.jl)`
   to your package's README to display the logo image [![](https://img.shields.io/badge/%F0%9F%9B%A9%EF%B8%8F_tested_with-JET.jl-233f9a)](https://github.com/aviatesk/JET.jl)
   that shows your package uses JET.jl for code quality checks (aviatesk/JET.jl#635).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JET"
 uuid = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-version = "0.11.6"
+version = "0.12.0"
 authors = ["Shuhei Kadowaki <aviatesk@gmail.com>"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 JET employs Julia's type inference system to detect potential bugs and type instabilities.
 
 > [!NOTE]
-> **The current latest version, v0.11 series, is only compatible with
-> [Julia v1.12](https://julialang.org/downloads/#current_stable_release) only**.
+> **The current latest version, v0.12 series, supports full JET functionality
+> on Julia v1.12 and v1.13 only.**
 >
 > The JET version that works with v1.11 is the [v0.9 series](https://github.com/aviatesk/JET.jl/tree/release-0.9),
 > but please note that bug fixes and new features added in the subsequent series may not necessarily be available.
@@ -19,12 +19,42 @@ JET employs Julia's type inference system to detect potential bugs and type inst
 > Additionally, the implementation of the `Base` module and standard libraries bundled with
 > Julia can also affect the results.
 >
-> Moreover, the Julia compiler's plugin system is still unstable and its interface changes
-> frequently, so each version of JET is compatible with only limited versions of Julia.
-> The Julia package manager will automatically select and install the latest version of JET
-> that is compatible with your Julia version. However, if you are using the nightly version
-> of Julia, please note that a compatible version of JET may not have been released yet,
-> and JET installed via the Julia package manager may not function properly.
+> Moreover, Julia's compiler plugin system is unstable and changes frequently.
+> Each JET release therefore supports full functionality on only a limited set
+> of Julia versions. JET may remain installable on newer Julia versions, but
+> loads empty stubs by default when full functionality is unavailable.
+
+## Julia compatibility and versioning
+
+JET distinguishes installation compatibility from functional compatibility.
+
+- The latest JET series keeps its Julia upper compat bound open. This allows
+  packages with JET as a test dependency to instantiate on Julia pre-releases
+  and nightly.
+- Full JET functionality is loaded only on explicitly supported Julia
+  versions. On unsupported future Julia versions, JET loads empty stubs and
+  its analysis APIs throw an explanatory error.
+- JET minor versions are bumped for ordinary semantic-versioning reasons and
+  may also mark a new Julia compatibility generation. Patch releases normally
+  stay within the same compatibility generation.
+- When support for a new Julia minor is released, older JET releases are
+  capped in the official [General](https://github.com/JuliaRegistries/General)
+  registry at the last Julia minor they support. This prevents package
+  resolution and lower-bound testing from selecting an old, incompatible JET.
+
+Test suites can remain instantiable on unsupported Julia versions and skip their
+JET-specific tests at runtime using the `JET_AVAILABLE` constant:
+
+```julia
+using JET
+
+if JET.JET_AVAILABLE
+    include("jet_tests.jl")
+end
+```
+
+Setting the `JET_DEV_MODE` preference to `true` forces JET to try loading
+full functionality on an unsupported Julia version.
 
 ## Quickstart
 See more commands, options and explanations in [the documentation](https://aviatesk.github.io/JET.jl/dev/).
@@ -41,14 +71,16 @@ julia> using JET
 ```
 
 > [!IMPORTANT]
-> The package manager will install the latest version of JET available for your Julia version.
-> However, depending on the versions of dependency packages already installed
-> in your environment, a working version of JET may not be installed.
+> The package manager installs a JET version allowed by registry metadata and
+> the compatibility constraints of your environment. This does not necessarily
+> mean full JET functionality is supported on your Julia version; check
+> `JET.JET_AVAILABLE` after loading JET.
 >
+> Existing dependencies may also prevent a working JET version from being
+> installed.
 > This can particularly occur when the version of [JuliaInterpreter.jl](https://github.com/JuliaDebug/JuliaInterpreter.jl)
 > is incompatible with JET, since JuliaInterpreter is also a dependency of the
 > very commonly used package [Revise.jl](https://github.com/timholy/Revise.jl).
->
 > In such cases, the most reliable way to install and use a working JET is to
 > set up a temporary environment (e.g., `Pkg.temp()`) and use JET there.
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,13 @@ function generate_index!()
         README = string(@doc JET)
         incode = false
         for line in split(README, '\n')
+            if line == "## Quickstart"
+                writeln(io, """
+                ```@docs
+                JET.JET_AVAILABLE
+                ```
+                """)
+            end
             if startswith(line, "```julia-repl") && !endswith(line, "noeval")
                 incode = true
                 writeln(io, "```@repl index")

--- a/ext/JETCthulhuExt.jl
+++ b/ext/JETCthulhuExt.jl
@@ -1,7 +1,7 @@
 module JETCthulhuExt
 
-using JET: JET_LOADABLE
-@static if JET_LOADABLE
+using JET: JET_AVAILABLE
+@static if JET_AVAILABLE
     include("JETCthulhuExtBase.jl")
 end
 

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -9,7 +9,25 @@ const USE_FIXED_WORLD = Preferences.load_preference(UUID("c3a54625-cd67-489e-a8e
 
 const PKG_EVAL = Base.get_bool_env("JULIA_PKGEVAL", false)
 
-const JET_LOADABLE = JET_DEV_MODE || PKG_EVAL || (get(VERSION.prerelease, 1, "") != "DEV")
+const MINIMUM_JULIA_VERSION = v"1.12.0-beta1.11"
+const FIRST_UNSUPPORTED_JULIA_VERSION = v"1.14.0-DEV"
+
+_is_supported_julia(version::VersionNumber) =
+    MINIMUM_JULIA_VERSION ≤ version < FIRST_UNSUPPORTED_JULIA_VERSION
+
+# PkgEval must exercise full JET functionality on pre-release Julia versions so that
+# compiler incompatibilities are detected instead of being hidden by empty stubs.
+"""
+    JET_AVAILABLE::Bool
+
+Whether full JET functionality is available in the current process.
+
+This is `true` on supported Julia versions, when `JET_DEV_MODE` is enabled, or under
+PkgEval. When `false`, JET is loaded with empty stubs so test suites can skip JET-specific
+checks while keeping their test environments usable.
+"""
+const JET_AVAILABLE = JET_DEV_MODE || PKG_EVAL || _is_supported_julia(VERSION)
+export JET_AVAILABLE
 
 # exports
 # =======
@@ -30,26 +48,11 @@ for exported_name in exports
     Core.eval(@__MODULE__, Expr(:export, exported_name))
 end
 
-using Compiler: Compiler as CC
-
-# Pre-release Julia versions are not supported, and we don't expect JET to even
-# precompile in pre-release versions. So, instead of having JET fail to precompile, we
-# simply make JET an empty module so that failure is delayed until the first time JET is
-# actually used. This means packages with a test dependency on JET don't fail to
-# precompile when their tests are run, instead there will be test failures when JET is
-# used (but potentially other tests can at least run).
-@static if JET_LOADABLE
-    @static if VERSION ≥ v"1.12.0-beta1.11"
-        include("JETBase.jl")
-    else
-        function __init__()
-            @warn """
-            The latest version of JET is incompatible with Julia versions earlier than `v"1.12.0-beta1.11"`.
-            To build a compatible Julia version, follow the instructions at
-            https://github.com/aviatesk/JET.jl/blob/master/CHANGELOG.md#0103.
-            """
-        end
-    end
+# Keep JET installable on unsupported future Julia versions so that packages with JET
+# as a test dependency can instantiate their test environments. Full functionality is
+# only loaded on supported Julia versions unless explicitly enabled with `JET_DEV_MODE`.
+@static if JET_AVAILABLE
+    include("JETBase.jl")
 else
     include("JETEmpty.jl")
 end

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -16,6 +16,8 @@ Base.Experimental.@optlevel 1
 # usings
 # ======
 
+using Compiler: Compiler as CC
+
 using Core: Builtin, IntrinsicFunction, Intrinsics, SimpleVector, svec
 
 using Core.IR

--- a/src/JETEmpty.jl
+++ b/src/JETEmpty.jl
@@ -1,10 +1,9 @@
-# Empty stubs for the exported functions/macros of JET.jl, to provide a more informative
-# error message when JET.jl is used with a pre-release version of Julia.
+# Empty stubs for the exported functions and macros of JET.jl.
 
 const empty_loading_message = """
-    JET.jl does not guarantee compatibility with nightly versions of Julia and,
-    it will not be loaded on nightly versions by default.
-    If you want to load JET on a nightly version, set the `JET_DEV_MODE` Preferences.jl
+    Full JET functionality is not available on Julia $VERSION.
+    JET was loaded with empty stubs so that this environment remains usable.
+    To try JET on this Julia version, set the `JET_DEV_MODE` Preferences.jl
     configuration to `true` and reload it.
     """ |> strip
 function __init__()
@@ -12,19 +11,15 @@ function __init__()
 end
 
 const empty_stub_message = strip("""
-    JET.jl does not guarantee compatibility with pre-release versions of Julia and
-    is not be loaded on this versions by default.
-        Julia VERSION = $VERSION
-    We recommend using a stable version of Julia in order to use JET.jl.
-    Or to try JET with this pre-release Julia version use Preferences.jl to enable
-    `JET_DEV_MODE`, and then reload JET. For example create a file named
-    `LocalPreferences.toml` which contains the section:
+    Full JET functionality is not available on Julia $VERSION.
+    To try JET on this Julia version, use Preferences.jl to enable `JET_DEV_MODE` and
+    reload JET. For example, create a `LocalPreferences.toml` file containing:
         ```toml
         [JET]
         JET_DEV_MODE = true
         ```
-    Note that JET.jl may not function properly with a pre-release versions of Julia
-    even with `JET_DEV_MODE` enabled.
+    JET may not function correctly on unsupported Julia versions even with
+    `JET_DEV_MODE` enabled.
     """)
 
 for exported_func in exports

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ using JET: Preferences
 @info "JET setup information:" JET.JET_DEV_MODE Preferences.load_preference(JET, "precompile_workload", true)
 
 @testset "JET.jl" begin
-    @static if JET.JET_LOADABLE
+    @static if JET.JET_AVAILABLE
         @testset "abstractinterpret" begin
             @testset "inferenceerrorreport.jl" include("abstractinterpret/test_inferenceerrorreport.jl")
 

--- a/test/test_JETEmpty.jl
+++ b/test/test_JETEmpty.jl
@@ -1,4 +1,6 @@
-using Test, JET
+using JET, Test
+
+@test !JET.JET_AVAILABLE
 
 for line in filter(!isempty, split(JET.empty_loading_message, '\n'))
     @test occursin(line, errmsg)


### PR DESCRIPTION
JET v0.11 does not correctly support Julia 1.13. Strict registry bounds can also prevent downstream test environments from instantiating on prerelease and nightly Julia versions.

Introduce the v0.12 compatibility policy. Keep the latest series installable, expose `JET_AVAILABLE`, and load empty stubs outside Julia 1.12-1.13 unless development mode or PkgEval requests (aviatesk/JET.jl#690) full loading. Document the policy and make nightly failures non-blocking.

Julia 1.13 tests and the documentation build pass. Nightly empty loading was verified. The Julia 1.12 full suite was interrupted before completion.

Closes aviatesk/JET.jl#842.