### PR TITLE
agents: Add JET development skills

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: changelog
+description: >-
+  Invoke before committing user-facing JET changes such as features, bug fixes,
+  compatibility changes, or deprecations. Skip internal refactors, CI or
+  docs-only changes, and routine dependency bumps without user impact.
+---
+
+# Updating CHANGELOG.md
+
+## Format
+
+This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Line length
+
+`CHANGELOG.md` is exempt from the 80-character Markdown line length rule
+because it is used for GitHub release notes, where hard line breaks disrupt
+rendering.
+
+Do not put everything on a single line unconditionally. Break long entries at
+natural points, such as sentence boundaries. Short, single-sentence entries
+are fine as one line.
+
+## Section structure
+
+Add new entries under `## [Unreleased]`. Do not edit a released section unless
+the user explicitly requests it.
+
+Use the established Keep a Changelog subsections as appropriate:
+
+- `### Added` for new functionality
+- `### Changed` for changes to existing functionality or compatibility
+- `### Deprecated` for features that will be removed
+- `### Removed` for removed functionality
+- `### Fixed` for bug fixes
+
+Use `### Internal` only when maintainers intentionally want to record a notable
+internal change. Do not add empty subsections or introduce a new category when
+an existing one fits.
+
+## Entry style
+
+- Start Added entries with "Added ..." and Fixed entries with "Fixed ...".
+- Describe Changed entries in terms of concrete behavior or compatibility.
+- Refer to GitHub issues as `aviatesk/JET.jl#NNN`.
+- Use backticks for report types, function names, configuration names, and
+  other code elements.
+- Record dependency changes when they affect supported Julia versions,
+  compatibility, installation, or user-visible behavior. Omit routine bumps.
+
+## Entry content
+
+Write entries from the user's perspective. Describe what changed in terms of
+user-visible behavior, not implementation details.
+
+- Do not include lowered IR details, Compiler.jl hook methods, abstract
+  interpretation state, or virtual-process internals unless users can
+  reasonably observe or interact with them.
+- The "why" of a fix rarely matters to users; the "what" does. If the prior
+  behavior is worth mentioning, describe its user-visible symptom rather than
+  its internal cause.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: commit
+description: >-
+  Use when writing a commit message, and MUST invoke before creating any git
+  commit. Provides commit message format and safety rules.
+---
+
+# Message guideline
+
+## Title format
+
+Use "component: Brief summary" format and imperative mood for the commit
+title.
+
+Examples:
+
+- "toplevel: Support versioned module expressions"
+- "optanalyzer: Analyze runtime dispatches on `IRCode`"
+- "test: Integrate JET failures with Test recording"
+
+## Body
+
+Write a body by default, including for small, self-contained changes. Do not
+treat a descriptive title as a reason to omit the body. When little explanation
+is needed, briefly state the motivation and implementation.
+
+Organize body paragraphs in this order and omit any paragraph that is not
+relevant:
+
+1. Explain the concrete problem, limitation, or goal motivating the change.
+   For user-facing work, describe the resulting capability or behavior. For
+   internal work, explain the engineering reason without inventing a
+   user-visible impact. Include a small code example when it adds clarity.
+2. Explain the approach used to implement the change.
+3. Mention important caveats, follow-up work, performance notes, or test
+   coverage when relevant.
+
+Write body paragraphs as explanatory prose with explicit subjects:
+
+- Prefer a concrete subject such as the affected component or newly introduced
+  type.
+- Use `This change` or `This commit` when describing the patch as a whole.
+- Use `The implementation` when explaining the mechanism.
+- Do not omit a subject merely to avoid `we` or `I`.
+
+Use backticks for code elements such as function names, variables, and paths.
+
+## Line length
+
+Ensure the maximum line length never exceeds 72 characters.
+
+## GitHub references
+
+When referencing external GitHub PRs or issues, use proper GitHub interlinking
+format: "owner/repo#123".
+
+## Co-author trailer
+
+If you wrote code yourself, include a co-author trailer at the end of the
+commit message, for example:
+
+`Co-Authored-By: GPT-5.6 Sol <noreply@openai.com>`
+
+Adjust the model name as appropriate. When simply asked to write a commit
+message without having written the code, do not add the trailer.
+
+## Examples
+
+The examples below are adapted from JET history. Co-author trailers are
+omitted.
+
+### Behavior change
+
+Reference: `2d06d461fe1d9304972bdb4887af688d0edab4f0`
+
+```
+optanalyzer: Analyze runtime dispatches on `IRCode`
+
+`OptAnalyzer` converted `OptimizationState` to `CodeInfo` before
+Compiler cache transformation. This interfered with the Julia 1.13
+inlining-cost lifecycle and required restoring the cost manually.
+
+`OptAnalyzer` now analyzes the final `IRCode` after
+`Compiler.optimize` instead. A lightweight state adapter provides report
+signatures and locations. The implementation recomputes frame
+eligibility instead of maintaining FIFO state.
+
+This change preserves Julia 1.12 compatibility while allowing Compiler
+to own cache transformation and inlining-cost computation.
+```
+
+### Bug fix
+
+Reference: `9bc9057b1c257b8905e8c8b4d888c88cc89e9378`
+
+```
+toplevel: Support versioned module expressions
+
+`virtual_process` assumed that a module body was always the third
+argument of a `module` expression. Julia 1.14 syntax adds a syntax
+version argument, shifting the module body and preventing definitions
+inside the module from being analyzed correctly.
+
+The implementation now takes the module body from the final expression
+argument. This change supports both legacy and versioned module layouts.
+```
+
+# Safety guidelines
+
+Before committing user-facing changes, use the
+[`changelog`](../changelog/SKILL.md) skill to decide whether `CHANGELOG.md`
+needs an entry.
+
+See the ["Git operations" section in AGENTS.md][git-operations].
+
+[git-operations]: ../../../AGENTS.md#git-operations

--- a/.agents/skills/run-test/SKILL.md
+++ b/.agents/skills/run-test/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: run-test
+description: >-
+  Use when choosing or running JET tests after code changes. Prefer the most
+  specific relevant test, use TestRunner for focused iteration, and reserve the
+  full suite for broad validation.
+---
+
+# Run JET tests
+
+Use this skill when validating JET changes or deciding which test command to
+run.
+
+## Choose the narrowest useful test
+
+If the user names a test file or testset, run it first. Otherwise, use
+[`test/runtests.jl`](../../../test/runtests.jl) and nearby tests to identify the
+smallest relevant target.
+
+Most test files can run independently. For example:
+
+```bash
+julia --startup-file=no --project=test test/ui/test_print.jl
+```
+
+- `--startup-file=no` avoids loading unrelated startup utilities.
+- `--project=test` selects JET's test environment and its dependencies.
+- Run commands from the repository root so relative paths and the workspace
+  resolve correctly.
+
+JET tests are organized by component. Common locations include:
+
+- `test/abstractinterpret/`
+- `test/analyzers/`
+- `test/toplevel/`
+- `test/ui/`
+
+There are also integration and miscellaneous tests directly under `test/`.
+Follow `test/runtests.jl` rather than assuming every test has a root-level path.
+
+## Focused iteration with TestRunner.jl
+
+When `testrunner --help` succeeds and the target `@testset` is clear, use
+[TestRunner.jl](https://github.com/aviatesk/TestRunner.jl) for faster iteration:
+
+```bash
+testrunner --project=test \
+  test/toplevel/test_virtualprocess.jl \
+  "syntax error reports"
+```
+
+TestRunner.jl is experimental. If it fails for a TestRunner-specific reason,
+fall back to running the complete test file independently.
+
+## Full-suite validation
+
+Avoid the full suite unless:
+
+- Changes affect multiple components or shared compiler infrastructure.
+- The user explicitly requests it.
+- No narrower test provides sufficient coverage.
+
+Use the package test lifecycle when matching CI or performing final broad
+validation:
+
+```bash
+julia --startup-file=no -e 'using Pkg; Pkg.test()'
+```
+
+JET's workspace also supports running `test/runtests.jl` directly:
+
+```bash
+julia --startup-file=no --project=test test/runtests.jl
+```
+
+## Environment failures
+
+If a failure looks environment-related, first confirm that the command ran from
+the repository root. Do not modify `Project.toml` or `test/Project.toml` to fix
+the environment. Report the unresolved failure and ask the user for guidance.
+
+## Reporting
+
+In the final response, report the exact command that ran and whether it passed,
+failed, or timed out. If tests were skipped, explain why.

--- a/.agents/skills/write-test/SKILL.md
+++ b/.agents/skills/write-test/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: write-test
+description: >-
+  Use when adding or modifying JET tests. Covers component placement,
+  independently runnable test modules, shared test utilities, `@testset`
+  organization, and focused assertions for JET reports.
+---
+
+# Write JET tests
+
+Use this skill when adding new JET tests or modifying existing test code.
+
+## Choose the test location
+
+Place tests beside the component they cover and include new files from
+[`test/runtests.jl`](../../../test/runtests.jl). Existing component directories
+include:
+
+- `test/abstractinterpret/`
+- `test/analyzers/`
+- `test/toplevel/`
+- `test/ui/`
+
+Use a root-level file under `test/` for cross-component integration or
+miscellaneous behavior when that matches the neighboring tests.
+
+## Test file structure
+
+New test files should normally define an independent module with a `test_`
+prefix matching the file name. For example,
+`test/toplevel/test_feature.jl` should follow this structure:
+
+```julia
+module test_feature
+
+include("../setup.jl")
+
+@testset "feature behavior" begin
+    let source = "x = 1"
+        result = report_text(source)
+        @test isempty(result.res.toplevel_error_reports)
+    end
+    let source = "x ="
+        result = report_text(source)
+        @test !isempty(result.res.toplevel_error_reports)
+    end
+end
+
+end # module test_feature
+```
+
+Include it from `test/runtests.jl` under the relevant component:
+
+```julia
+@testset "toplevel" begin
+    @testset "feature.jl" include("toplevel/test_feature.jl")
+end
+```
+
+Most existing tests follow this convention. Do not copy the known exception in
+`test/abstractinterpret/test_inferenceerrorreport.jl`, which currently depends
+on running in `Main`.
+
+## Shared test utilities
+
+Subdirectory tests that need JET's report helpers generally include
+[`test/setup.jl`](../../../test/setup.jl) with `include("../setup.jl")`.
+It loads `Test`, JET, and the helpers from `test/interactive_utils.jl`.
+
+Do not include the shared setup automatically when direct `using JET, Test` or
+narrow imports are sufficient.
+
+## Organize test code
+
+Use concise behavior-oriented `@testset` names. Group related cases into
+coherent `@testset` blocks so `testrunner` can select them by name. Nest
+`@testset` blocks when a larger behavior area has useful subgroups.
+
+Keep `using`, `import`, helper functions, macros, and type definitions at module
+scope unless local placement is specifically required.
+
+When an `@testset` contains multiple test units, use a separate `let` block for
+each unit to prevent variable collisions. A `let` block is unnecessary when the
+`@testset` contains only one unit because there is no later unit with which its
+variables can collide. A helper function or `do` block also provides local
+scope.
+
+Prefer assertions on report types, fields, counts, and semantic properties.
+Reserve output-string assertions for formatting and UI behavior, such as tests
+under `test/ui/`, unless the exact rendered message is the behavior under test.
+
+## After writing tests
+
+Use the [`run-test`](../run-test/SKILL.md) workflow and run the most specific
+relevant test before broader validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,31 +25,6 @@ keep the maximum line length under _80 characters_.
   - Good: `## Conclusion and alternative approaches`
   - Bad: `## Conclusion And Alternative Approaches`
 
-## Commit message formatting
-
-When writing commit messages, follow the format "component: Brief summary" for
-the title.
-
-In the body, write paragraphs in this order:
-
-1. Explain the concrete problem or user-visible limitation being fixed.
-   If appropriate, include a small code example when it makes the issue
-   clearer.
-2. Explain the approach used to fix the problem.
-3. Mention important caveats, follow-up work, performance notes, or test
-   coverage when relevant.
-
-Use backticks for code elements (function names, variables, file paths, etc.)
-to improve readability.
-
-Ensure that the maximum line length never exceeds 72 characters.
-When referencing external GitHub PRs or issues, use proper GitHub interlinking
-format (e.g., "owner/repo#123" for PRs/issues).
-Finally, if you write code yourself, include a co-author trailer at the end
-of the commit message, e.g.: `Co-Authored-By: GPT-5.5 <noreply@openai.com>`
-(adjust the model name as appropriate). However, when simply asked to write
-a commit message, there's no need to add that trailer.
-
 # File names
 
 For file names, use `-` (hyphen) as the word separator by default.
@@ -62,9 +37,9 @@ so they use underscores.
 # Coding rules
 
 - When writing functions, use the most restrictive signature type practical so
-  JET can catch unintended errors in itself. Loose signatures are fine while 
-  prototyping, but committed code should specify expected argument types unless 
-  generic behavior is intentional. When unsure, prefer the more restrictive 
+  JET can catch unintended errors in itself. Loose signatures are fine while
+  prototyping, but committed code should specify expected argument types unless
+  generic behavior is intentional. When unsure, prefer the more restrictive
   signature.
 
 - For function calls with keyword arguments, use an explicit `;` for clarity.
@@ -82,9 +57,9 @@ so they use underscores.
   ```
 
 - Avoid unnecessary logs:
-  Don't clutter the language server log with excessive information.
-  If you must use print debugging, generally use `@info`/`@warn` behind the
-  `JET_DEV_MODE` flag, like this:
+  Don't clutter JET's output with excessive information. If you must use print
+  debugging, generally use `@info`/`@warn` behind the `JET_DEV_MODE` flag, like
+  this:
   ```julia
   if JET_DEV_MODE
       @info ...
@@ -103,117 +78,38 @@ The same applies to tests: concise `@testset` descriptions and behavior-level
 comments are fine when they clarify what is being tested. Explain test setup
 only when it encodes a non-obvious constraint or hack.
 
-# Running test code
-Please make sure to test new code when you wrote.
+# Running tests
 
-If explicit test file or code is provided, prioritize running that.
-Otherwise, you can run the entire test suite for the JET project by executing
-`using Pkg; Pkg.test()` from the root directory of this repository.
+Please make sure to test new code when you write it.
 
-For example, if you receive a prompt like this:
-> Improve the printed message of top-level error reports.
-> Use test/ui/test_print.jl for the test cases.
-
-The command you should run is:
-```bash
-julia --startup-file=no -e 'using Test; @testset "test_print" include("test/ui/test_print.jl")'
-```
-Note that the usage of the `--startup-file=no` flag, which avoids loading
-unnecessary startup utilities.
-
-# Test code structure
-Test code should be written in files that define independent module spaces with
-a `test_` prefix.
-Then include these files from [`test/runtests.jl`](./test/runtests.jl).
-This ensures that these files can be run independently from the REPL.
-For example, test code for the "completion" feature would be in a file like
-this:
-> test/test_virtualprocess.jl
-```julia
-module test_virtualprocess
-using Test # Each module space needs to explicitly declare the code needed for execution
-...
-end # module test_virtualprocess
-```
-And `test/test_virtualprocess.jl` is included from `test/runtests.jl` like this:
-> test/runtests.jl
-```julia
-@testset "JET.jl" begin
-   ...
-   @testset "virtualprocess" include("test_virtualprocess.jl")
-   ...
-end
-```
-
-In each test file, you are encouraged to use `@testset "testset name"` to
-organize our tests cleanly. For code clarity, unless specifically necessary,
-avoid using `using`, `import`, and `struct` definitions  inside `@testset`
-blocks, and instead place them at the top level.
-
-Also, you are encouraged to use `let`-blocks to ensure that names aren't
-unintentionally reused between multiple test cases.
-For example, here is what good test code looks like:
-```julia
-module test_virtualprocess
-
-using Test # Each module space needs to explicitly declare the code needed for execution
-using JET: some_func
-
-function test_with()
-    ...
-end
-function testcase_util(s::AbstractString)
-    ...
-end
-function with_testcase(s::AbstractString)
-    ...
-end
-
-@testset "some_func" begin
-    let s = "..."
-        ret = some_func(testcase_util(s))
-        @test test_with(ret)
-    end
-    let s = "..."
-        ret = some_func(testcase_util(s))
-        @test test_with(ret)
-    end
-
-    # or `let` is unnecessary when testing with function scope
-    with_testcase(s) do case
-        ret = some_func(case)
-        @test test_with(ret)
-    end
-end
-
-end # module test_virtualprocess
-```
-Additionally, by using `@testset` as shown above, not only are tests hierarchized,
-but through integration with [TestRunner.jl](https://github.com/aviatesk/TestRunner.jl),
-you can also selectively execute specific `@testset`s, without executing the
-entire test file or test suite.
-If you're using this language server for development as well, you can run tests
-from code lenses or code actions within test files. If you need to run them from
-the command line, you can use commands like the following
-(assuming the `testrunner` executable is installed):
-```bash
-testrunner --verbose test/test_virtualprocess "some_func"
-```
-Note that TestRunner.jl is still experimental.
-The most reliable way to run tests is still to execute test files standalone.
+Run the most specific relevant test when practical. Prefer a named test file or
+component-specific test over the full suite. Avoid `Pkg.test()` unless changes
+affect multiple components, the user explicitly requests the full suite, or no
+narrower validation is appropriate.
 
 # Environment-related issues
-For AI agents: **NEVER MODIFY [Project.toml](./Project.toml) OR  [test/Project.toml](./test/Project.toml) BY YOURSELF**.
-If you encounter errors that seem to be environment-related when running tests,
-in most cases this is due to working directory issues, so first `cd` to the root directory of this project
-and re-run the tests. Never attempt to fix environment-related issues yourself.
-If you cannot resolve the problem, inform the human engineer and ask for instructions.
+
+For AI agents: never modify [`Project.toml`](./Project.toml) or
+[`test/Project.toml`](./test/Project.toml) by yourself.
+
+If test failures look environment-related, first ensure the test ran from the
+root directory of this project. Never attempt dependency or project-file fixes
+yourself. If the problem remains, inform the human engineer and ask for
+instructions.
 
 # About modifications to code you've written
-If you, as an AI agent, add or modify code, and the user appears to have made
-further manual changes to that code after your response, please respect those
-modifications as much as possible.
-For example, if the user has deleted a function you wrote, do not reintroduce
-that function in subsequent code generation.
-If you believe that changes made by the user are potentially problematic,
-please clearly explain your concerns and ask the user for clarification.
+
+If the user manually changes work you previously produced, respect those
+changes. Do not reintroduce deleted code or revert user edits without explicit
+permission. If you think a user edit is problematic, explain your concern and
+ask for clarification.
+
+# Git operations
+
+Only perform Git operations when the user explicitly requests them. Before
+creating any commit, use the [`commit`](./.agents/skills/commit/SKILL.md) skill.
+
+After any Git operation, wait for explicit follow-up instructions before doing
+more. If the user provides feedback on a commit, do not automatically amend it
+or create a fixup commit. Explain what could change and wait for explicit
+instruction.


### PR DESCRIPTION
JET lacked reusable agent instructions for changelog updates, commit messages, and test workflows. The existing guidance also mixed repository-wide policy with task-specific procedures in `AGENTS.md`.

This commit adds project-local skills for those workflows and adapts their commands, examples, and conventions to JET. `AGENTS.md` now keeps only repository-wide policies and Git safety rules.

The documented standalone and TestRunner examples pass. This change is limited to agent documentation and does not affect JET runtime behavior.