### PR TITLE
Remove `watch_file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remaining installable as a test dependency.
 - Improved the implementation of optimization analysis to make it more robust.
 
+### Removed
+- **Breaking**: Removed the experimental `watch_file` entry point.
+  Use [JETLS.jl](https://github.com/aviatesk/JETLS.jl) for interactive
+  diagnostics.
+
 ### Fixed
 - Fixed a data race in shared top-level binding state (aviatesk/JET.jl#840,
   thanks [@PatrickHaecker](https://github.com/PatrickHaecker)).

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -48,11 +48,7 @@ JET.PrintConfig
 JET.VSCode.VSCodeConfig
 ```
 
-## [Watch Configurations](@id watch-config)
 
-```@docs
-JET.WatchConfig
-```
 
 ## [Configuration File](@id config-file)
 

--- a/docs/src/jetanalysis.md
+++ b/docs/src/jetanalysis.md
@@ -423,7 +423,6 @@ If you're interested in how JET selects "top-level definitions", please see [`JE
 
 ```@docs
 JET.report_file
-JET.watch_file
 JET.report_package
 JET.report_text
 ```

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -36,7 +36,6 @@ const exports = Set{Symbol}((
     # jetanalyzer
     Symbol("@report_call"), :report_call, Symbol("@test_call"), :test_call,
     :report_file, :test_file, :report_package, :test_package, :report_text, :reportkey, :test_text,
-    :watch_file,
     # optanalyzer
     Symbol("@report_opt"), :report_opt, Symbol("@test_opt"), :test_opt,
     # configurations

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -924,9 +924,9 @@ configuration file support.
 This means you can use `$CONFIG_FILE_NAME` configuration file to specify any of configurations
 explained above and share that with others.
 
-When [`report_file`](@ref) or [`watch_file`](@ref) is called, it will look for
-`$CONFIG_FILE_NAME` in the directory of the given file, and search _up_ the file tree until
-a JET configuration file is (or isn't) found.
+When [`report_file`](@ref) is called, it will look for `$CONFIG_FILE_NAME` in the directory
+of the given file, and search _up_ the file tree until a JET configuration file is
+(or isn't) found.
 When found, the configurations specified in the file will be applied.
 
 A configuration file can specify configurations like:
@@ -1219,124 +1219,6 @@ function analyze_and_report_expr!(interp::ConcreteInterpreter, x::Union{JS.Synta
     return JETToplevelResult(analyzer, res, source; jetconfigs...)
 end
 
-"""
-Configurations for "watch" mode.
-The configurations will only be active when used with [`watch_file`](@ref).
-
----
-- `revise_all::Bool = true` \\
-  Redirected to [`Revise.entr`](https://timholy.github.io/Revise.jl/stable/user_reference/#Revise.entr)'s `all` keyword argument.
-  When set to `true`, JET will retrigger analysis as soon as code updates are detected in
-  any module tracked by Revise.
-  Currently when encountering `import/using` statements, JET won't perform analysis, but
-  rather will just load the modules as usual execution (this also means Revise will track
-  those modules).
-  So if you're editing both files analyzed by JET and modules that are used within the files,
-  this configuration should be enabled.
----
-- `revise_modules = nothing` \\
-  Redirected to [`Revise.entr`](https://timholy.github.io/Revise.jl/stable/user_reference/#Revise.entr)'s `modules` positional argument.
-  If a iterator of `Module` is given, JET will retrigger analysis whenever code in `modules` updates.
-
-  !!! tip
-      This configuration is useful when your're also editing files that are not tracked by Revise,
-      e.g. editing functions defined in `Base`:
-      ```julia-repl
-      # re-perform analysis when you make a change to `Base`
-      julia> watch_file(yourfile; revise_modules = [Base])
-      ```
----
-"""
-struct WatchConfig
-    # Revise configurations
-    revise_all::Bool
-    revise_modules
-    function WatchConfig(; revise_all::Bool = true,
-                           revise_modules = nothing,
-                           __jetconfigs...)
-        return new(revise_all, revise_modules)
-    end
-end
-
-function watch_file_with_func(func, args...; jetconfigs...)
-    try
-        return _watch_file_with_func(func, args...; jetconfigs...)
-    catch err
-        if !(err isa MethodError && err.f === _watch_file_with_func)
-            rethrow(err)
-        end
-        error("Revise.jl is not loaded; load Revise and try again.")
-    end
-end
-
-struct InsufficientWatches <: Exception
-    included_files::Set{String}
-end
-
-function _watch_file_with_func(func, args...; jetconfigs...)
-    local included_files::Set{String}
-
-    config = WatchConfig(; jetconfigs...)
-
-    included_files = let res = func(args...; jetconfigs...)
-        show(res) # XXX use `display` here?
-        JET.included_files(res.res)
-    end
-
-    interrupted = false
-    while !interrupted
-        try
-            let included_files=included_files
-            Revise.entr(collect(included_files), config.revise_modules;
-                        postpone = true, all = config.revise_all) do
-                next_included_files = let res = func(args...; jetconfigs...)
-                    show(res) # XXX use `display` here?
-                    JET.included_files(res.res)
-                end
-                if any(∉(included_files), next_included_files)::Bool
-                    # refresh watch files
-                    throw(InsufficientWatches(next_included_files))
-                end
-                return nothing
-            end
-            end
-            interrupted = true # `InterruptException` was gracefully handled within `entr`, shutdown watch mode
-        catch err
-            # handle "expected" errors, keep running
-
-            if isa(err, InsufficientWatches)
-                included_files = err.included_files
-                continue
-            elseif (isa(err, LoadError) ||
-                    (isa(err, ErrorException) && startswith(err.msg, "lowering returned an error")) ||
-                    isa(err, Revise.ReviseEvalException))
-                continue
-
-            # async errors
-            elseif isa(err, CompositeException)
-                errs = err.exceptions
-                i = findfirst(@nospecialize(e)->isa(e, TaskFailedException), errs)
-                if !isnothing(i)
-                    tfe = errs[i]::TaskFailedException
-                    let res = tfe.task.result
-                        if isa(res, InsufficientWatches)
-                            included_files = res.included_files
-                            continue
-                        elseif (isa(res, LoadError) ||
-                                (isa(res, ErrorException) && startswith(res.msg, "lowering returned an error")) ||
-                                isa(res, Revise.ReviseEvalException))
-                            continue
-                        end
-                    end
-                end
-            end
-
-            # fatal uncaught error happened in Revise.jl
-            rethrow(err)
-        end
-    end
-end
-
 # Test.jl integration
 # -------------------
 
@@ -1508,9 +1390,7 @@ const GENERAL_CONFIGURATIONS = Set{Symbol}((
     :context, :analyze_from_definitions, :concretization_patterns, :virtualize, :toplevel_logger,
     # ui
     :print_toplevel_success, :print_inference_success, :fullpath, :sourceinfo, :stacktrace_types_limit,
-    :vscode_console_output,
-    # watch
-    :revise_all, :revise_modules))
+    :vscode_console_output))
 
 # interface
 # =========

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1832,24 +1832,3 @@ See [`@test_call`](@ref) for the details.
 function test_text(args...; jetconfigs...)
     return func_test(report_text, :test_text, args...; jetconfigs...)
 end
-
-"""
-    watch_file(file::AbstractString; jetconfigs...)
-
-Watches `file` and keeps re-triggering analysis with [`report_file`](@ref) on code update.
-JET will try to analyze all the `include`d files reachable from `file`, and it will
-re-trigger analysis if there is code update detected in any of the `include`d files.
-
-This entry point currently uses [Revise.jl](https://timholy.github.io/Revise.jl/stable/) to
-monitor code updates, and _can only be used after Revise has been loaded into the session_.
-So note that you'll need to have run e.g., `using Revise` at some earlier stage to use it.
-Revise offers possibilities to track changes in files that are not directly analyzed by JET,
-including changes made to `Base` files using configurations like `revise_modules = [Base]`.
-See [watch configurations](@ref watch-config) for more details.
-
-!!! warning
-    This interface is very experimental and likely to subject to change or removal without notice.
-
-See also [`report_file`](@ref).
-"""
-watch_file(args...; jetconfigs...) = watch_file_with_func(report_file, args...; jetconfigs...)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -228,7 +228,7 @@ These configurations will be active for all the top-level entries explained in t
       concrete call sites will produce more accurate results than analysis entered from
       (maybe not concrete-typed) method signatures.
 
-  Also see: [`report_file`](@ref), [`watch_file`](@ref), [`report_package`](@ref)
+  Also see: [`report_file`](@ref), [`report_package`](@ref)
 ---
 - `concretization_patterns::Vector{Any} = Any[]` \\
   Specifies a customized top-level code concretization strategy.

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -80,31 +80,5 @@ end
     @test_throws "foo = :bar" @report_call foo = :bar sum(Char[])
 end
 
-# NOTE this test is not stable as `schedule(t, InterruptException(); error=true)` may not work as expected
-# @testset "watch_file" begin
-#     @test_throws "Revise.jl is not loaded; load Revise and try again." watch_file("../demo.jl")
-#
-#     using Revise
-#
-#     let t = @async begin
-#             mktemp() do path, io
-#                 redirect_stdout(io) do
-#                     watch_file("../demo.jl")
-#                 end
-#                 flush(io)
-#                 read(path, String)
-#             end
-#         end
-#         sleep(5)
-#         if istaskstarted(t) && !(istaskdone(t) || istaskfailed(t))
-#             ok = true
-#             schedule(t, InterruptException(); error=true)
-#         else
-#             ok = false
-#         end
-#         @test ok
-#         @test occursin("5 possible errors found", fetch(t))
-#     end
-# end
 
 end # module test_misc


### PR DESCRIPTION
Interactive diagnostic workflows are now better served by JETLS, so JET no longer needs to maintain its experimental file-watching entry point.

Remove `watch_file`, its Revise-based implementation, and the `revise_all` and `revise_modules` configurations. Update the manual and changelog to direct users to JETLS for interactive diagnostics.