### PR TITLE
config: Select one config file per analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: JET no longer accepts Julia compiler parameter keywords such as
   `max_methods` and `inlining` as user-facing configuration options for analysis
   entry points or `.JET.toml`; such keywords now throw `JETConfigError`.
+- JET configuration files are now selected once per analysis through the
+  `config_file` keyword. Entry points use deterministic default locations and
+  no longer search parent directories; explicit keyword configurations take
+  precedence over file configurations.
 - JET now loads empty stubs on unsupported future Julia versions while
   remaining installable as a test dependency.
 - Improved the implementation of optimization analysis to make it more robust.

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -64,6 +64,10 @@ const Argtypes = Vector{Any}
 
 const CONFIG_FILE_NAME = ".JET.toml"
 
+struct DefaultConfigFile end
+const DEFAULT_CONFIG_FILE = DefaultConfigFile()
+const ConfigFile = Union{DefaultConfigFile,Nothing,AbstractString}
+
 # TODO define all interface functions in JETInterface?
 
 function copy_report end
@@ -313,6 +317,7 @@ const JET_LOGGER_LEVELS_DESC = let
     join(descs, ", ")
 end
 jet_logger_level(@nospecialize io::IO) = get(io, JET_LOGGER_LEVEL, DEFAULT_LOGGER_LEVEL)::Int
+default_toplevel_logger() = IOContext(stdout, JET_LOGGER_LEVEL => DEFAULT_LOGGER_LEVEL)
 
 # analysis core
 # =============
@@ -873,23 +878,56 @@ General users should use high-level entry points like [`report_file`](@ref).
 function analyze_and_report_file!(interp::ConcreteInterpreter, filename::AbstractString,
                                   pkgid::Union{Nothing,PkgId} = nothing;
                                   jetconfigs...)
-    jetconfigs = apply_file_config(jetconfigs, filename)
+    isfile(filename) || throw(ArgumentError("$filename doesn't exist"))
+    jetconfigs = set_if_missing(jetconfigs, :toplevel_logger, default_toplevel_logger())
     entrytext = read(filename, String)
     return analyze_and_report_text!(interp, entrytext, filename, pkgid; jetconfigs...)
 end
 
-function apply_file_config(jetconfigs, filename::AbstractString)
-    isfile(filename) || throw(ArgumentError("$filename doesn't exist"))
-    jetconfigs = set_if_missing(jetconfigs, :toplevel_logger, IOContext(stdout, JET_LOGGER_LEVEL => DEFAULT_LOGGER_LEVEL))
-    configfile = find_config_file(dirname(abspath(filename)))
-    if !isnothing(configfile)
-        config = parse_config_file(configfile)
-        merge!(jetconfigs, config) # overwrite configurations
-        toplevel_logger(get(jetconfigs, :toplevel_logger, nothing); filter=≥(JET_LOGGER_LEVEL_INFO)) do @nospecialize(io::IO)
-            println(io, lazy"applied configurations in $configfile")
+function default_config_file()
+    return normpath(pwd(), CONFIG_FILE_NAME)
+end
+
+function default_config_file(filename::AbstractString)
+    return normpath(dirname(abspath(filename)), CONFIG_FILE_NAME)
+end
+
+function default_config_file(pkgmod::Module)
+    dir = pkgdir(pkgmod)
+    isnothing(dir) && throw(ArgumentError("package directory for $pkgmod is not available"))
+    return normpath(dir, CONFIG_FILE_NAME)
+end
+
+function resolve_config_file(::DefaultConfigFile, default_file::AbstractString)
+    default_file = abspath(default_file)
+    return isfile(default_file) ? default_file : nothing
+end
+
+resolve_config_file(::Nothing, ::AbstractString) = nothing
+
+function resolve_config_file(config_file::AbstractString, ::AbstractString)
+    config_file = abspath(config_file)
+    isfile(config_file) ||
+        throw(ArgumentError("configuration file $config_file doesn't exist"))
+    return config_file
+end
+
+function apply_config_file(jetconfigs, config_file::ConfigFile,
+                           default_file::AbstractString; defaults=())
+    configs = kwargs_dict(defaults)
+    overrides = kwargs_dict(jetconfigs)
+    config_file = resolve_config_file(config_file, default_file)
+    if !isnothing(config_file)
+        merge!(configs, parse_config_file(config_file, keys(overrides)))
+    end
+    merge!(configs, overrides)
+    if !isnothing(config_file)
+        logger = get(configs, :toplevel_logger, nothing)
+        toplevel_logger(logger; filter=≥(JET_LOGGER_LEVEL_INFO)) do @nospecialize(io::IO)
+            println(io, lazy"applied configurations in $config_file")
         end
     end
-    return jetconfigs
+    return configs
 end
 
 set_if_missing(configs, args...) = (@nospecialize; set_if_missing!(kwargs_dict(configs), args...))
@@ -902,32 +940,24 @@ end
 
 function kwargs_dict(@nospecialize configs)
     dict = Dict{Symbol,Any}()
-    for (key, val) in configs
+    for (key, val) in pairs(configs)
         dict[Symbol(key)] = val
     end
     return dict
 end
 
-function find_config_file(dir::AbstractString)
-    next_dir = dirname(dir)
-    if (next_dir == dir || # ensure to escape infinite recursion
-        isempty(dir))      # reached to the system root
-        return nothing
-    end
-    path = normpath(dir, CONFIG_FILE_NAME)
-    return isfile(path) ? path : find_config_file(next_dir)
-end
-
 """
-JET.jl offers [`.prettierrc` style](https://prettier.io/docs/en/configuration.html)
-configuration file support.
-This means you can use `$CONFIG_FILE_NAME` configuration file to specify any of configurations
-explained above and share that with others.
+JET.jl supports `$CONFIG_FILE_NAME` configuration files for sharing analysis
+configurations.
 
-When [`report_file`](@ref) is called, it will look for `$CONFIG_FILE_NAME` in the directory
-of the given file, and search _up_ the file tree until a JET configuration file is
-(or isn't) found.
-When found, the configurations specified in the file will be applied.
+Each high-level analysis entry point selects at most one configuration file. By default,
+[`report_file`](@ref) uses `$CONFIG_FILE_NAME` in the root script directory,
+[`report_package`](@ref) uses the package root, and call/text entry points use the
+current working directory. JET does not search parent directories.
+
+Specify `config_file::AbstractString` to use an exact configuration file, or
+`config_file = nothing` to disable configuration file loading. An explicitly specified
+file must exist. Configuration files at default locations are optional.
 
 A configuration file can specify configurations like:
 ```toml
@@ -935,11 +965,19 @@ analyze_from_definitions = true # analyze methods from their declared signatures
 ... # other configurations
 ```
 
-Note that the following configurations should be string(s) of valid Julia code:
-- `context`: string of Julia code, which can be `parse`d and `eval`uated into `Module`
-- `concretization_patterns`: vector of string of Julia code, which can be `parse`d into a
-  Julia expression pattern expected by [`MacroTools.@capture` macro](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/).
-- `toplevel_logger`: string of Julia code, which can be `parse`d and `eval`uated into `Union{IO,Nothing}`
+The following configurations use strings in TOML:
+- `mode` and `sourceinfo`: strings converted to `Symbol`s
+- `analyze_from_definitions`: a boolean or a string converted to `Symbol`
+- `target_modules` and `ignored_modules`: arrays of module-name strings converted to
+  `Symbol`s
+- `context`: Julia code parsed and evaluated into a `Module`
+- `concretization_patterns`: an array of Julia expression-pattern strings parsed for
+  [`MacroTools.@capture`](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/)
+- `toplevel_logger`: Julia code parsed and evaluated into `Union{IO,Nothing}`
+
+!!! warning
+    `context` and `toplevel_logger` are evaluated as Julia code. Only load configuration
+    files from trusted projects.
 
 E.g. the configurations below are equivalent:
 - configurations via keyword arguments
@@ -960,11 +998,43 @@ E.g. the configurations below are equivalent:
     Configurations specified as keyword arguments have precedence over those specified
     via a configuration file.
 """
-parse_config_file(path::AbstractString) = process_config_dict(TOML.parsefile(path))
+parse_config_file(path::AbstractString) = parse_config_file(path, ())
+
+function parse_config_file(path::AbstractString, overridden_keys)
+    config_dict = kwargs_dict(TOML.parsefile(path))
+    for key in overridden_keys
+        delete!(config_dict, key)
+    end
+    return process_config_dict!(config_dict)
+end
 
 process_config_dict(configs) = process_config_dict!(kwargs_dict(configs))
 
 function process_config_dict!(config_dict::Dict{Symbol,Any})
+    for key in (:mode, :sourceinfo)
+        value = get(config_dict, key, nothing)
+        if !isnothing(value)
+            isa(value, String) || throw(JETConfigError(
+                "`$key` should be string", key, value))
+            config_dict[key] = Symbol(value)
+        end
+    end
+    analyze_from_definitions = get(config_dict, :analyze_from_definitions, nothing)
+    if analyze_from_definitions isa String
+        config_dict[:analyze_from_definitions] = Symbol(analyze_from_definitions)
+    elseif !(isnothing(analyze_from_definitions) || analyze_from_definitions isa Bool)
+        throw(JETConfigError(
+            "`analyze_from_definitions` should be bool or string",
+            :analyze_from_definitions, analyze_from_definitions))
+    end
+    for key in (:target_modules, :ignored_modules)
+        value = get(config_dict, key, nothing)
+        if !isnothing(value)
+            isa(value, Vector{String}) || throw(JETConfigError(
+                "`$key` should be array of string", key, value))
+            config_dict[key] = Symbol.(value)
+        end
+    end
     context = get(config_dict, :context, nothing)
     if !isnothing(context)
         isa(context, String) || throw(JETConfigError(
@@ -1087,7 +1157,7 @@ function analyze_and_report_package!(analyzer::AbstractAnalyzer, pkgmod::Module;
 
     start = time()
     res = VirtualProcessResult(nothing)
-    jetconfigs = set_if_missing(jetconfigs, :toplevel_logger, IOContext(stdout, JET_LOGGER_LEVEL => DEFAULT_LOGGER_LEVEL))
+    jetconfigs = set_if_missing(jetconfigs, :toplevel_logger, default_toplevel_logger())
     config = ToplevelConfig(; jetconfigs...)
 
     # Revise's signature population may execute code, which can increment the world age,

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1477,19 +1477,23 @@ JETInterface.valid_configurations(::JETAnalyzer) = JET_ANALYZER_VALID_CONFIGURAT
 # -----------
 
 """
-    report_call(f, [types]; jetconfigs...) -> JETCallResult
-    report_call(tt::Type{<:Tuple}; jetconfigs...) -> JETCallResult
-    report_call(mi::Core.MethodInstance; jetconfigs...) -> JETCallResult
+    report_call(f, [types]; config_file, jetconfigs...) -> JETCallResult
+    report_call(tt::Type{<:Tuple}; config_file, jetconfigs...) -> JETCallResult
+    report_call(mi::Core.MethodInstance; config_file, jetconfigs...) -> JETCallResult
 
 Analyzes a function call with the given type signature to find type-level errors
 and returns back detected problems.
 
 The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as a keyword argument.
+can be specified as a keyword argument. By default, this function uses
+`$CONFIG_FILE_NAME` in the current working directory.
 
 See [the documentation of the error analysis](@ref jetanalysis) for more details.
 """
-function report_call(args...; jetconfigs...)
+function report_call(args...;
+                     config_file::ConfigFile=DEFAULT_CONFIG_FILE,
+                     jetconfigs...)
+    jetconfigs = apply_config_file(jetconfigs, config_file, default_config_file())
     analyzer = JETAnalyzer(; jetconfigs...)
     return analyze_and_report_call!(analyzer, args...; jetconfigs...)
 end
@@ -1607,14 +1611,13 @@ end
 # ---------
 
 """
-    report_file(file::AbstractString; jetconfigs...) -> JETToplevelResult
+    report_file(file::AbstractString; config_file, jetconfigs...) -> JETToplevelResult
 
 Analyzes `file` to find type-level errors and returns back detected problems.
 
-This function looks for `$CONFIG_FILE_NAME` configuration file in the directory of `file`,
-and searches _upward_ in the file tree until a `$CONFIG_FILE_NAME` is (or isn't) found.
-When found, the configurations specified in the file are applied.
-See [JET's configuration file specification](@ref config-file) for more details.
+By default, this function uses `$CONFIG_FILE_NAME` in the directory of the root
+`file`. See [JET's configuration file specification](@ref config-file) for details
+and explicit `config_file` selection.
 
 The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
 can be specified as a keyword argument, and if given, they are preferred over the configurations
@@ -1642,10 +1645,16 @@ specified by a `$CONFIG_FILE_NAME` configuration file.
     ```
     See [JET's top-level analysis configurations](@ref toplevel-config) for more details.
 """
-function report_file(args...; jetconfigs...)
-    # TODO read a configuration file and apply it here?
+function report_file(filename::AbstractString,
+                     pkgid::Union{Nothing,PkgId}=nothing;
+                     config_file::ConfigFile=DEFAULT_CONFIG_FILE,
+                     jetconfigs...)
+    isfile(filename) || throw(ArgumentError("$filename doesn't exist"))
+    defaults = (; toplevel_logger=default_toplevel_logger())
+    jetconfigs = apply_config_file(
+        jetconfigs, config_file, default_config_file(filename); defaults)
     interp = JETConcreteInterpreter(JETAnalyzer(; jetconfigs...))
-    return analyze_and_report_file!(interp, args...; jetconfigs...)
+    return analyze_and_report_file!(interp, filename, pkgid; jetconfigs...)
 end
 
 """
@@ -1666,7 +1675,7 @@ function test_file(args...; jetconfigs...)
 end
 
 """
-    report_package(package::Module; jetconfigs...) -> JETToplevelResult
+    report_package(package::Module; config_file, jetconfigs...) -> JETToplevelResult
 
 Analyzes `package` and returns back type-level errors.
 
@@ -1674,6 +1683,10 @@ This function uses [Revise.jl](https://github.com/timholy/Revise.jl) to collect 
 signatures defined in the package and analyzes each method based on its signature.
 This approach allows JET to analyze a package without requiring top-level call sites or
 actual usage examples.
+
+By default, this function uses `$CONFIG_FILE_NAME` in the package root. See
+[JET's configuration file specification](@ref config-file) for details and explicit
+`config_file` selection.
 
 This analysis is performed incrementally. This means that when the same package is analyzed
 multiple times, changes that Revise can handle are dynamically reflected and change the
@@ -1725,22 +1738,33 @@ configurations. By default, `report_package` enables the following configuration
         Please use `target_modules` instead, which allows for more flexible filtering.
 """
 function report_package(pkgmod::Module;
-                        ignore_missing_comparison::Bool=true,
-                        ignore_throws::Bool=true,
-                        target_defined_modules::Union{Nothing,Bool}=nothing, # TODO remove this handling from v0.12
+                        ignore_missing_comparison::Union{Missing,Bool}=missing,
+                        ignore_throws::Union{Missing,Bool}=missing,
+                        target_defined_modules::Union{Nothing,Bool}=nothing,
+                        config_file::ConfigFile=DEFAULT_CONFIG_FILE,
                         jetconfigs...)
-    # TODO read a configuration file and apply it here?
-    if isnothing(target_defined_modules)
-        target_modules = nothing
-    else
+    overrides = kwargs_dict(jetconfigs)
+    if !ismissing(ignore_missing_comparison)
+        overrides[:ignore_missing_comparison] = ignore_missing_comparison
+    end
+    if !ismissing(ignore_throws)
+        overrides[:ignore_throws] = ignore_throws
+    end
+    defaults = (;
+        ignore_missing_comparison=true,
+        ignore_throws=true,
+        toplevel_logger=default_toplevel_logger())
+    jetconfigs = apply_config_file(
+        overrides, config_file, default_config_file(pkgmod); defaults)
+    if !isnothing(target_defined_modules)
         @warn """
         `target_defined_modules::Bool` configuration is deprecated.
         Please use `target_modules` instead and specify the modules you want to target with e.g. `target_modules=(pkgmod,)`
         """
-        target_modules = (pkgmod,)
+        jetconfigs[:target_modules] = (pkgmod,)
     end
-    analyzer = JETAnalyzer(; ignore_missing_comparison, ignore_throws, target_modules, jetconfigs...)
-    return analyze_and_report_package!(analyzer, pkgmod; target_modules, jetconfigs...)
+    analyzer = JETAnalyzer(; jetconfigs...)
+    return analyze_and_report_package!(analyzer, pkgmod; jetconfigs...)
 end
 
 """
@@ -1805,12 +1829,17 @@ function test_package(args...; toplevel_logger=nothing, jetconfigs...)
 end
 
 """
-    report_text(text::AbstractString; jetconfigs...) -> JETToplevelResult
-    report_text(text::AbstractString, filename::AbstractString; jetconfigs...) -> JETToplevelResult
+    report_text(text::AbstractString; config_file, jetconfigs...) -> JETToplevelResult
+    report_text(text::AbstractString, filename::AbstractString;
+                config_file, jetconfigs...) -> JETToplevelResult
 
-Analyzes top-level `text` and returns back type-level errors.
+Analyzes top-level `text` and returns back type-level errors. By default, this
+function uses `$CONFIG_FILE_NAME` in the current working directory.
 """
-function report_text(args...; jetconfigs...)
+function report_text(args...;
+                     config_file::ConfigFile=DEFAULT_CONFIG_FILE,
+                     jetconfigs...)
+    jetconfigs = apply_config_file(jetconfigs, config_file, default_config_file())
     interp = JETConcreteInterpreter(JETAnalyzer(; jetconfigs...))
     return analyze_and_report_text!(interp, args...; jetconfigs...)
 end

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -388,9 +388,9 @@ const OPT_ANALYZER_VALID_CONFIGURATIONS =
 JETInterface.valid_configurations(::OptAnalyzer) = OPT_ANALYZER_VALID_CONFIGURATIONS
 
 """
-    report_opt(f, [types]; jetconfigs...) -> JETCallResult
-    report_opt(tt::Type{<:Tuple}; jetconfigs...) -> JETCallResult
-    report_opt(mi::Core.MethodInstance; jetconfigs...) -> JETCallResult
+    report_opt(f, [types]; config_file, jetconfigs...) -> JETCallResult
+    report_opt(tt::Type{<:Tuple}; config_file, jetconfigs...) -> JETCallResult
+    report_opt(mi::Core.MethodInstance; config_file, jetconfigs...) -> JETCallResult
 
 Analyzes a function call with the given type signature to detect optimization failures and
 unresolved method dispatches.
@@ -398,9 +398,13 @@ unresolved method dispatches.
 The [general configurations](@ref) and [the optimization analysis specific configurations](@ref optanalysis-config)
 can be specified as a keyword argument.
 
+By default, this function uses `$CONFIG_FILE_NAME` in the current working directory.
 See [the documentation of the optimization analysis](@ref optanalysis) for more details.
 """
-function report_opt(args...; jetconfigs...)
+function report_opt(args...;
+                    config_file::ConfigFile=DEFAULT_CONFIG_FILE,
+                    jetconfigs...)
+    jetconfigs = apply_config_file(jetconfigs, config_file, default_config_file())
     analyzer = OptAnalyzer(; jetconfigs...)
     return analyze_and_report_call!(analyzer, args...; jetconfigs...)
 end

--- a/test/.JET.toml
+++ b/test/.JET.toml
@@ -1,1 +1,1 @@
-# we put an empty JET configuration here, to make sure the JET configuration file at the repository root doesn't affect the whole test suite
+# Empty default configuration for analyses whose root script is in this directory.

--- a/test/analyzers/test_optanalyzer.jl
+++ b/test/analyzers/test_optanalyzer.jl
@@ -193,6 +193,18 @@ function target_modules_compute(x)
 end
 
 @testset "OptAnalyzer configurations" begin
+    mktemp() do path, io
+        write(io, "skip_noncompileable_calls = false\n")
+        flush(io)
+
+        result = report_opt(identity, (Any,); config_file=path)
+        @test !result.analyzer.skip_noncompileable_calls
+
+        result = report_opt(identity, (Any,);
+            config_file=path, skip_noncompileable_calls=true)
+        @test result.analyzer.skip_noncompileable_calls
+    end
+
     @testset "function_filter" begin
         @assert JET.InferenceParams(JET.OptAnalyzer()).max_union_splitting < 5
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -31,7 +31,11 @@ macro toml_str(s); TOML.parse(TOML.Parser(s)); end
 @testset "`process_config_dict`" begin
     let config_dict = toml"""
         # usual
-        analyze_from_definitions = true
+        analyze_from_definitions = "main"
+        mode = "typo"
+        sourceinfo = "compact"
+        target_modules = ["Foo"]
+        ignored_modules = ["Bar"]
 
         # will be `parse`d or `eval`ed
         context = "Base"
@@ -40,7 +44,11 @@ macro toml_str(s); TOML.parse(TOML.Parser(s)); end
         """
 
         config = process_config_dict(config_dict)
-        @test (:analyze_from_definitions => true) in config
+        @test (:analyze_from_definitions => :main) in config
+        @test (:mode => :typo) in config
+        @test (:sourceinfo => :compact) in config
+        @test (:target_modules => [:Foo]) in config
+        @test (:ignored_modules => [:Bar]) in config
         @test (:context => Base) in config
         @test (:concretization_patterns => [:(const x_ = y_)]) in config
         @test (:toplevel_logger => stdout) in config
@@ -70,6 +78,42 @@ macro toml_str(s); TOML.parse(TOML.Parser(s)); end
         """
         config = process_config_dict(config_dict)
         @test (:concretization_patterns => [:(const x_ = y_)]) in config
+    end
+end
+
+@testset "configuration file selection" begin
+    mktempdir() do dir
+        config_file = normpath(dir, JET.CONFIG_FILE_NAME)
+        write(config_file, "mode = \"typo\"\nignore_throws = true\n")
+        child = mkpath(normpath(dir, "child"))
+
+        cd(dir) do
+            result = report_call(()->throw("foo"))
+            @test result.analyzer isa JET.TypoJETAnalyzer
+            @test isempty(JET.get_reports(result))
+        end
+
+        cd(child) do
+            result = report_call(()->throw("foo"))
+            @test result.analyzer isa JET.BasicJETAnalyzer
+            @test !isempty(JET.get_reports(result))
+
+            result = report_call(()->throw("foo"); config_file)
+            @test result.analyzer isa JET.TypoJETAnalyzer
+            @test isempty(JET.get_reports(result))
+
+            result = report_call(()->throw("foo");
+                config_file, mode=:basic, ignore_throws=false)
+            @test result.analyzer isa JET.BasicJETAnalyzer
+            @test !isempty(JET.get_reports(result))
+
+            result = report_call(()->throw("foo"); config_file=nothing)
+            @test result.analyzer isa JET.BasicJETAnalyzer
+            @test !isempty(JET.get_reports(result))
+        end
+
+        missing = normpath(dir, "missing.toml")
+        @test_throws ArgumentError report_call(identity, (Any,); config_file=missing)
     end
 end
 

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1362,37 +1362,54 @@ end
 @testset "configuration file" begin
     mktempdir() do dir
         analysis_target = normpath(dir, "concretization_patterns.jl")
-        config_target   = normpath(dir, JET.CONFIG_FILE_NAME)
+        config_target = normpath(dir, JET.CONFIG_FILE_NAME)
+        nested_dir = mkpath(normpath(dir, "nested"))
+        nested_target = normpath(nested_dir, "concretization_patterns.jl")
 
-        back = pwd()
-        try # in order to check the functionality, fixtures/..JET.toml logs toplevel analysis
-            # into toplevel.txt (relative to the current working directory)
-            # and so let's `cd` into the temporary directory to not pollute this directory
-            cd(dir)
-
-            open(CONCRETIZATION_PATTERNS_FILE) do f
-                write(analysis_target, f)
+        cd(dir) do
+            for target in (analysis_target, nested_target)
+                open(CONCRETIZATION_PATTERNS_FILE) do f
+                    write(target, f)
+                end
             end
 
-            # no configuration, thus top-level analysis should fail
             let res = report_file2(analysis_target)
-                nreported = print_reports(IOBuffer(), res)
-                @test !iszero(nreported)
+                @test !iszero(print_reports(IOBuffer(), res))
             end
 
-            # setup a configuration file
             open(CONCRETIZATION_PATTERNS_CONFIG) do f
                 write(config_target, f)
             end
 
-            # now any top-level analysis failure shouldn't happen
-            let res = report_file2(analysis_target)
-                nreported = print_reports(IOBuffer(), res)
-                @test iszero(nreported) # no error happened
-                @test isfile("toplevel.txt") # not closed yet
+            let res = report_file(analysis_target)
+                @test iszero(print_reports(IOBuffer(), res))
+                @test isfile("toplevel.txt")
             end
-        finally
-            cd(back)
+
+            let res = report_file2(nested_target)
+                @test !iszero(print_reports(IOBuffer(), res))
+            end
+            let res = report_file2(nested_target; config_file=config_target)
+                @test iszero(print_reports(IOBuffer(), res))
+            end
+
+            let text = read(analysis_target, String)
+                res = report_text(text, analysis_target;
+                    config_file=config_target, toplevel_logger=nothing)
+                @test iszero(print_reports(IOBuffer(), res))
+            end
+
+            let res = report_file2(analysis_target;
+                    concretization_patterns=Any[])
+                @test !iszero(print_reports(IOBuffer(), res))
+            end
+            let res = report_file2(analysis_target; config_file=nothing)
+                @test !iszero(print_reports(IOBuffer(), res))
+            end
+
+            missing = normpath(dir, "missing.toml")
+            @test_throws ArgumentError report_file2(
+                analysis_target; config_file=missing)
         end
     end
 end


### PR DESCRIPTION
JET previously searched parent directories from a root file and loaded configuration after constructing some analyzers. This made configuration selection ambiguous for multi-file analysis and prevented language servers from choosing one workspace configuration deterministically.

Add a `config_file` control keyword with entry-specific default paths. Configuration is now resolved before analyzer construction with defaults, file values, and explicit keywords layered in that order. Parent-directory lookup is removed, `nothing` disables file loading, and explicit missing paths raise `ArgumentError`.

The parser also converts TOML strings for symbol-valued options and avoids processing file values overridden by keywords. `test_misc` and `test_optanalyzer` pass. Top-level suites remain blocked on Julia 1.12.6 by a pre-existing `JuliaInterpreter.FrameCode` API mismatch.