### PR TITLE
config: Remove `.JET.toml` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,12 +72,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Breaking**: JET no longer accepts Julia compiler parameter keywords such as
   `max_methods` and `inlining` as user-facing configuration options for analysis
-  entry points or `.JET.toml`; such keywords now throw `JETConfigError`.
+  entry points; such keywords now throw `JETConfigError`.
 - JET now loads empty stubs on unsupported future Julia versions while
   remaining installable as a test dependency.
 - Improved the implementation of optimization analysis to make it more robust.
 
 ### Removed
+- **Breaking**: Removed support for `.JET.toml` configuration files, including
+  the parent-directory file lookup that `report_file` performed. A single
+  configuration file could not be shared between analyzers that accept
+  different configuration sets, and some configurations could not even be
+  specified through the file at all. All analysis configurations are now
+  specified via keyword arguments of each entry point.
 - **Breaking**: Removed the experimental `watch_file` entry point.
   Use [JETLS.jl](https://github.com/aviatesk/JETLS.jl) for interactive
   diagnostics.

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -47,11 +47,3 @@ JET.PrintConfig
 ```@docs
 JET.VSCode.VSCodeConfig
 ```
-
-
-
-## [Configuration file](@id config-file)
-
-```@docs
-JET.parse_config_file
-```

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -49,7 +49,7 @@ using MacroTools: @capture, normalise, striplines
 
 using InteractiveUtils: InteractiveUtils
 
-using Pkg: Pkg, TOML
+using Pkg: Pkg
 
 using Revise
 
@@ -61,8 +61,6 @@ using Test:
 # ======
 
 const Argtypes = Vector{Any}
-
-const CONFIG_FILE_NAME = ".JET.toml"
 
 # TODO define all interface functions in JETInterface?
 
@@ -873,23 +871,10 @@ General users should use high-level entry points like [`report_file`](@ref).
 function analyze_and_report_file!(interp::ConcreteInterpreter, filename::AbstractString,
                                   pkgid::Union{Nothing,PkgId} = nothing;
                                   jetconfigs...)
-    jetconfigs = apply_file_config(jetconfigs, filename)
-    entrytext = read(filename, String)
-    return analyze_and_report_text!(interp, entrytext, filename, pkgid; jetconfigs...)
-end
-
-function apply_file_config(jetconfigs, filename::AbstractString)
     isfile(filename) || throw(ArgumentError("$filename doesn't exist"))
     jetconfigs = set_if_missing(jetconfigs, :toplevel_logger, IOContext(stdout, JET_LOGGER_LEVEL => DEFAULT_LOGGER_LEVEL))
-    configfile = find_config_file(dirname(abspath(filename)))
-    if !isnothing(configfile)
-        config = parse_config_file(configfile)
-        merge!(jetconfigs, config) # overwrite configurations
-        toplevel_logger(get(jetconfigs, :toplevel_logger, nothing); filter=≥(JET_LOGGER_LEVEL_INFO)) do @nospecialize(io::IO)
-            println(io, lazy"applied configurations in $configfile")
-        end
-    end
-    return jetconfigs
+    entrytext = read(filename, String)
+    return analyze_and_report_text!(interp, entrytext, filename, pkgid; jetconfigs...)
 end
 
 set_if_missing(configs, args...) = (@nospecialize; set_if_missing!(kwargs_dict(configs), args...))
@@ -906,105 +891,6 @@ function kwargs_dict(@nospecialize configs)
         dict[Symbol(key)] = val
     end
     return dict
-end
-
-function find_config_file(dir::AbstractString)
-    next_dir = dirname(dir)
-    if (next_dir == dir || # ensure to escape infinite recursion
-        isempty(dir))      # reached to the system root
-        return nothing
-    end
-    path = normpath(dir, CONFIG_FILE_NAME)
-    return isfile(path) ? path : find_config_file(next_dir)
-end
-
-"""
-JET.jl offers [`.prettierrc` style](https://prettier.io/docs/en/configuration.html)
-configuration file support.
-This means you can use `$CONFIG_FILE_NAME` configuration file to specify any of configurations
-explained above and share that with others.
-
-When [`report_file`](@ref) is called, it will look for `$CONFIG_FILE_NAME` in the directory
-of the given file, and search _up_ the file tree until a JET configuration file is
-(or isn't) found.
-When found, the configurations specified in the file will be applied.
-
-A configuration file can specify configurations like:
-```toml
-analyze_from_definitions = true # analyze methods from their declared signatures
-... # other configurations
-```
-
-Note that the following configurations should be string(s) of valid Julia code:
-- `context`: string of Julia code, which can be `parse`d and `eval`uated into `Module`
-- `concretization_patterns`: vector of string of Julia code, which can be `parse`d into a
-  Julia expression pattern expected by [`MacroTools.@capture` macro](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/).
-- `toplevel_logger`: string of Julia code, which can be `parse`d and `eval`uated into `Union{IO,Nothing}`
-
-E.g. the configurations below are equivalent:
-- configurations via keyword arguments
-  ```julia
-  report_file(somefile;
-              concretization_patterns = [:(const GLOBAL_CODE_STORE = x_)],
-              toplevel_logger = IOContext(open("toplevel.txt", "w"), :JET_LOGGER_LEVEL => 1))
-  ```
-- configurations via a configuration file
-  $(let
-      text = read(normpath(@__DIR__, "..", "test", "fixtures", "..JET.toml"), String)
-      lines = split(text, '\n')
-      pushfirst!(lines, "```toml"); push!(lines, "```")
-      join(lines, "\n  ")
-  end)
-
-!!! note
-    Configurations specified as keyword arguments have precedence over those specified
-    via a configuration file.
-"""
-parse_config_file(path::AbstractString) = process_config_dict(TOML.parsefile(path))
-
-process_config_dict(configs) = process_config_dict!(kwargs_dict(configs))
-
-function process_config_dict!(config_dict::Dict{Symbol,Any})
-    context = get(config_dict, :context, nothing)
-    if !isnothing(context)
-        isa(context, String) || throw(JETConfigError(
-            "`context` should be string of Julia code", :context, context))
-        context = Core.eval(Main, trymetaparse(context, :context))
-        config_dict[:context] = context
-    end
-    concretization_patterns = get(config_dict, :concretization_patterns, nothing)
-    if !isnothing(concretization_patterns)
-        isa(concretization_patterns, Vector{String}) || throw(JETConfigError(
-            "`concretization_patterns` should be array of string of Julia expression",
-            :concretization_patterns, concretization_patterns))
-        concretization_patterns = Any[
-            trymetaparse(pat, :concretization_patterns)
-            for pat in concretization_patterns]
-        config_dict[:concretization_patterns] = concretization_patterns
-    end
-    toplevel_logger = get(config_dict, :toplevel_logger, nothing)
-    if !isnothing(toplevel_logger)
-        isa(toplevel_logger, String) || throw(JETConfigError(
-            "`toplevel_logger` should be string of Julia code",
-            :toplevel_logger, toplevel_logger))
-        toplevel_logger = Core.eval(Main, trymetaparse(toplevel_logger, :toplevel_logger))
-        config_dict[:toplevel_logger] = toplevel_logger
-    end
-    return config_dict
-end
-
-function trymetaparse(s::String, name::Symbol)
-    s = strip(s)
-    ret = Meta.parse(s; raise=false)
-    if isexpr(ret, :error) || isexpr(ret, :incomplete)
-        err = ret.args[1]
-        msg = lazy"""Failed to parse configuration string.
-          ∘ given: `$s`
-          ∘ error: $err
-        """
-        throw(JETConfigError(msg, name, s))
-    end
-    return ret
 end
 
 function find_pkgmod(pkg)

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1611,14 +1611,8 @@ end
 
 Analyzes `file` to find type-level errors and returns back detected problems.
 
-This function looks for `$CONFIG_FILE_NAME` configuration file in the directory of `file`,
-and searches _upward_ in the file tree until a `$CONFIG_FILE_NAME` is (or isn't) found.
-When found, the configurations specified in the file are applied.
-See [JET's configuration file specification](@ref config-file) for more details.
-
 The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as a keyword argument, and if given, they are preferred over the configurations
-specified by a `$CONFIG_FILE_NAME` configuration file.
+can be specified as a keyword argument.
 
 !!! tip
     When you want to analyze your package but no files that actually use its functions are
@@ -1643,7 +1637,6 @@ specified by a `$CONFIG_FILE_NAME` configuration file.
     See [JET's top-level analysis configurations](@ref toplevel-config) for more details.
 """
 function report_file(args...; jetconfigs...)
-    # TODO read a configuration file and apply it here?
     interp = JETConcreteInterpreter(JETAnalyzer(; jetconfigs...))
     return analyze_and_report_file!(interp, args...; jetconfigs...)
 end
@@ -1729,7 +1722,6 @@ function report_package(pkgmod::Module;
                         ignore_throws::Bool=true,
                         target_defined_modules::Union{Nothing,Bool}=nothing, # TODO remove this handling from v0.12
                         jetconfigs...)
-    # TODO read a configuration file and apply it here?
     if isnothing(target_defined_modules)
         target_modules = nothing
     else

--- a/test/.JET.toml
+++ b/test/.JET.toml
@@ -1,1 +1,0 @@
-# we put an empty JET configuration here, to make sure the JET configuration file at the repository root doesn't affect the whole test suite

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,7 +12,6 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -25,4 +24,3 @@ Libdl = "1.10"
 Logging = "1.10"
 Random = "1.10"
 StaticArrays = "1.7.0"
-TOML = "1.0.3"

--- a/test/fixtures/..JET.toml
+++ b/test/fixtures/..JET.toml
@@ -1,5 +1,0 @@
-# supposed to concretize `const GLOBAL_CODE_STORE = Dict()` in test/fixtures/concretization_patterns.jl
-concretization_patterns = ["const GLOBAL_CODE_STORE = Dict()"]
-
-# logs toplevel analysis into toplevel.txt with debug logging level
-toplevel_logger = """IOContext(open("toplevel.txt", "w"), :JET_LOGGER_LEVEL => 1)"""

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -24,55 +24,6 @@ try; f_method_instance2(Some{AbstractString}("throws")); catch end
     end
 end
 
-using JET: process_config_dict
-using TOML: TOML
-macro toml_str(s); TOML.parse(TOML.Parser(s)); end
-
-@testset "`process_config_dict`" begin
-    let config_dict = toml"""
-        # usual
-        analyze_from_definitions = true
-
-        # will be `parse`d or `eval`ed
-        context = "Base"
-        concretization_patterns = ["const x_ = y_"]
-        toplevel_logger = "stdout"
-        """
-
-        config = process_config_dict(config_dict)
-        @test (:analyze_from_definitions => true) in config
-        @test (:context => Base) in config
-        @test (:concretization_patterns => [:(const x_ = y_)]) in config
-        @test (:toplevel_logger => stdout) in config
-    end
-
-    # error when invalid expression given
-    let config_dict = toml"""
-        concretization_patterns = ["const x_ = end"]
-        """
-        @test_throws JET.JETConfigError process_config_dict(config_dict)
-    end
-
-    # error when incomplete expression given
-    let config_dict = toml"""
-        concretization_patterns = ["const x_ = "]
-        """
-        @test_throws JET.JETConfigError process_config_dict(config_dict)
-    end
-
-    # should be whitespece/newline insensitive
-    let config_dict = toml"""
-        concretization_patterns = [
-            \"\"\"
-            const x_ = y_
-            \"\"\"
-        ]
-        """
-        config = process_config_dict(config_dict)
-        @test (:concretization_patterns => [:(const x_ = y_)]) in config
-    end
-end
-
 @testset "configuration validation" begin
     # https://github.com/aviatesk/JET.jl/issues/414
     @test_throws "lkdsjkdlkas" report_call(+, (Int, Int), lkdsjkdlkas=true)

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1293,11 +1293,8 @@ end
     end
 end
 
-# will be used in the following two testsets
-let fixtures_dir = normpath(pkgdir(JET), "test", "fixtures")
-    global const CONCRETIZATION_PATTERNS_FILE   = normpath(fixtures_dir, "concretization_patterns.jl")
-    global const CONCRETIZATION_PATTERNS_CONFIG = normpath(fixtures_dir, "..JET.toml")
-end
+const CONCRETIZATION_PATTERNS_FILE =
+    normpath(pkgdir(JET), "test", "fixtures", "concretization_patterns.jl")
 
 @testset "custom concretization pattern" begin
     # custom concretization pattern should work on AST level
@@ -1355,45 +1352,6 @@ end
             const foo = Dict()
         end concretization_patterns = [:(const foo = Dict())]
         @test isconcrete(res, vmod, :foo)
-    end
-end
-
-# NOTE better to be in test_misc.jl, but here it is since this test is only valid when the testset above gets passed
-@testset "configuration file" begin
-    mktempdir() do dir
-        analysis_target = normpath(dir, "concretization_patterns.jl")
-        config_target   = normpath(dir, JET.CONFIG_FILE_NAME)
-
-        back = pwd()
-        try # in order to check the functionality, fixtures/..JET.toml logs toplevel analysis
-            # into toplevel.txt (relative to the current working directory)
-            # and so let's `cd` into the temporary directory to not pollute this directory
-            cd(dir)
-
-            open(CONCRETIZATION_PATTERNS_FILE) do f
-                write(analysis_target, f)
-            end
-
-            # no configuration, thus top-level analysis should fail
-            let res = report_file2(analysis_target)
-                nreported = print_reports(IOBuffer(), res)
-                @test !iszero(nreported)
-            end
-
-            # setup a configuration file
-            open(CONCRETIZATION_PATTERNS_CONFIG) do f
-                write(config_target, f)
-            end
-
-            # now any top-level analysis failure shouldn't happen
-            let res = report_file2(analysis_target)
-                nreported = print_reports(IOBuffer(), res)
-                @test iszero(nreported) # no error happened
-                @test isfile("toplevel.txt") # not closed yet
-            end
-        finally
-            cd(back)
-        end
     end
 end
 


### PR DESCRIPTION
The `.JET.toml` configuration file mechanism had structural problems. Only one file can exist per directory, yet `JETAnalyzer` and `OptAnalyzer` validate different sets of configuration names, so a single file could not serve both analyzers. The TOML parser only converted the `context`, `concretization_patterns`, and `toplevel_logger` values, so Symbol- or function-valued options such as `mode` and `function_filter` could not be specified through the file at all. Moreover, the `context` and `toplevel_logger` values were evaluated with `Core.eval`, so analyzing a file could execute arbitrary code from a `.JET.toml` found by the parent-directory lookup. A GitHub code search also shows no project other than JET itself uses the format, and the language server use case is better served by JETLS's own workspace configuration.

This commit removes the configuration file machinery entirely: `find_config_file`, `parse_config_file`, `process_config_dict`, and the file lookup in `analyze_and_report_file!`. All analysis configurations are now specified exclusively via keyword arguments of each entry point.

`test_misc` passes, and `report_file` with keyword-specified `concretization_patterns` was verified manually.