### PR TITLE
docs: Documentation overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry points; such keywords now throw `JETConfigError`.
 - JET now loads empty stubs on unsupported future Julia versions while
   remaining installable as a test dependency.
+- Overhauled JET's documentation across the project.
 - Improved the implementation of optimization analysis to make it more robust.
 
 ### Removed
@@ -391,7 +392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their own customized interpretation logic (aviatesk/JET.jl#721).
 ### Added (Internal)
 - Added the ability for external users of JET to customize virtualprocess.jl.
-  Similar to the design of `JuliaInterpreter.Interpreter` and `Base.Compiler.AbstractInterpreter`,
+  Similar to the design of `JuliaInterpreter.Interpreter` and `Compiler.AbstractInterpreter`,
   the new `JET.ConcreteInterpreter <: JuliaInterpreter.Interpreter` interface is designed,
   allowing external packages to subtype it and customize the behavior of `virtual_process(interp::JET.ConcreteInterpreter, ...)`.
   Please note that this is still undocumented and is a highly experimental interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: JET no longer accepts Julia compiler parameter keywords such as
   `max_methods` and `inlining` as user-facing configuration options for analysis
   entry points; such keywords now throw `JETConfigError`.
+- Module matchers for the `target_modules`/`ignored_modules` configurations now
+  follow lexical module nesting that stops at namespace roots: `Base` is no
+  longer considered a submodule of `Main`. `target_modules = (Main,)` therefore
+  matches only code defined interactively in the REPL or in an analyzed script,
+  instead of also matching every report from `Base`.
 - JET now loads empty stubs on unsupported future Julia versions while
   remaining installable as a test dependency.
 - Overhauled JET's documentation across the project.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,24 @@
 [![](https://codecov.io/gh/aviatesk/JET.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/aviatesk/JET.jl)
 [![](https://img.shields.io/badge/%F0%9F%9B%A9%EF%B8%8F_tested_with-JET.jl-233f9a)](https://github.com/aviatesk/JET.jl)
 
-JET employs Julia's type inference system to detect potential bugs and type instabilities.
+JET employs Julia's type inference system to detect potential bugs and type
+instabilities.
 
 > [!NOTE]
-> **The current latest version, v0.12 series, supports full JET functionality
+> **The latest release series, v0.12, supports full JET functionality
 > on Julia v1.12 and v1.13 only.**
 >
-> The JET version that works with v1.11 is the [v0.9 series](https://github.com/aviatesk/JET.jl/tree/release-0.9),
-> but please note that bug fixes and new features added in the subsequent series may not necessarily be available.
+> The JET version that works with Julia v1.11 is the
+> [v0.9 series](https://github.com/aviatesk/JET.jl/tree/release-0.9),
+> but note that bug fixes and new features added in later series are not
+> necessarily available there.
 
 > [!WARNING]
-> Please note that due to JET's tight integration with the Julia compiler, the results
-> presented by JET can vary significantly depending on the version of Julia you are using.
-> Additionally, the implementation of the `Base` module and standard libraries bundled with
-> Julia can also affect the results.
+> Please note that due to JET's tight integration with the Julia compiler,
+> the results presented by JET can vary significantly depending on the version
+> of Julia you are using.
+> Additionally, the implementation of the `Base` module and standard libraries
+> bundled with Julia can also affect the results.
 >
 > Moreover, Julia's compiler plugin system is unstable and changes frequently.
 > Each JET release therefore supports full functionality on only a limited set
@@ -30,7 +34,7 @@ JET distinguishes installation compatibility from functional compatibility.
 
 - The latest JET series keeps its Julia upper compat bound open. This allows
   packages with JET as a test dependency to instantiate on Julia pre-releases
-  and nightly.
+  and nightly builds.
 - Full JET functionality is loaded only on explicitly supported Julia
   versions. On unsupported future Julia versions, JET loads empty stubs and
   its analysis APIs throw an explanatory error.
@@ -42,8 +46,8 @@ JET distinguishes installation compatibility from functional compatibility.
   registry at the last Julia minor they support. This prevents package
   resolution and lower-bound testing from selecting an old, incompatible JET.
 
-Test suites can remain instantiable on unsupported Julia versions and skip their
-JET-specific tests at runtime using the `JET_AVAILABLE` constant:
+Test environments can remain instantiable on unsupported Julia versions, and
+JET-specific tests can be skipped at runtime using the `JET_AVAILABLE` constant:
 
 ```julia
 using JET
@@ -53,15 +57,20 @@ if JET.JET_AVAILABLE
 end
 ```
 
+<!-- @doc JET.JET_AVAILABLE -->
+
 Setting the `JET_DEV_MODE` preference to `true` forces JET to try loading
 full functionality on an unsupported Julia version.
 
+<!-- @doc JET.JET_DEV_MODE -->
+
 ## Quickstart
-See more commands, options and explanations in [the documentation](https://aviatesk.github.io/JET.jl/dev/).
+See more commands, options, and explanations in
+[the documentation](https://aviatesk.github.io/JET.jl/dev/).
 
 ### Installation
-JET is a standard Julia package.
-So you can just install it via Julia's built-in package manager and use it just like any other package:
+JET is a standard Julia package, so you can install it via Julia's built-in
+package manager and use it just like any other package:
 
 ```julia-repl noeval
 julia> using Pkg; Pkg.add("JET")
@@ -78,15 +87,20 @@ julia> using JET
 >
 > Existing dependencies may also prevent a working JET version from being
 > installed.
-> This can particularly occur when the version of [JuliaInterpreter.jl](https://github.com/JuliaDebug/JuliaInterpreter.jl)
+> This is particularly likely when the version of
+> [JuliaInterpreter.jl](https://github.com/JuliaDebug/JuliaInterpreter.jl)
 > is incompatible with JET, since JuliaInterpreter is also a dependency of the
 > very commonly used package [Revise.jl](https://github.com/timholy/Revise.jl).
 > In such cases, the most reliable way to install and use a working JET is to
-> set up a temporary environment (e.g., `Pkg.temp()`) and use JET there.
+> set up a temporary environment (e.g., `Pkg.activate(; temp=true)`) and use
+> JET there.
 
 ### Detect type instability with `@report_opt`
-Type instabilities can be detected in function calls using the `@report_opt` macro, which works similar to the `@code_warntype` macro.
-Note that, because JET relies on Julia's type inference, if a chain of inference is broken due to dynamic dispatch, then all downstream function calls will be unknown to the compiler, and so JET cannot analyze them.
+Type instabilities can be detected in function calls using the `@report_opt`
+macro, which works similarly to the `@code_warntype` macro.
+Note that, because JET relies on Julia's type inference, it cannot see through
+unresolved dynamic dispatch: callees reached only through such calls are not
+analyzed, so problems inside them go unreported.
 
 ```julia-repl
 julia> @report_opt foldl(+, Any[]; init=0)
@@ -108,7 +122,13 @@ julia> @report_opt foldl(+, Any[]; init=0)
 ```
 
 ### Detect type errors with `@report_call`
-This works best on type stable code, so use `@report_opt` liberally before using `@report_call`.
+While `@report_opt` detects performance problems, `@report_call` detects
+potential bugs: calls that may throw at runtime, such as `MethodError`s.
+Since JET cannot see through unresolved dynamic dispatch, fixing the
+instabilities reported by `@report_opt` first lets `@report_call` cover more
+of your code. That said, `@report_call` is often less noisy than `@report_opt`,
+so it is also perfectly reasonable to start with `@report_call` alone.
+
 ```julia-repl
 julia> @report_call foldl(+, Char[])
 ═════ 2 possible errors found ═════
@@ -132,7 +152,9 @@ julia> @report_call foldl(+, Char[])
 ```
 
 ### Analyze packages with `report_package`
-This looks for all method definitions and analyses function calls based on their signatures. Note that this is less accurate than `@report_call`, because the actual input types cannot be known for generic methods.
+This looks for all method definitions and analyzes function calls based on
+their signatures. Note that this is less accurate than `@report_call`, because
+the actual input types cannot be known for generic methods.
 
 ```julia-repl
 julia> using Pkg; Pkg.activate(; temp=true, io=devnull); Pkg.add("AbstractTrees"; io=devnull);
@@ -148,10 +170,10 @@ julia> report_package(AbstractTrees)
 [toplevel-info] Analyzed all top-level definitions (all: 256 | analyzed: 256 | cached: 0 | took: 7.116 sec)
 [ Info: tracking Base
 ═════ 7 possible errors found ═════
-┌ isroot(root::Any, x::Any) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:102
+┌ isroot(root::Any, x::Any) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:102
 │ no matching method found `parent(::Any, ::Any)`: AbstractTrees.parent(root::Any, x::Any)
 └────────────────────
-┌ StableNode{T}(x::T, ch::Any) where T @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:260
+┌ StableNode{T}(x::T, ch::Any) where T @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:260
 │┌ collect(::Type{StableNode{_A}} where _A, itr::Any) @ Base ./array.jl:641
 ││┌ _collect(::Type{StableNode{_A}}, itr::Any, isz::Union{Base.HasLength, Base.HasShape}) where _A @ Base ./array.jl:643
 │││┌ _array_for(::Type{StableNode{_A}} where _A, itr::Base.HasLength, isz::Any) @ Base ./array.jl:673
@@ -162,16 +184,16 @@ julia> report_package(AbstractTrees)
 │││││┌ axes(A::Base.HasLength) @ Base ./abstractarray.jl:98
 ││││││ no matching method found `size(::Base.HasLength)`: size(A::Base.HasLength)
 │││││└────────────────────
-┌ IndexNode(tree::Any) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:117
+┌ IndexNode(tree::Any) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:117
 │ no matching method found `rootindex(::Any)`: rootindex(tree::Any)
 └────────────────────
-┌ parent(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:127
+┌ parent(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:127
 │ no matching method found `parentindex(::Any, ::Any)`: pidx = parentindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
-┌ nextsibling(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:132
+┌ nextsibling(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:132
 │ no matching method found `nextsiblingindex(::Any, ::Any)`: sidx = nextsiblingindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
-┌ prevsibling(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:137
+┌ prevsibling(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:137
 │ no matching method found `prevsiblingindex(::Any, ::Any)`: sidx = prevsiblingindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
 
@@ -179,33 +201,46 @@ julia> report_package(AbstractTrees; target_modules=(AbstractTrees,)) # ignore e
 [toplevel-info] Skipped analysis for cached definition (256/256)
 [toplevel-info] Analyzed all top-level definitions (all: 256 | analyzed: 0 | cached: 256 | took: 0.036 sec)
 ═════ 5 possible errors found ═════
-┌ isroot(root::Any, x::Any) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:102
+┌ isroot(root::Any, x::Any) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/base.jl:102
 │ no matching method found `parent(::Any, ::Any)`: AbstractTrees.parent(root::Any, x::Any)
 └────────────────────
-┌ IndexNode(tree::Any) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:117
+┌ IndexNode(tree::Any) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:117
 │ no matching method found `rootindex(::Any)`: rootindex(tree::Any)
 └────────────────────
-┌ parent(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:127
+┌ parent(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:127
 │ no matching method found `parentindex(::Any, ::Any)`: pidx = parentindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
-┌ nextsibling(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:132
+┌ nextsibling(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:132
 │ no matching method found `nextsiblingindex(::Any, ::Any)`: sidx = nextsiblingindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
-┌ prevsibling(idx::IndexNode) @ AbstractTrees /Users/aviatesk/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:137
+┌ prevsibling(idx::IndexNode) @ AbstractTrees ~/.julia/packages/AbstractTrees/Ftf8W/src/indexing.jl:137
 │ no matching method found `prevsiblingindex(::Any, ::Any)`: sidx = prevsiblingindex((idx::IndexNode).tree::Any, (idx::IndexNode).index::Any)
 └────────────────────
 ```
 
 ## Limitations
-JET explores the functions you call directly as well as their *inferable* callees. However, if the argument types for a call cannot be inferred, JET does not analyze the callee. Consequently, a report of `No errors detected` does not imply that your entire codebase is free of errors. To increase the confidence in JET's results use `@report_opt` to make sure your code is inferrible.
+JET explores the functions you call directly as well as their *inferable* callees.
+However, if the argument types for a call cannot be inferred, JET does not
+analyze the callee. Consequently, a report of `No errors detected` does not
+imply that your entire codebase is free of errors.
+To increase confidence in JET's results, use `@report_opt` to make sure your
+code is inferable.
 
 <!--
-JET integrates with [SnoopCompile](https://github.com/timholy/SnoopCompile.jl), and you can sometimes use SnoopCompile to collect the data to perform more comprehensive analyses. SnoopCompile's limitation is that it only collects data for calls that have not been previously inferred, so you must perform this type of analysis in a fresh session.
+JET integrates with [SnoopCompile](https://github.com/timholy/SnoopCompile.jl),
+and you can sometimes use SnoopCompile to collect the data to perform more
+comprehensive analyses. SnoopCompile's limitation is that it only collects data
+for calls that have not been previously inferred, so you must perform this type
+of analysis in a fresh session.
 
-See [SnoopCompile's JET-integration documentation](https://timholy.github.io/SnoopCompile.jl/stable/jet/) for further details.
+See [SnoopCompile's JET-integration documentation](https://timholy.github.io/SnoopCompile.jl/stable/jet/)
+for further details.
 -->
 
-## Acknowledgement
-This project started as my undergrad thesis project at Kyoto University, supervised by Prof. Takashi Sakuragawa.
-We were heavily inspired by [ruby/typeprof](https://github.com/ruby/typeprof), an experimental type understanding/checking tool for Ruby.
-The grad thesis about this project is published at <https://github.com/aviatesk/grad-thesis>, but currently, it's only available in Japanese.
+## Acknowledgements
+This project started as my undergraduate thesis at Kyoto University,
+supervised by Prof. Takashi Sakuragawa.
+It was heavily inspired by [ruby/typeprof](https://github.com/ruby/typeprof),
+an experimental type understanding/checking tool for Ruby.
+The thesis is published at <https://github.com/aviatesk/grad-thesis>,
+but currently it's only available in Japanese.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,11 @@
-using JET, Documenter, Literate, Markdown
+using Documenter, JET, Literate, Markdown
 
 const DOC_SRC_DIR          = normpath(@__DIR__, "src")
 const INDEX_FILENAME       = normpath(DOC_SRC_DIR, "index.md")
 const PLUGIN_API_FILENAME  = normpath(DOC_SRC_DIR, "generated-plugin-api.md")
 const PLUGIN_EXAMPLES_DIRS = (normpath(@__DIR__, "..", "examples"), normpath(DOC_SRC_DIR, "generated-plugin-examples"))
+# JET's exported API, plus the unexported names that `generate_index!` documents in index.md.
+const DOC_LINKABLE_NAMES   = push!(Set(String.(names(JET))), "JET_DEV_MODE")
 
 writeln(io, xs...) = write(io, xs..., '\n')
 
@@ -19,13 +21,6 @@ function generate_index!()
         README = string(@doc JET)
         incode = false
         for line in split(README, '\n')
-            if line == "## Quickstart"
-                writeln(io, """
-                ```@docs
-                JET.JET_AVAILABLE
-                ```
-                """)
-            end
             if startswith(line, "```julia-repl") && !endswith(line, "noeval")
                 incode = true
                 writeln(io, "```@repl index")
@@ -42,14 +37,16 @@ function generate_index!()
                 end
                 continue
             end
+            # Link code spans that name a documented JET API. Match the whole span
+            # (optionally `JET.`-qualified) rather than a substring, so that spans like
+            # `report_package(AbstractTrees)` are not turned into links.
             line_ref = replace(line,
                 r"`(.+?)`" => function (word)
-                    if any(names(JET)) do name
-                            occursin(String(name), word)
-                        end
-                        return "[$word](@ref)"
-                    end
-                    return word
+                    name = replace(word, '`' => "", "JET." => "")
+                    name in DOC_LINKABLE_NAMES || return word
+                    # Always resolve against `JET`: an unqualified `@ref` resolves in the
+                    # page's own context, which only sees JET's exported names.
+                    return "[$word](@ref JET.$name)"
                 end)
             writeln(io, line_ref)
         end
@@ -116,19 +113,21 @@ function generate_api_doc(examples_pages)
         examples_contents = codeblock("Pages = $(repr(examples_pages))", "@contents")
 
         s = md"""
-        # [`AbstractAnalyzer` framework](@id AbstractAnalyzer-Framework)
+        # [`AbstractAnalyzer` framework](@id AbstractAnalyzer-framework)
 
         $contents
 
         JET offers an infrastructure to implement a "plugin" code analyzer.
-        Actually, [JET's default error analyzer](@ref jetanalysis) is one specific instance
-        of such a plugin analyzer built on top of the framework.
+        Actually, [JET's default error analyzer](@ref jetanalysis) is one
+        specific instance of such a plugin analyzer built on top of the
+        framework.
 
-        In this documentation we will try to elaborate the framework APIs and showcase example analyzers.
+        This documentation elaborates on the framework APIs and showcases
+        example analyzers.
 
         !!! warning
-            The APIs described in this page is _very_ experimental and subject to changes.
-            And this documentation is also very WIP.
+            The APIs described on this page are highly experimental and subject
+            to change. This documentation is also a work in progress.
 
         ## Interfaces
 
@@ -150,7 +149,7 @@ end
 let
     DocMeta.setdocmeta!(JET, :DocTestSetup, :(using JET); recursive=true)
     examples = generate_example_docs!()
-    makedocs(; modules = [JET, Base.Compiler], # TODO use the Compiler stdlib wiht the full implementation?
+    makedocs(; modules = [JET],
                sitename = "JET.jl",
                pages = Any[
                     "README" => generate_index!(),

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -11,22 +11,27 @@ the [`sourceinfo`](@ref print-config) configuration set to `:full`:
 ```julia
 @report_call sourceinfo=:full sum("julia")
 ```
-or equivalently:
+
+Or equivalently:
+
 ```julia
 report_call(sum, (String,); sourceinfo=:full)
 ```
 
-You can also analyze a top-level script `path/to/file.jl` while specifying the [`target_modules` configuration](@ref result-config):
+You can also analyze a top-level script `path/to/file.jl` while specifying the
+[`target_modules` configuration](@ref result-config):
+
 ```julia
 report_file("path/to/file.jl";
             target_modules = (Main,))
 ```
 
 !!! note
-    The documented objects listed below (such as "`JET.configured_reports`") represent internal configuration structures.
-    While you won't interact with these objects directly, their documentation describes the available configuration options
-    that you can pass as keyword arguments to JET's analysis functions.
-
+    The documented objects listed below (such as
+    "`JET.configured_reports`") represent internal configuration structures.
+    While you won't interact with these objects directly, their documentation
+    describes the available configuration options that you can pass as keyword
+    arguments to JET's analysis functions.
 
 ## [Configurations for analysis result](@id result-config)
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -2,19 +2,24 @@
 
 ## [Abstract interpretation](@id abstractinterpret)
 
-In order to perform type-level program analysis, JET.jl uses
-[`Base.Compiler.AbstractInterpreter` interface](https://github.com/JuliaLang/julia/blob/master/base/compiler/types.jl),
-and customizes its abstract interpretation by overloading a subset of `Base.Compiler` functions, that are originally
-developed for Julia compiler's type inference and optimizations that aim at generating efficient native code for CPU execution.
+In order to perform type-level program analysis, JET.jl uses the
+`Compiler.AbstractInterpreter` interface and customizes its abstract
+interpretation by overloading a subset of the `Compiler` functions, which were
+originally developed for the Julia compiler's type inference and for
+optimizations that aim at generating efficient native code for CPU execution.
 
-[`JET.AbstractAnalyzer`](@ref) overloads a set of `Base.Compiler` functions to implement the "core" functionalities
-of JET's analysis, including inter-procedural error report propagation and caching of the analysis result.
-And each plugin analyzer (e.g. [`JET.JETAnalyzer`](@ref)) will overload more `Base.Compiler` functions so that it can
-perform its own program analysis on top of the core `AbstractAnalyzer` infrastructure.
+[`JET.AbstractAnalyzer`](@ref) overloads a subset of `Compiler` methods to
+implement JET's core functionality, including interprocedural propagation of
+error reports and caching of analysis results. Each plugin analyzer, such as
+[`JET.JETAnalyzer`](@ref), overloads additional `Compiler` methods to
+implement its own analysis on top of the `AbstractAnalyzer` infrastructure.
 
-Most overloads use the [`invoke`](https://docs.julialang.org/en/v1/base/base/#Core.invoke) reflection, which allows
-`AbstractAnalyzer` to dispatch to the original `AbstractInterpreter`'s abstract interpretation methods while still
-passing `AbstractAnalyzer` to the subsequent (maybe overloaded) callees.
+Most of these overloads use
+[`invoke`](https://docs.julialang.org/en/v1/base/base/#Core.invoke)
+to call the corresponding methods for `AbstractInterpreter`. The actual
+`AbstractAnalyzer` instance is still passed as the interpreter argument, so
+calls made from within those original methods can dispatch back to
+analyzer-specific overloads.
 
 ### How `AbstractAnalyzer` manages caches
 
@@ -43,7 +48,9 @@ JET.JETCallResult
 
 ### [Splitting and filtering reports](@id optanalysis-splitting)
 
-Both `JETToplevelResult` and `JETCallResult` can be split into individual failures for integration with tools like Cthulhu:
+Both `JETToplevelResult` and `JETCallResult` can be split into individual
+failures for integration with tools like Cthulhu:
+
 ```@docs
 JET.get_reports
 JET.reportkey

--- a/docs/src/jetanalysis.md
+++ b/docs/src/jetanalysis.md
@@ -89,21 +89,32 @@ add a new `bar(::AbstractString)` definition.
 
 As for the second error, let's assume that, for some reason, we are not
 interested in fixing it and want to ignore errors that may happen within
-`Base`. We can use the [`target_modules`](@ref result-config) configuration to
-limit the analysis scope to the current module context and ignore the possible
-error that may happen within `sum(a)`[^1].
+`Base`. We can use the [`ignored_modules`](@ref result-config) configuration to
+exclude `Base` from the analysis scope and ignore the possible error that may
+happen within `sum(a)`[^1].
 
-[^1]: We used `target_modules` just for the sake of demonstration. To make it
+[^1]: We used `ignored_modules` just for the sake of demonstration. To make it
     more idiomatic, we should initialize `a` as a typed vector, `a = Int[]`, and
     then we will not get any problems from `sum(a)` even without the
-    `target_modules` configuration.
+    `ignored_modules` configuration.
 
 ```@repl quickstart
 # hot-fix the definition of `bar`
 bar(s::AbstractString) = parse(Int, s)
 
 # now no errors should be reported!
-@report_call target_modules=(@__MODULE__,) foo("1 2 3")
+@report_call ignored_modules=(Base,) foo("1 2 3")
+```
+
+The complementary [`target_modules`](@ref result-config) configuration keeps
+only the reports that match. A module given to these configurations matches
+that module *and its submodules*, where the matching stops at namespace roots:
+`Base` and package root modules do not count as submodules of `Main`. Since
+code defined interactively in the REPL lives in `Main`, we can get the same
+effect by retaining `Main` only:
+
+```@repl quickstart
+@report_call target_modules=(Main,) foo("1 2 3")
 ```
 
 So far, we have used the default error analysis mode, which collects problems
@@ -153,13 +164,13 @@ with the unit-testing infrastructure of Julia's
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/):
 
 ```@repl quickstart
-@test_call target_modules=(@__MODULE__,) foo("1 2 3")
+@test_call ignored_modules=(Base,) foo("1 2 3")
 
 using Test
 
 # we can get a nice summary using `@testset`!
 @testset "JET testset" begin
-    @test_call target_modules=(@__MODULE__,) foo("1 2 3") # should pass
+    @test_call ignored_modules=(Base,) foo("1 2 3") # should pass
 
     test_call(myifelse, (Integer, Int, Int); mode=:sound)
 

--- a/docs/src/jetanalysis.md
+++ b/docs/src/jetanalysis.md
@@ -1,33 +1,35 @@
 # [Error analysis](@id jetanalysis)
 
-Julia's type system is quite expressive and its type inference is strong enough to generate
-fairly optimized code from a highly generic program written in a concise syntax.
-But as opposed to other statically-compiled languages, Julia by design does _not_ error nor
-warn anything even if it detects possible errors during its compilation process no matter
-how serious they are. In essence, Julia achieves highly generic and composable programming
-by delaying all the errors and warnings to the runtime.
+Julia's type system is quite expressive, and its type inference is strong enough
+to generate fairly optimized code from a highly generic program written in a
+concise syntax. Unlike other statically compiled languages, however, Julia by
+design does not report an error or warning when it detects possible errors
+during compilation, no matter how serious they are. In essence, Julia achieves
+highly generic and composable programming by delaying all errors and warnings
+until runtime.
 
 This is a core design choice of the language. On the one hand, Julia's dynamism
-allows it to work in places where data types can not be fully decided ahead of runtime
-(e.g. when the program is duck-typed with generic pieces of code, or when the program
-consumes some data that is only known at runtime). On the other hand, with Julia, it's
-not straightforward to have such modern development experiences that a static language can
-typically offer, as like static type checking and rich IDE features.
+allows it to work in places where data types cannot be fully decided ahead of
+runtime (e.g., when the program is duck-typed with generic pieces of code, or
+when the program consumes some data that is only known at runtime). On the
+other hand, with Julia, it is not straightforward to have the modern
+development experiences that a static language can typically offer, such as
+static type checking and rich IDE features.
 
-JET is a trial to get the best of both worlds: can we have a sufficiently useful static
-checking without losing all the beauty of Julia's dynamism and composability?
-JET's approach is very different from
-["gradual typing"](https://en.wikipedia.org/wiki/Gradual_typing),
-that is a common technique to bring static analysis into a dynamic language, as used for
-e.g. [mypy](https://github.com/python/mypy) for Python and
-[TypeScript](https://www.typescriptlang.org/) for JavaScript.
-Rather, JET's static analysis is powered by Julia's builtin type inference system, that
-is based on a technique called
+JET is a trial to get the best of both worlds: can we have sufficiently useful
+static checking without losing all the beauty of Julia's dynamism and
+composability? JET's approach is very different from
+["gradual typing"](https://en.wikipedia.org/wiki/Gradual_typing), which is a
+common technique for bringing static analysis into a dynamic language, as used
+by, e.g., [mypy](https://github.com/python/mypy) for Python and
+[TypeScript](https://www.typescriptlang.org/) for JavaScript. Rather, JET's
+static analysis is powered by Julia's built-in type inference system, which is
+based on a technique called
 ["abstract interpretation"](https://en.wikipedia.org/wiki/Abstract_interpretation).
-This way JET can analyze just a normal Julia program and smartly detect possible
-errors statically, without requiring any additional setups like scattering type annotations
-just for the sake of analysis but preserving original polymorphism and composability of
-the program, as effectively as the Julia compiler can optimize your Julia program.
+JET can therefore analyze a normal Julia program and detect possible errors
+without analysis-only type annotations, preserving the program's original
+polymorphism and composability. Its effectiveness depends on the precision of
+Julia's type inference, which also powers compiler optimization.
 
 ## [Quick start](@id jetanalysis-quick-start)
 
@@ -35,33 +37,37 @@ the program, as effectively as the Julia compiler can optimize your Julia progra
 using JET
 ```
 
-Let's start with the simplest example: how JET can find anything wrong with `sum("julia")`?
-[`@report_call`](@ref) and [`report_call`](@ref) analyzes a given function call and report
-back possible problems. They can be used in a similar way as
+Let's start with the simplest example: how can JET find anything wrong with
+`sum("julia")`? [`@report_call`](@ref) and [`report_call`](@ref) analyze a given
+function call and report possible problems. They can be used similarly to
 [`@code_typed`](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed)
 and [`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed).
-Those [interactive entry points](@ref jetanalysis-interactive-entry) are the easiest
-way to use JET:
+These [interactive entry points](@ref jetanalysis-interactive-entry) are the
+easiest way to use JET:
+
 ```@repl quickstart
 @report_call sum("julia")
 ```
 
-So JET found two possible problems. Now let's see how they can occur in _actual execution_:
+So JET found two possible problems. Now let's see how they can occur in actual
+execution:
+
 ```@repl quickstart
 sum("julia") # will lead to `MethodError: +(::Char, ::Char)`
 sum("") # will lead to `MethodError: zero(Type{Char})`
 ```
 
-We should note that `@report_call sum("julia")` could detect both of those two different
-errors that can happen at runtime. This is because `@report_call` does a static analysis —
-it analyzes the function call in a way that does not rely on one instance of runtime
-execution, but rather it reasons about all the possible executions!
-This is one of the biggest advantages of static analysis because other alternatives to
-check software qualities like "testing" usually rely on _some_ runtime execution and they
-can only cover a subset of all the possible executions.
+Note that `@report_call sum("julia")` could detect both of those different
+errors that can happen at runtime. This is because `@report_call` performs
+static analysis: it analyzes the function call in a way that does not rely on
+one instance of runtime execution, but rather reasons about all possible
+executions. This is one of the biggest advantages of static analysis because
+other ways to check software quality, such as testing, usually rely on _some_
+runtime execution and can cover only a subset of all possible executions.
 
-As mentioned above, JET is designed to work with _just a normal_ Julia program.
-Let's define new arbitrary functions and run JET on it:
+As mentioned above, JET is designed to work with a _normal_ Julia program. Let's
+define new arbitrary functions and run JET on them:
+
 ```@repl quickstart
 function foo(s0)
     a = []
@@ -76,32 +82,35 @@ bar(s::String) = parse(Int, s)
 @report_call foo("1 2 3")
 ```
 
-Now let's fix this problematic code.
-First, we can fix the definition of `bar` so that it accepts generic `AbstractString` input.
-JET's analysis result can be dynamically updated when we refine a function definition,
-and so we just need to add a new `bar(::AbstractString)` definition.
-As for the second error, let's assume, for some reason, we're not interested in fixing it and
-we want to ignore errors that may happen within `Base`. Then we can use the
-[`target_modules`](@ref result-config) configuration to limit the analysis scope to
-the current module context to ignore the possible error that may happen within `sum(a)`[^1].
+Now let's fix this problematic code. First, we can fix the definition of `bar`
+so that it accepts generic `AbstractString` input. JET's analysis result can be
+dynamically updated when we refine a function definition, so we just need to
+add a new `bar(::AbstractString)` definition.
 
-[^1]: We used `target_modules` just for the sake of demonstration. To make it more
-      idiomatic, we should initialize `a` as typed vector `a = Int[]`, and then we won't
-      get any problem from `sum(a)` even without the `target_modules` configuration.
+As for the second error, let's assume that, for some reason, we are not
+interested in fixing it and want to ignore errors that may happen within
+`Base`. We can use the [`target_modules`](@ref result-config) configuration to
+limit the analysis scope to the current module context and ignore the possible
+error that may happen within `sum(a)`[^1].
+
+[^1]: We used `target_modules` just for the sake of demonstration. To make it
+    more idiomatic, we should initialize `a` as a typed vector, `a = Int[]`, and
+    then we will not get any problems from `sum(a)` even without the
+    `target_modules` configuration.
 
 ```@repl quickstart
-# hot fix the definition of `bar`
+# hot-fix the definition of `bar`
 bar(s::AbstractString) = parse(Int, s)
 
-# now no errors should be reported !
+# now no errors should be reported!
 @report_call target_modules=(@__MODULE__,) foo("1 2 3")
 ```
 
-So far, we have used the default error analysis pass, which collects problems according to
-one specific (somewhat opinionated) definition of "errors".
-JET offers other error reporting passes, including the "sound" error detection
-as well as the simpler "typo" detection pass.
-They can be switched using the `mode` configuration:
+So far, we have used the default error analysis mode, which collects problems
+according to one specific, somewhat opinionated definition of "errors". JET
+offers other analysis modes, including "sound" error detection and the simpler
+"typo" detection mode (see [`JETAnalyzer`](@ref JET.JETAnalyzer) for an
+overview). They can be switched using the `mode` configuration:
 
 ```@repl quickstart
 function myifelse(cond, a, b)
@@ -112,11 +121,13 @@ function myifelse(cond, a, b)
     end
 end
 
-# the default analysis pass doesn't report "non-boolean (T) used in boolean context" error
-# as far as there is a possibility when the condition "can" be bool (NOTE: Bool <: Integer)
+# the default analysis pass doesn't report a
+# "non-boolean `T` found in boolean context" error if the condition could be
+# `Bool` (note that `Bool <: Integer`)
 report_call(myifelse, (Integer, Int, Int))
 
-# the sound analyzer doesn't permit such a case: it requires the type of a conditional value to be `Bool` strictly
+# the sound analyzer requires the type of a conditional value to be strictly
+# `Bool`
 report_call(myifelse, (Integer, Int, Int); mode=:sound)
 
 function strange_sum(a)
@@ -136,52 +147,61 @@ end
 @report_call mode=:typo strange_sum([])
 ```
 
-We can use [`@test_call`](@ref) and [`test_call`](@ref) to assert that your program is free
-from problems that `@report_call` can detect.
-They work nicely with [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s
-unit-testing infrastructure:
+We can use [`@test_call`](@ref) and [`test_call`](@ref) to assert that your
+program is free from problems that `@report_call` can detect. They work nicely
+with the unit-testing infrastructure of Julia's
+[`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/):
+
 ```@repl quickstart
 @test_call target_modules=(@__MODULE__,) foo("1 2 3")
 
 using Test
 
-# we can get the nice summery using `@testset` !
+# we can get a nice summary using `@testset`!
 @testset "JET testset" begin
     @test_call target_modules=(@__MODULE__,) foo("1 2 3") # should pass
 
     test_call(myifelse, (Integer, Int, Int); mode=:sound)
 
-    @test_call broken=true foo("1 2 3") # `broken` and `skip` options are supported
+    @test_call broken=true foo("1 2 3")  # `broken` and `skip` options are supported
 
-    @test foo("1 2 3") == 6 # of course other `Test` macros can be used in the same place
+    @test foo("1 2 3") == 6  # other `Test` macros can be used in the same place
 end
 ```
 
-JET uses JET itself in its test pipeline: JET's static analysis has been proven to
-be very useful and helped its development a lot.
-If interested, take a peek at [JET's `"self check"` testset](https://github.com/aviatesk/JET.jl/blob/master/test/self_check.jl).
+JET uses itself in its test pipeline: JET's static analysis has been proven to
+be very useful and has helped its development a lot. If interested, take a peek
+at JET's
+[`"self check"` testset](https://github.com/aviatesk/JET.jl/blob/master/test/self_check.jl).
 
-Lastly, let's see the example that demonstrates JET can analyze a "top-level" program.
-The top-level analysis should be considered as a somewhat experimental feature, and at this moment
-you may need additional configurations to run it correctly. Please read the descriptions of
-[top-level entry points](@ref jetanalysis-toplevel-entry) and choose an appropriate entry point for
-your use case. Here we run [`report_file`](@ref) on [demo.jl](https://github.com/aviatesk/JET.jl/blob/master/demo.jl).
-It automatically extracts and loads "definitions" of functions, structs and such,
+Lastly, let's see an example that demonstrates that JET can analyze a
+"top-level" program. Top-level analysis should be considered somewhat
+experimental, and currently you may need additional configurations to run it
+correctly. Please read the descriptions of
+[top-level entry points](@ref jetanalysis-toplevel-entry) and choose an
+appropriate entry point for your use case. Here we run [`report_file`](@ref) on
+[demo.jl](https://github.com/aviatesk/JET.jl/blob/master/demo.jl). It
+automatically extracts and loads "definitions" of functions, structs, and such,
 and then analyzes their "usages" statically:
+
 ```@repl quickstart
 report_file(normpath(Base.pkgdir(JET), "demo.jl"))
 ```
 
-## Errors kinds and how to fix them
+## Error kinds and how to fix them
 
 ### `no matching method found`
+
 #### Description
+
 This error occurs when running the code might throw a `MethodError` at runtime.
-Similar to normal `MethodErrors`, this happens if a function is being called without a method matching the given argument types.
+Similar to regular `MethodError`s, this happens if a function is called without
+an applicable method for the given argument types.
 
 This is the most common error detected in most Julia code.
 
 #### Example
+
 ```@repl nomatch1
 f(x::Integer) = x + one(x);
 g(x) = f(x);
@@ -191,16 +211,27 @@ using JET # hide
 ```
 
 #### How to fix
-This error indicates some kind of type error in your code. You fix it like you would fix a regular `MethodError` thrown at runtime.
+
+This error indicates some kind of type error in your code. Fix it as you would a
+regular `MethodError` thrown at runtime.
 
 ### `no matching method found (x/y union split)`
-#### Description
-This error occurs when a variable `x` is inferred to be a union type, and `x` being one or more of the union's members would lead to a `MethodError`. For example, if the compiler infers `x` to be of type `Union{A, B}`, and then a function `f(x)` is called which would lead to a `MethodError` if `x` is a `A`, this error would occur.
 
-More technically, this happens when one or more branches created by the compiler through union splitting contains a `no matching method found` error.
+#### Description
+
+This error occurs when a variable `x` is inferred to be a union type, and `x`
+being one or more of the union's members would lead to a `MethodError`. For
+example, suppose the compiler infers `x` to be of type `Union{A, B}` and the
+code then calls `f(x)`. This error occurs if the call would lead to a
+`MethodError` when `x` is an `A`.
+
+More technically, this happens when one or more branches created by the compiler
+through union splitting contain a `no matching method found` error.
 
 #### Example
+
 Minimal example:
+
 ```@repl union1
 struct Foo
     x::Union{Int, String}
@@ -215,6 +246,7 @@ using JET # hide
 ```
 
 More common example:
+
 ```@repl union1
 function pos_after_tab(v::AbstractArray{UInt8})
     # findfirst can return `nothing` on no match
@@ -226,12 +258,21 @@ end
 ```
 
 #### How to fix
-This error is unique in that idiomatic Julia code may still lead to this error. For example, in the `pos_after_tab` function above, if the input vector does not have a `'\t'` byte, `p` will be `nothing`, and a `MethodError` will be thrown when `nothing + 1` is attempted.
-However, in many situations, the possibility of such a `MethodError` is not a mistake, but rather an idiomatic way of erroring.
 
-There are different possibilities to address this kind of error. Let's take the `pos_after_tab` example:
+This error is unique in that idiomatic Julia code may still lead to it. For
+example, in the `pos_after_tab` function above, if the input vector does not
+have a `'\t'` byte, `p` will be `nothing`, and a `MethodError` will be thrown
+when `nothing + 1` is attempted. However, in many situations, the possibility
+of such a `MethodError` is not a mistake but rather an idiomatic way of raising
+an error.
 
-If you actually _could_ expect `p` to legitimately be `nothing` for valid input (i.e. the input could lack a `'\t'` byte), then your function should be written to take this edge case into account:
+There are different possibilities for addressing this kind of error. Let's
+take the `pos_after_tab` example.
+
+If you could legitimately expect `p` to be `nothing` for valid input (i.e., the
+input could lack a `'\t'` byte), then your function should be written to take
+this edge case into account:
+
 ```@repl union2
 function pos_after_tab(v::AbstractArray{UInt8})
     p = findfirst(isequal(UInt8('\t')), v)
@@ -246,9 +287,17 @@ using JET # hide
 @report_call pos_after_tab(codeunits("a\tb"))
 ```
 
-By adding the `if p === nothing` check, the compiler will know that the type of `p` must be `Nothing` inside the `if` block, and `Int` in the `else` block. This way, the compiler knows a `MethodError` is not possible, and the error will disappear.
+By adding the `if p === nothing` check, the compiler will know that the type of
+`p` must be `Nothing` inside the `if` block and `Int` in the `else` block. This
+way, the compiler knows a `MethodError` is not possible, and the error will
+disappear.
 
-If you expect a `'\t'` byte to always be present, such that `findfirst` always should return an `Int` for valid input, you can add a typeassert in the function to assert that the return value of `findfirst` must be, say, an `Integer`. Then, the compiler will know that if the typeassert passes, the value returned by `findfirst` cannot be `nothing` (and hence in this case must be `Int`):
+If you expect a `'\t'` byte to always be present, such that `findfirst` should
+always return an `Int` for valid input, you can add a type assertion in the
+function to assert that the return value of `findfirst` must be, say, an
+`Integer`. Then, the compiler will know that if the type assertion passes, the
+value returned by `findfirst` cannot be `nothing` and hence, in this case, must
+be an `Int`:
 
 ```@repl union2
 function pos_after_tab(v::AbstractArray{UInt8})
@@ -259,15 +308,22 @@ end;
 @report_call pos_after_tab(codeunits("a\tb"))
 ```
 
-The code will still error at runtime due to the typeassert if `findfirst` returns `nothing`, but JET will no longer detect it as an error, because the programmer, by adding the typeassert, explicitly acknowledge that the compiler's inference may not be precise enough, and helps the compiler.
+The code will still error at runtime due to the type assertion if `findfirst`
+returns `nothing`, but JET will no longer detect it as an error because the
+programmer, by adding the type assertion, explicitly acknowledges that the
+compiler's inference may not be precise enough and helps the compiler.
 
-Note that adding a typeassert also improves code quality:
-* The programmer's intent to never observe `nothing` is communicated clearly
-* After the typeassert passes, `p` is inferred to be `Int` instead of a union, and this more precise type inference generates more efficient code.
-* More precise inference reduces the risk of invalidations from the code, improving latency.
+Note that adding a type assertion also improves code quality:
 
-A special case occurs when loading `Union`-typed fields from structs.
-Julia does not realize that loading the same field multiple times from a mutable struct necessarily returns the same object. Hence, in the following example:
+- The programmer's intent never to observe `nothing` is communicated clearly.
+- After the type assertion passes, `p` is inferred to be `Int` instead of a
+  union, and this more precise type inference generates more efficient code.
+- More precise inference reduces the risk of invalidations from the code,
+  improving latency.
+
+A special case occurs when loading `Union`-typed fields from structs. Julia does
+not realize that loading the same field multiple times from a mutable struct
+necessarily returns the same object. Hence, consider the following example:
 
 ```@repl union3
 mutable struct Foo
@@ -286,7 +342,11 @@ using JET # hide
 @report_call f(Foo(1))
 ```
 
-We might reasonably expect the compiler to know that in the `else` branch, `x.x` must be an `Int`, since it just checked that it is not `nothing`. However, the compiler does not know that the value obtained from loading the `x` field in the expression `x.x` on the like with the if statement in this case is the same value as the value obtained when loading the `x` field in the `x.x + 1` statement.
+We might reasonably expect the compiler to know that in the `else` branch,
+`x.x` must be an `Int`, since it just checked that it is not `nothing`. However,
+the compiler does not know that the value obtained from loading the `x` field
+in the `x.x` expression on the line with the `if` statement is the same value
+as the value obtained when loading the `x` field in the `x.x + 1` statement.
 You can solve this issue by assigning `x.x` to a variable:
 
 ```@repl union3
@@ -303,10 +363,14 @@ end;
 ```
 
 ### `X is not defined`
+
 #### Description
-This happens when a name `X` is used in a function, but no object named `X` can be found.
+
+This happens when a name `X` is used in a function, but no object named `X` can
+be found.
 
 #### Example
+
 ```@repl defined1
 f(x) = foo(x) + 1;
 
@@ -315,15 +379,23 @@ using JET # hide
 ```
 
 #### How to fix
+
 This error can have a couple of causes:
-* `X` is misspelled. If so, correct the typo
-* `X` exists, but cannot be reached from the scope of the function.
-  If so, pass it in as an argument to the offending function.
+
+- `X` is misspelled. If so, correct the typo.
+- `X` exists but cannot be reached from the scope of the function. If so, pass
+  it as an argument to the offending function.
 
 ### `type T has no field F`
+
 #### Description
-This error occurs when `Core.getfield` is (indirectly) called with a nonexisting and hardcoded field name. For example, if an object have a field called `vec` and you type it `vector`.
+
+This error occurs when `Core.getfield` is called, directly or indirectly, with
+a nonexistent hard-coded field name. For example, an object might have a field
+called `vec`, but you type `vector`.
+
 #### Example
+
 ```@repl field1
 struct Foo
     my_field
@@ -335,14 +407,22 @@ using JET # hide
 ```
 
 #### How to fix
+
 This error often occurs when the field name is mistyped. Correct the typo.
 
 ### `BoundsError: Attempt to access T at index [i]`
+
 #### Description
-This error occurs when it is known at compile time that the call will throw a `BoundsError`.
-Note that most `BoundsErrors` cannot be predicted at compile time. For the compiler to know a function attempts to access a container out of bounds, both the container length and the index value must be known at compiletime. Hence, the error is detected for a `Tuple` input in the example below, but not for a `Vector` input.
+
+This error occurs when it is known at compile time that the call will throw a
+`BoundsError`. Note that most `BoundsError`s cannot be predicted at compile
+time. For the compiler to know that a function attempts to access a container
+out of bounds, both the container length and the index value must be known at
+compile time. Hence, the error is detected for a `Tuple` input in the example
+below, but not for a `Vector` input.
 
 #### Example
+
 ```@repl bounds1
 get_fourth(x) = x[4]
 
@@ -352,15 +432,24 @@ using JET # hide
 ```
 
 #### How to fix
-If this error appears, the offending code uses a bad index. Since the error most often occurs when the index is hardcoded, simply fix the index value.
+
+If this error appears, the offending code uses a bad index. Since the error most
+often occurs when the index is hard-coded, simply fix the index value.
 
 ### `may throw [...]`
+
 #### Description
-This error indicates that JET detected the possibility of an exception.
-By default, JET will not report this error, unless a function is inferred to _always_ throw, AND the exception is not caught in a try statement. In "sound" mode, this error is reported if the function _may_ throw.
+
+This error indicates that JET detected the possibility of an exception. By
+default, JET will not report this error unless a function is inferred to
+_always_ throw and the exception is not caught in a `try` statement. In "sound"
+mode, this error is reported if the function _may_ throw.
 
 #### Example
-In this example, the function is known at compile time to throw an uncaught exception, and so is reported by default:
+
+In this example, the function is known at compile time to throw an uncaught
+exception, so it is reported by default:
+
 ```@repl throw1
 f(x) = x isa Integer ? throw("Integer") : nothing;
 
@@ -368,7 +457,9 @@ using JET # hide
 @report_call f(1)
 ```
 
-In this example, it's not known at compile time whether it throws, and therefore, JET reports no errors by default. In sound mode, the error is reported.
+In this example, it is not known at compile time whether the function throws,
+so JET reports no errors by default. In sound mode, the error is reported.
+
 ```@repl throw2
 f(x) = x == 9873984732 ? nothing : throw("Bad value")
 
@@ -377,7 +468,9 @@ using JET # hide
 @report_call mode=:sound f(1)
 ```
 
-In this example, the exception is handled, so JET reports no errors by default. In sound mode, the error is reported:
+In this example, the exception is handled, so JET reports no errors by default.
+In sound mode, the error is reported:
+
 ```@repl throw3
 g() = throw();
 f() = try
@@ -397,7 +490,9 @@ using JET # hide
 ### [Interactive entry points](@id jetanalysis-interactive-entry)
 
 JET offers interactive analysis entry points that can be used similarly to
-[`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed) and its family:
+[`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed) and
+its family:
+
 ```@docs
 JET.@report_call
 JET.report_call
@@ -405,21 +500,23 @@ JET.report_call
 
 ### [Top-level entry points](@id jetanalysis-toplevel-entry)
 
-JET can also analyze your "top-level" program: it can just take your Julia script or package
-and will report possible errors.
+JET can also analyze your "top-level" program: it can take your Julia script or
+package and report possible errors.
 
-Note that JET will analyze your top-level program "half-statically": JET will selectively
-interpret and load "definitions" (like a function or struct definition) and try to
-simulate Julia's top-level code execution process.
-While it tries to avoid executing any other parts of code like function calls and analyzes
-them based on abstract interpretation instead (and this is a part where JET statically analyzes your code).
-If you're interested in how JET selects "top-level definitions", please see [`JET.virtual_process`](@ref).
+JET analyzes your top-level program "half-statically": it selectively
+interprets and loads "definitions", such as function or struct definitions,
+and tries to simulate Julia's top-level code execution process. It tries to
+avoid executing any other parts of the code, such as function calls, and
+analyzes them based on abstract interpretation instead. This is where JET
+statically analyzes your code. If you are interested in how JET selects
+"top-level definitions", see [`JET.virtual_process`](@ref).
 
 !!! warning
-    Because JET will interpret "definitions" in your code, that part of top-level analysis
-    certainly _runs_ your code. So we should note that JET can cause some side effects from your code;
-    for example, JET will try to expand all the macros used in your code, and so the side effects
-    involved with macro expansions will also happen in JET's analysis process.
+    Because JET interprets "definitions" in your code, that part of top-level
+    analysis certainly _runs_ your code. Note that JET can therefore cause side
+    effects from your code. For example, JET will try to expand all macros used
+    in your code, so side effects involved with macro expansions will also
+    happen during JET's analysis process.
 
 ```@docs
 JET.report_file
@@ -429,8 +526,12 @@ JET.report_text
 
 ### [`Test` integration](@id jetanalysis-test-integration)
 
-JET also exports entries that are fully integrated with [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s unit-testing infrastructure.
-It can be used in your test suite to assert your program is free from errors that JET can detect:
+JET also exports entry points that are fully integrated with the unit-testing
+infrastructure of Julia's
+[`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
+They can be used in your test suite to assert that your program is free from
+errors that JET can detect:
+
 ```@docs
 JET.@test_call
 JET.test_call
@@ -439,10 +540,17 @@ JET.test_package
 JET.test_text
 ```
 
+## [`JETAnalyzer`](@id jetanalyzer)
+
+```@docs
+JET.JETAnalyzer
+```
+
 ## [Configurations](@id jetanalysis-config)
 
-In addition to the [general configurations](@ref), the error analysis can take the
-following specific configurations:
+In addition to the [general configurations](@ref general-configurations),
+error analysis can take the following specific configurations:
+
 ```@docs
 JET.JETAnalyzerConfig
 ```

--- a/docs/src/optanalysis.md
+++ b/docs/src/optanalysis.md
@@ -172,7 +172,7 @@ end
 
 @report_opt compute(30)  # bunch of reports will be reported from the `println` call
 
-@report_opt target_modules=(@__MODULE__,) compute(30)  # focus on what we wrote, and no error should be reported
+@report_opt target_modules=(Main,) compute(30)  # focus on what we wrote, and no error should be reported
 ```
 
 There is also [`function_filter`](@ref optanalysis-config), which can ignore
@@ -187,7 +187,7 @@ unit-testing infrastructure, and we can use it like other `Test` macros e.g.
 ```@repl quickstart
 @test_opt sumup(cos)
 
-@test_opt target_modules=(@__MODULE__,) compute(30)
+@test_opt target_modules=(Main,) compute(30)
 
 using Test
 
@@ -197,7 +197,7 @@ using Test
     n = rand(Int)
     @test_opt sumup(cos, n) # should pass
 
-    @test_opt target_modules=(@__MODULE__,) compute(30) # should pass
+    @test_opt target_modules=(Main,) compute(30) # should pass
 
     @test_opt broken=true compute(30) # should pass with the "broken" annotation
 end

--- a/docs/src/optanalysis.md
+++ b/docs/src/optanalysis.md
@@ -1,33 +1,59 @@
 # [Optimization analysis](@id optanalysis)
 
-Successful type inference and optimization are key to high-performing Julia programs.
-But as mentioned in [the performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/), there are some
-chances where Julia can not infer the types of your program very well and can not optimize it well accordingly.
+Successful type inference and optimization are key to high-performing Julia
+programs. But as mentioned in
+[the performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/),
+there are cases where Julia cannot infer the types of your program well and
+consequently cannot optimize it well either.
 
-While there are many possibilities of "type-instabilities", like usage of non-constant global variable most notably,
-probably the most tricky one would be ["captured variable"](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured)
-– Julia can not really well infer the type of variable that is observed and modified by both inner function and enclosing one.
-And such type instabilities can lead to various optimization failures. One of the most common barriers to performance
-is known as "runtime dispatch", which happens when a matching method can't be resolved by the compiler due to the lack
-of type information and it is looked up at runtime instead. Since runtime dispatch is caused by poor type information,
-it often indicates the compiler could not do other optimizations including inlining and scalar replacements of aggregates.
+There are many possible causes of such "type instabilities". The most common is
+the use of non-constant global variables, while probably the trickiest is the
+["captured variable"](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured):
+Julia cannot infer the type of a variable well when it is observed and modified
+both by an inner function and by its enclosing one. Type instabilities like
+these can lead to various optimization failures. One of the most common
+barriers to performance is known as "runtime dispatch", which happens when the
+compiler cannot resolve a matching method due to the lack of type information
+and the method must be looked up at runtime instead. Since runtime dispatch is
+caused by poor type information, it often indicates that the compiler also
+could not apply other optimizations, including inlining and scalar replacement
+of aggregates.
 
-In order to avoid such problems, we usually inspect the output of [`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed)
-or its family, and check if there is anywhere type is not well inferred and optimization was not successful.
-But the problem is that one needs to have enough knowledge about inference and optimization in order to interpret
-the output. Another problem is that they can only present the "final" output of the inference and optimization, and we
-can not inspect the entire call graph and may miss finding where a problem actually happened and how the type-instability
-has been propagated.
-There is a nice package called [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), which allows us to look at
-the outputs of `code_typed` by _descending_ into a call tree, recursively and interactively. The workflow with Cthulhu
-is much more efficient and powerful, but still, it requires much familiarity with the Julia compiler and it tends to be tedious.
+To avoid such problems, we usually inspect the output of
+[`code_typed`](https://docs.julialang.org/en/v1/base/base/#Base.code_typed)
+or its family and check whether any types are not well inferred and any
+optimizations were unsuccessful. One problem with this workflow is that it
+requires enough knowledge about inference and optimization to interpret the
+output. Another is that these tools present only the "final" output of
+inference and optimization: we cannot inspect the entire call graph, so we may
+miss the place where a problem actually happens and how the type instability
+propagates from there.
+
+There is a nice package called
+[Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl), which allows us to look
+at the outputs of `code_typed` by descending into a call tree, recursively and
+interactively. The workflow with Cthulhu is much more efficient and powerful,
+but it still requires familiarity with the Julia compiler, and it tends to be
+tedious.
 
 So, why not automate it?
-JET implements such an analyzer that investigates the optimized representation of your program and _automatically_ detects
-anywhere the compiler failed in optimization. Especially, it can find where Julia creates captured variables, where
-runtime dispatch will happen, and where Julia gives up the optimization work due to unresolvable recursive function call.
 
-[SnoopCompile also detects inference failures](https://timholy.github.io/SnoopCompile.jl/stable/tutorials/snoop_inference_analysis/), but JET and SnoopCompile use different mechanisms: JET performs *static* analysis of a particular call, while SnoopCompile performs *dynamic* analysis of new inference. As a consequence, JET's detection of inference failures is reproducible (you can run the same analysis repeatedly and get the same result) but terminates at any non-inferable node of the call graph: you will miss runtime dispatch in any non-inferable callees. Conversely, SnoopCompile's detection of inference failures can explore the entire callgraph, but only for those portions that have not been previously inferred, and the analysis cannot be repeated in the same session.
+JET implements such an analyzer: it investigates the optimized representation
+of your program and automatically detects places where the compiler failed to
+optimize. In particular, it can find where Julia creates captured variables,
+where runtime dispatch happens, and where Julia gives up optimization because
+of an unresolvable recursive function call.
+
+[SnoopCompile also detects inference failures](https://timholy.github.io/SnoopCompile.jl/stable/tutorials/snoop_inference_analysis/),
+but JET and SnoopCompile use different mechanisms: JET performs _static_
+analysis of a particular call, while SnoopCompile performs _dynamic_ analysis of
+new inference. As a consequence, JET's detection of inference failures is
+reproducible (you can run the same analysis repeatedly and get the same result)
+but terminates at any non-inferable node of the call graph: you will miss
+runtime dispatch in any non-inferable callees. Conversely, SnoopCompile's
+detection of inference failures can explore the entire callgraph, but only for
+those portions that have not been previously inferred, and the analysis cannot
+be repeated in the same session.
 
 ## [Quick start](@id optanalysis-quick-start)
 
@@ -35,10 +61,12 @@ runtime dispatch will happen, and where Julia gives up the optimization work due
 using JET
 ```
 
-JET exports [`@report_opt`](@ref), which analyzes the entire call graph of a given generic function call,
-and then reports detected performance pitfalls.
+JET exports [`@report_opt`](@ref), which analyzes the entire call graph of a
+given generic function call, and then reports detected performance pitfalls.
 
-As a first example, let's see how we can find and fix runtime dispatches using JET:
+As a first example, let's see how we can find and fix runtime dispatches using
+JET:
+
 ```@repl quickstart
 n = rand(Int); # non-constant global variable
 make_vals(n) = n ≥ 0 ? (zero(n):n) : (n:zero(n));
@@ -55,10 +83,13 @@ end;
 @report_opt sumup(sin) # runtime dispatches will be reported
 ```
 
-JET's analysis result will be dynamically updated when we (re-)define functions[^1], and we can "hot-fix" the runtime
-dispatches within the same running Julia session like this:
+JET's analysis result will be dynamically updated when we (re-)define
+functions[^1], and we can "hot-fix" the runtime dispatches within the same
+running Julia session like this:
+
 ```@repl quickstart
-# we can pass parameters as a function argument instead, and then everything will be type-stable
+# we can pass parameters as a function argument instead, and then
+# everything will be type-stable
 function sumup(f, n)
     vals = make_vals(n)
     s = zero(eltype(vals))
@@ -72,10 +103,13 @@ end;
 
 @report_opt sumup(sin, rand(Int)) # now runtime dispatch free !
 ```
-[^1]: Technically, it's fully integrated with [Julia's method invalidation system](https://julialang.org/blog/2020/08/invalidations/).
 
-`@report_opt` can also report the existence of captured variables, which are really better to be eliminated within
-performance-sensitive context:
+[^1]: Technically, it's fully integrated with
+    [Julia's method invalidation system](https://julialang.org/blog/2020/08/invalidations/).
+
+`@report_opt` can also report the existence of captured variables, which are
+really better to be eliminated within performance-sensitive context:
+
 ```@repl quickstart
 # the examples below are all adapted from https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
 function abmult(r::Int)
@@ -114,10 +148,11 @@ end;
 @report_opt abmult(42)
 ```
 
-With the [`target_modules`](@ref result-config) configuration, we can easily limit the analysis scope to a specific module context:
+With the [`target_modules`](@ref result-config) configuration, we can easily
+limit the analysis scope to a specific module context:
+
 ```@repl quickstart
-# problem: when ∑1/n exceeds `x` ?
-function compute(x)
+function compute(x)  # problem: when ∑1/n exceeds `x` ?
     r = 1
     s = 0.0
     n = 1
@@ -135,16 +170,20 @@ function compute(x)
     return n, s
 end
 
-@report_opt compute(30) # bunch of reports will be reported from the `println` call
+@report_opt compute(30)  # bunch of reports will be reported from the `println` call
 
-@report_opt target_modules=(@__MODULE__,) compute(30) # focus on what we wrote, and no error should be reported
+@report_opt target_modules=(@__MODULE__,) compute(30)  # focus on what we wrote, and no error should be reported
 ```
 
-There is also [`function_filter`](@ref optanalysis-config), which can ignore specific function calls.
+There is also [`function_filter`](@ref optanalysis-config), which can ignore
+specific function calls.
 
-[`@test_opt`](@ref) can be used to assert that a given function call is free from performance pitfalls.
-It is fully integrated with [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s unit-testing infrastructure,
-and we can use it like other `Test` macros e.g. `@test`:
+[`@test_opt`](@ref) can be used to assert that a given function call is free
+from performance pitfalls. It is fully integrated with
+[`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s
+unit-testing infrastructure, and we can use it like other `Test` macros e.g.
+`@test`:
+
 ```@repl quickstart
 @test_opt sumup(cos)
 
@@ -166,9 +205,11 @@ end
 
 ## [Integration with Cthulhu](@id cthulhu-integration)
 
-If you identify inference problems, you may want to fix them. Cthulhu can be a useful tool for gaining more insight, and JET integrates nicely with Cthulhu.
+If you identify inference problems, you may want to fix them. Cthulhu can be a
+useful tool for gaining more insight, and JET integrates nicely with Cthulhu.
 
-To exploit Cthulhu, you first need to split the overall report into individual inference failures:
+To exploit Cthulhu, you first need to split the overall report into individual
+inference failures:
 
 ```@repl quickstart
 report = @report_opt sumup(sin);
@@ -176,8 +217,8 @@ rpts = JET.get_reports(report)
 ```
 
 !!! tip
-    If `rpts` is a long list, consider using `urpts = unique(reportkey, rpts)` to trim it.
-    See [`reportkey`](@ref).
+    If `rpts` is a long list, consider using
+    `urpts = unique(reportkey, rpts)` to trim it. See [`reportkey`](@ref).
 
 Now you can `ascend` individual reports:
 
@@ -196,7 +237,16 @@ or browse typed code:
    Browse typed code
 ```
 
-`ascend` will show the full call-chain to reach a particular runtime dispatch; in this case, it was our entry point, but in other cases it may be deeper in the call graph. In this case, we've interactively moved the selector `>` down to the `sumup` call (you cannot descend into the `"runtime dispatch to..."` as there is no known code associated with it) and hit `<Enter>`, at which point Cthulhu showed us that the call to `make_vals(::Any)` occured only on line 4 of the definition of `sumup` (which we entered at the REPL). Cthulhu is now prompting us to either open the code in an editor (which will fail in this case, since there is no associated file!) or view the type-annoted code. If we select the "Browse typed code" option we see
+`ascend` will show the full call-chain to reach a particular runtime dispatch;
+in this case, it was our entry point, but in other cases it may be deeper in the
+call graph. In this case, we've interactively moved the selector `>` down to the
+`sumup` call (you cannot descend into the `"runtime dispatch to..."` as there is
+no known code associated with it) and hit `<Enter>`, at which point Cthulhu
+showed us that the call to `make_vals(::Any)` occured only on line 4 of the
+definition of `sumup` (which we entered at the REPL). Cthulhu is now prompting
+us to either open the code in an editor (which will fail in this case, since
+there is no associated file!) or view the type-annoted code. If we select the
+"Browse typed code" option we see
 
 ```
 sumup(f) @ Main REPL[7]:1
@@ -216,13 +266,16 @@ Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
 
 with red highlighting to indicate the non-inferable arguments.
 
-For more information, you're encouraged to read Cthulhu's documentation, which includes a video tutorial better-suited to this interactive tool.
+For more information, you're encouraged to read Cthulhu's documentation, which
+includes a video tutorial better-suited to this interactive tool.
 
 ## [Entry points](@id optanalysis-entry)
 
 ### [Interactive entry points](@id optanalysis-interactive-entry)
 
-The optimization analysis offers interactive entry points that can be used in the same way as [`@report_call`](@ref) and [`report_call`](@ref):
+The optimization analysis offers interactive entry points that can be used in
+the same way as [`@report_call`](@ref) and [`report_call`](@ref):
+
 ```@docs
 JET.@report_opt
 JET.report_opt
@@ -230,8 +283,10 @@ JET.report_opt
 
 ### [`Test` integration](@id optanalysis-test-integration)
 
-As with [the default error analysis](@ref jetanalysis), the optimization analysis also offers the integration with
+As with [the default error analysis](@ref jetanalysis), the optimization
+analysis also offers the integration with
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/):
+
 ```@docs
 JET.@test_opt
 JET.test_opt
@@ -239,16 +294,22 @@ JET.test_opt
 
 ### [Top-level entry points](@id optanalysis-toplevel-entry)
 
-By default, JET doesn't offer top-level entry points for the optimization analysis, because it's usually used for only a
-selective portion of your program.
-But if you want you can just use [`report_file`](@ref) or similar top-level entry points with specifying
-`analyzer = OptAnalyzer` configuration in order to apply the optimization analysis on a top-level script,
-e.g. `report_file("path/to/file.jl"; analyzer = OptAnalyzer)`.
+JET doesn't offer top-level entry points for the optimization analysis, because
+the analysis is usually applied to a selective portion of a program rather than
+to a whole script or package. The top-level entry points listed in
+[the error analysis documentation](@ref jetanalysis-toplevel-entry) always use
+[`JETAnalyzer`](@ref JET.JETAnalyzer), and passing an analyzer through them is
+not supported.
 
+To apply the optimization analysis to code that is only reachable from a
+top-level script, wrap that code in a function and analyze the function with
+[`report_opt`](@ref).
 
 ## [Configurations](@id optanalysis-config)
 
-In addition to the [general configurations](@ref), the optimization analysis can take the following specific configurations:
+In addition to the [general configurations](@ref general-configurations), the
+optimization analysis can take the following specific configurations:
+
 ```@docs
 JET.OptAnalyzer
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,14 +1,22 @@
 # JET tutorial
-JET leverages the Julia compiler's inference to check user code for type instability and type errors.
-This tutorial will demonstrate how to use JET effectively.
-It presupposes the reader has working knowledge of Julia, and understands Julian concepts such as "dynamic dispatch" and "type stability" - see the [Julia documentation](https://docs.julialang.org/en/v1/) for explanation of these concepts.
 
-Because JET relies on the compiler's type inference, it is not able to effectively analyze type unstable code.
-Making your code type stable is a prerequisite for effectively using JET's type error analysis.
-Therefore, we will begin by showing how to use JET to fix type instabilities.
+JET leverages the Julia compiler's inference to check user code for type
+instability and type errors. This tutorial will demonstrate how to use JET
+effectively. It presupposes the reader has working knowledge of Julia, and
+understands Julian concepts such as "dynamic dispatch" and "type stability"; see
+the [Julia documentation](https://docs.julialang.org/en/v1/) for an explanation
+of these concepts.
 
-First of all, you need to install JET: JET is a standard Julia package.
-So you can just install it via Julia's built-in package manager and use it just like any other package:
+Because JET relies on the compiler's type inference, it cannot see through
+unresolved dynamic dispatch, so type instability reduces the coverage of JET's
+analysis. Making your code type stable lets JET's type error analysis cover more
+of it. Therefore, we will begin by showing how to use JET to fix type
+instabilities.
+
+First of all, you need to install JET: JET is a standard Julia package. So you
+can just install it via Julia's built-in package manager and use it just like
+any other package:
+
 ```julia-repl
 julia> using Pkg; Pkg.add("JET")
 [ some output elided ]
@@ -21,95 +29,143 @@ using JET
 ```
 
 ## Detecting type instability with `@report_opt`
-JET exports a function [`report_opt`](@ref) and the related macro [`@report_opt`](@ref).
-It works similar to the function/macro pair `(@)code_warntype` from Base - except that it automatically analyses all the way down the function chain, and that it only displays any issues found.
+
+JET exports a function [`report_opt`](@ref) and the related macro
+[`@report_opt`](@ref). It works similarly to the function/macro pair
+`(@)code_warntype` from Base, except that it automatically analyses all the way
+down the function chain and displays only the issues found.
 
 For example, suppose we have the function:
+
 ```@repl tutorial
 add_one_first(x) = first(x) + 1;
 ```
 
 Any type instabilities of a given function call can be analysed thus:
+
 ```@repl tutorial
 @report_opt add_one_first([1])
 @report_opt add_one_first(Any[1])
 ```
 
-You can see that `add_one_first` is type stable when called with a `Vector{Int}`, but it leads to dynamic dispatch when called with `Vector{Any}`.
+You can see that `add_one_first` is type stable when called with a
+`Vector{Int}`, but it leads to dynamic dispatch when called with `Vector{Any}`.
 
-Suppose now we have _two levels_ of type instability, where one type instability "hides behind" another type instability, as in this example:
+Suppose now we have two levels of type instability, where one type instability
+"hides behind" another type instability, as in this example:
+
 ```@repl tutorial
 add_one_first(x) = first(x) + 1;
 func_var = add_one_first;
 f(x) = func_var(x);
 @report_opt f(Any[1])
 ```
-The dynamic dispatch we see here come from the fact that `func_var` is an untyped global variable.
-Remember that `add_one_first` was also type unstable when called with a `Vector{Any}`. So why doesn't `@report_opt` report that second type instability from calling `add_one_first(::Vector{Any})`?
-The reason is that because the Julia compiler does not know at compile time that `func_var` is equal to `add_one_first`, JET cannot "see through" the first type instability and see that `add_one_first(Any[1])` will eventually be called.
 
-If we fix the first instability by defining the global variable `my_func_var` as `const`:
+The dynamic dispatch we see here comes from the fact that `func_var` is an
+untyped global variable.
+Remember that `add_one_first` was also type unstable when called with a
+`Vector{Any}`. So why doesn't `@report_opt` report that second type instability
+from calling `add_one_first(::Vector{Any})`?
+The reason is that because the Julia compiler does not know at compile time that
+`func_var` is equal to `add_one_first`, JET cannot "see through" the first type
+instability and see that `add_one_first(Any[1])` will eventually be called.
+
+If we fix the first instability by defining the global variable `my_func_var` as
+`const`:
+
 ```@repl tutorial
 const my_func_var = add_one_first;
 ```
 
-Then the compiler knows that `add_one_first` will be called, and the second type instability from this function is revealed:
+Then the compiler knows that `add_one_first` will be called, and the second type
+instability from this function is revealed:
+
 ```@repl tutorial
 f(x) = my_func_var(x)
 @report_opt f(Any[1])
 ```
 
-Sometimes, type instability only shows up much deeper into a call chain, several functions deep.
-This is not a problem for JET.
-In the example below, JET sees type instability ~10 function calls deep:
+Sometimes, type instability only shows up much deeper into a call chain, several
+functions deep. This is not a problem for JET. In the example below, JET sees
+type instability ~10 function calls deep:
+
 ```@repl tutorial
 @report_opt sum(Any[1])
 ```
 
-As mentioned above, effective use of JET begins with liberal use of `@report_opt` to eliminate or reduce any dynamic dispatch, such that the Julia compiler is not blinded by dynamic dispatch.
+As mentioned above, eliminating or reducing dynamic dispatch with `@report_opt`
+keeps the Julia compiler from being blinded by dynamic dispatch and thereby
+widens the reach of JET's analysis.
 
-After the program has been made as type stable as possible, it's time to use `@report_call` to find type errors.
+After the program has been made as type stable as possible, it's time to use
+`@report_call` to find type errors.
 
 ## Analyse methods with `@report_call`
-The function/macro pair [`report_call`](@ref) and [`@report_call`](@ref) works just like `(@)report_opt` - but where the latter reports dynamic dispatch, the former finds type errors.
+
+The function/macro pair [`report_call`](@ref) and [`@report_call`](@ref) works
+just like `(@)report_opt`, except that where the latter reports dynamic
+dispatch, the former finds type errors.
 
 The `@report_call` macro analyses function calls like so:
+
 ```@repl tutorial
 @report_call sum(['a'])
 ```
 
 In this example, JET found two possible type errors:
-* If the input vector is empty, the function call will error with a `MethodError` after attempting to call `zero(Char)`.
-* If the input vector has two or more elements, the call will error after attempting to call `+(::Char, ::Char)`.
-Note that these type errors show up even though the input vector had exactly one element, and so neither of these errors would actually occur at runtime if `sum(['a'])` had been executed.
-This happens because JET analyses the code on a _type_ level, only looking at the code generated with the input _types_. It does not analyze what will actually happen with the given input value.
 
-Note also that the two possible errors shown are mutally exclusive - no input will lead to both errors.
-Nonetheless, JET is able to detect both possibilities, because it analyses all possible branches in the generated function call.
+- If the input vector is empty, the function call will error with a
+  `MethodError` after attempting to call `zero(Char)`.
+- If the input vector has two or more elements, the call will error after
+  attempting to call `+(::Char, ::Char)`.
 
-In contrast, if we analyse the same `sum` method on a `Vector{Int}` instead of `Vector{Char}`:
+Note that these type errors show up even though the input vector had exactly one
+element, and so neither of these errors would actually occur at runtime if
+`sum(['a'])` had been executed.
+This happens because JET analyses the code on a _type_ level, only looking at
+the code generated with the input _types_. It does not analyze what will
+actually happen with the given input value.
+
+Note also that the two possible errors shown are mutually exclusive - no input
+will lead to both errors.
+Nonetheless, JET is able to detect both possibilities, because it analyses all
+possible branches in the generated function call.
+
+In contrast, if we analyse the same `sum` method on a `Vector{Int}` instead of
+`Vector{Char}`:
+
 ```@repl tutorial
 @report_call sum([1])
 ```
 
-The two errors above do not appear. These errors do not apply to `Vector{Int}`, because `zero(Int)` is well-defined and so is `+(::Int, ::Int)`.
-This illustrates that JET does not analyze _methods_, but rather _function calls with specific types_. More precisely, JET analyses so-called _methodinstances_, since methodinstances are compiled whereas methods are not.
+The two errors above do not appear. These errors do not apply to `Vector{Int}`,
+because `zero(Int)` is well-defined and so is `+(::Int, ::Int)`.
+This illustrates that JET does not analyze _methods_, but rather _function calls
+with specific types_. More precisely, JET analyses so-called _methodinstances_,
+since methodinstances are compiled whereas methods are not.
 
 ## Analyse whole packages with `report_package`
-As shown above, _methods_ cannot be analyzed, but only _methodinstances_, i.e. methods plus the types of their arguments.
-Most packages, however, define only methods, and do not contain callsites. That is, they do not have any information about the types that these methods will be called with.
 
-However, JET is able to do limited analysis using only the method signature extracted from the method definition.
+As shown above, _methods_ cannot be analyzed, but only _methodinstances_, i.e.
+methods plus the types of their arguments.
+Most packages, however, define only methods, and do not contain callsites. That
+is, they do not have any information about the types that these methods will be
+called with.
+
+However, JET is able to do limited analysis using only the method signature
+extracted from the method definition.
 For example, if I define this simple function:
 
 ```julia
 first_plus_n(itr, n::Real) = first(itr) + n;
 ```
 
-, then _at the very least_, we can guarantee that `itr isa Any` and `n isa Real`.
-Hence, JET can analyze the methodinstance `first_plus_n(::Any, ::Real)`, using only the method definition.
+Then, at the very least, we can guarantee that `itr isa Any` and `n isa Real`.
+Hence, JET can analyze the methodinstance `first_plus_n(::Any, ::Real)` using
+only the method definition.
 
-The JET function [`report_package`](@ref) extracts all method definitions in a package, and using the extracted signatures, runs `report_call` on them.
+The JET function [`report_package`](@ref) extracts all method definitions in a
+package, and using the extracted signatures, runs `report_call` on them.
 For example, the package `BioSymbols` can be analysed like this:
 
 ```julia
@@ -119,55 +175,85 @@ julia> report_package(BioSymbols)
 [ output elided ]
 ```
 
-Note that `report_package` is less precise than `@report_call`, because method signatures of idiomatic Julia code are often very generic, so there is less type information in the signature itself than there is when given concrete argument types.
+Note that `report_package` is less precise than `@report_call`, because method
+signatures of idiomatic Julia code are often very generic, so there is less type
+information in the signature itself than there is when given concrete argument
+types.
 
 ## Usage tips
-### Use `@report_opt` before `@report_call`
-JET works best on type-stable code.
-Iron out type instabilities using `@report_opt` before using `@report_call`
+
+### Combine `@report_opt` with `@report_call`
+
+JET's error analysis covers more of your code when the code is type-stable, so
+ironing out type instabilities with `@report_opt` improves the results of
+`@report_call`. That said, `@report_call` is often less noisy than
+`@report_opt`, so it is also perfectly reasonable to start with `@report_call`
+alone.
 
 ### Filtering away false positives
-It is common to find that JET finds lots of errors in your functions, which all derive from type instability and type issues in your dependencies.
-In fact, type issues from dependencies are often so plentiful they flood your analysis with false positives, which can make working with JET harder.
 
-To reduce false positives, you can use the keywords `ignored_modules` and `target_modules`.Both take an iterable of modules.
+It is common to find that JET finds lots of errors in your functions, which all
+derive from type instability and type issues in your dependencies.
+In fact, type issues from dependencies are often so plentiful they flood your
+analysis with false positives, which can make working with JET harder.
 
-The former removes any errors that originate from any of the given modules, while the latter removes any errors _except_ ones originating from these modules.
+To reduce false positives, you can use the keywords `ignored_modules` and
+`target_modules`. Both take an iterable of modules.
+
+The former removes any errors that originate from any of the given modules,
+while the latter removes any errors _except_ ones originating from these
+modules.
 
 For example, in the REPL (which is in module `Main`), we can define:
+
 ```@repl tutorial
 g(x) = first(x) + 1
 ```
 
 This throws in a `Base` function if we pass `nothing` into it:
+
 ```@repl tutorial
 @report_call g(nothing)
 ```
 
-Since the error originates from `Base`, we can filter the error away by ignoring `Base`, or equivalently, we may retain only the ones from `Main`. Note that we pass `(Base,)` as a 1-element Tuple of modules:
+Since the error originates from `Base`, we can filter the error away by ignoring
+`Base`, or equivalently, we may retain only the ones from `Main`. Note that we
+pass `(Base,)` as a 1-element Tuple of modules:
+
 ```@repl tutorial
 @report_call ignored_modules=(Base,) g(nothing)
 @report_call target_modules=(@__MODULE__,) g(nothing)
 ```
 
-The `AnyFrameModule` construct can be used to filter for (or against) any error where _any_ of the function calls in the callchain originates from the given module.
-For example, in the example above, the function call begins in `Main` and ends in `Base`, so the callchain includes both modules.
-Ignoring `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)` will then ignore the error:
+The `AnyFrameModule` construct can be used to filter for (or against) any error
+where _any_ of the function calls in the callchain originates from the given
+module.
+For example, in the example above, the function call begins in `Main` and ends
+in `Base`, so the callchain includes both modules.
+Ignoring `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)` will then ignore the
+error:
 
 ```@repl tutorial
 @report_call ignored_modules=(AnyFrameModule(Base),) g(nothing)
 @report_call ignored_modules=(AnyFrameModule(@__MODULE__),) g(nothing)
 ```
 
-Similarly, the error would be retained if `target_modules` would have been `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)`.
+Similarly, the error would be retained if `target_modules` would have been
+`AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)`.
 
-Beware that this filtering may filter away legitimate problems in your package. In the example above, if your code calls `f(nothing)`, the error may originate from Base, but it's clearly an error in your own code to call `f(nothing)`.
-So it is recommended to only filter away modules if they produce so many false positives that it makes using JET difficult.
+Beware that this filtering may filter away legitimate problems in your package.
+In the example above, if your code calls `g(nothing)`, the error may originate
+from Base, but it's clearly an error in your own code to call `g(nothing)`.
+So it is recommended to only filter away modules if they produce so many false
+positives that it makes using JET difficult.
 
 ### Analyze scripts and apps by using a `main` function
-Scripts and apps called from the command line have a single logical entry point. If you wrap the logic in a `main` function, JET can analyse the entire script.
 
-For example, suppose you made this command-line script which added two numbers from the command line:
+Scripts and apps called from the command line have a single logical entry point.
+If you wrap the logic in a `main` function, JET can analyse the entire script.
+
+For example, suppose you made this command-line script which added two numbers
+from the command line:
 
 ```julia
 a = parse(Int, first(ARGS))
@@ -176,6 +262,7 @@ println(a + b)
 ```
 
 You could rewrite this as:
+
 ```julia
 function main()
     a = parse(Int, first(ARGS))
@@ -186,21 +273,28 @@ end
 main()
 ```
 
-, and then analyse the script with JET using `@report_call main()`.
-Using a `main` function has the further advantage that it makes it for other people to understand what your script does when invoked.
+You can then analyse the script with JET using `@report_call main()`. Using a
+`main` function has the further advantage of making it easier for other people
+to understand what your script does when invoked.
 
-Alternatively, JET also provides the function [`report_file`](@ref), which you can call like:
+Alternatively, JET also provides the function [`report_file`](@ref), which you
+can call like:
+
 ```julia
 julia> report_file("my_script.jl")
 ```
 
-, which will be equivalent to checking `@report_call main()`, if the script contains a `main()` call at top level.
+This is equivalent to checking `@report_call main()` if the script contains a
+`main()` call at top level.
 
 ### Analyze packages using a representative workload
-As shown above, packages can be analysed with `report_package`.
-However, generic type signatures often used in packages lead to imprecise inference and thus imprecise analysis.
 
-To improve analysis, you can create a file `src/workload.jl` in your package, which uses all (or most) functionality of the package.
+As shown above, packages can be analysed with `report_package`.
+However, generic type signatures often used in packages lead to imprecise
+inference and thus imprecise analysis.
+
+To improve analysis, you can create a file `src/workload.jl` in your package,
+which uses all (or most) functionality of the package.
 The function could look like:
 
 ```julia
@@ -211,11 +305,18 @@ function exercise_mypkg()
 end
 ```
 
-Because such usage necessarily requires passing concrete types to your functions, calling `@report_call exercise_mypkg()` leads to more precise analysis than `report_package`.
+Because such usage necessarily requires passing concrete types to your
+functions, calling `@report_call exercise_mypkg()` leads to more precise
+analysis than `report_package`.
 
-Furthermore, once you have written a function like `exercise_mypkg`, you can use a package like [`PrecompileTools`](https://github.com/JuliaLang/PrecompileTools.jl) to precompile the function, which will thus precompile all code exercised in the function, significantly reducing your package's latency.
+Furthermore, once you have written a function like `exercise_mypkg`, you can use
+a package like
+[`PrecompileTools`](https://github.com/JuliaLang/PrecompileTools.jl) to
+precompile the function, which will thus precompile all code exercised in the
+function, significantly reducing your package's latency.
 
-Conversely, if you've already implemented a precompile workload, you can do the following:
+Conversely, if you've already implemented a precompile workload, you can do the
+following:
 
 ```julia
 using MyPkg, JET, MethodAnalysis
@@ -226,9 +327,17 @@ badmis = filter(mis) do mi
 end
 ```
 
-Then you can inspect the methodinstances in `badmis` individually with `report_call(mi)`.
+Then you can inspect the methodinstances in `badmis` individually with
+`report_call(mi)`.
 
 There are two caveats to note:
 
-- `methodinstances(MyPkg)` only covers *functions* owned by `MyPkg`. If `MyPkg` defines an "extension" method `OtherPkg.f(...)`, any corresponding methodinstances would appear in the list for `OtherPkg`.
-- if you [disable precompilation](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development) for your development version of the package, you'll get a greatly-reduced list of methodinstances that does not reflect ordinary usage. This style of JET analysis should only be performed on packages that are actively using their precompilation workloads.
+- `methodinstances(MyPkg)` only covers _functions_ owned by `MyPkg`. If `MyPkg`
+  defines an "extension" method `OtherPkg.f(...)`, any corresponding
+  methodinstances would appear in the list for `OtherPkg`.
+- If you
+  [disable precompilation](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development)
+  for your development version of the package, you'll get a greatly-reduced
+  list of methodinstances that does not reflect ordinary usage. This style of
+  JET analysis should only be performed on packages that are actively using
+  their precompilation workloads.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -217,25 +217,35 @@ This throws in a `Base` function if we pass `nothing` into it:
 ```
 
 Since the error originates from `Base`, we can filter the error away by ignoring
-`Base`, or equivalently, we may retain only the ones from `Main`. Note that we
-pass `(Base,)` as a 1-element Tuple of modules:
+`Base`. Note that we pass `(Base,)` as a 1-element Tuple of modules:
 
 ```@repl tutorial
 @report_call ignored_modules=(Base,) g(nothing)
-@report_call target_modules=(@__MODULE__,) g(nothing)
 ```
+
+Equivalently, we may retain only the reports from our own code with
+`target_modules`. A module given to these keywords matches that module *and
+its submodules*, where the matching stops at namespace roots: `Base` and
+package root modules do not count as submodules of `Main`. Since code defined
+interactively in the REPL lives in `Main`, retaining `Main` filters the error
+away as well:
+
+```@repl tutorial
+@report_call target_modules=(Main,) g(nothing)
+```
+
+To match a single module without its submodules, wrap it in
+`JET.LastFrameModuleExact`.
 
 The `AnyFrameModule` construct can be used to filter for (or against) any error
 where _any_ of the function calls in the callchain originates from the given
-module.
-For example, in the example above, the function call begins in `Main` and ends
-in `Base`, so the callchain includes both modules.
-Ignoring `AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)` will then ignore the
-error:
+module. For example, in the example above, the function call begins in `Main`
+and ends in `Base`, so the callchain includes both modules. Ignoring
+`AnyFrameModule(Base)` _or_ `AnyFrameModule(Main)` will then ignore the error:
 
 ```@repl tutorial
 @report_call ignored_modules=(AnyFrameModule(Base),) g(nothing)
-@report_call ignored_modules=(AnyFrameModule(@__MODULE__),) g(nothing)
+@report_call ignored_modules=(AnyFrameModule(Main),) g(nothing)
 ```
 
 Similarly, the error would be retained if `target_modules` would have been

--- a/examples/find_unstable_api.jl
+++ b/examples/find_unstable_api.jl
@@ -253,19 +253,19 @@ end #hide
 
 # ```
 # ═════ 59 possible errors found ═════
-# ┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:39 Core.kwfunc(IRTools.Inner.invoke_meta)(Core.apply_type(Core.NamedTuple, (:world,))(Core.tuple(world)), IRTools.Inner.invoke_meta, T)
-# │┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:69 IRTools.Inner.#invoke_meta#6(world, _3, T)
-# ││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:74 Core.kwfunc(IRTools.Inner.meta)(Core.apply_type(Core.NamedTuple, (:types, :world))(Core.tuple(S, world)), IRTools.Inner.meta, T)
-# │││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:38 IRTools.Inner.#meta#1(types, world, _3, T)
-# ││││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:43 Base._methods_by_ftype
+# ┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:39 Core.kwfunc(IRTools.Inner.invoke_meta)(Core.apply_type(Core.NamedTuple, (:world,))(Core.tuple(world)), IRTools.Inner.invoke_meta, T)
+# │┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:69 IRTools.Inner.#invoke_meta#6(world, _3, T)
+# ││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:74 Core.kwfunc(IRTools.Inner.meta)(Core.apply_type(Core.NamedTuple, (:types, :world))(Core.tuple(S, world)), IRTools.Inner.meta, T)
+# │││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:38 IRTools.Inner.#meta#1(types, world, _3, T)
+# ││││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:43 Base._methods_by_ftype
 # │││││ usage of unstable API `Base._methods_by_ftype` found
 # ││││└─────────────────────────────────────────────────────────────────────────────────
-# ││││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:49 Base.isgenerated
+# ││││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:49 Base.isgenerated
 # │││││ usage of unstable API `Base.isgenerated` found
 # ││││└─────────────────────────────────────────────────────────────────────────────────
-# ││││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:49 Base.uncompressed_ast
+# ││││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:49 Base.uncompressed_ast
 # │││││ usage of unstable API `Base.uncompressed_ast` found
 # ││││└─────────────────────────────────────────────────────────────────────────────────
-# ││││┌ @ /Users/aviatesk/.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:54
+# ││││┌ @ ~.julia/packages/IRTools/aSVI5/src/reflection/reflection.jl:54
 # ... # many other "unstable API"s detected
 # ```

--- a/src/JET.jl
+++ b/src/JET.jl
@@ -3,6 +3,33 @@ module JET
 using Preferences: Preferences
 using .Preferences: UUID
 
+"""
+    const JET_DEV_MODE::Bool
+
+Whether JET is loaded in development mode.
+
+This is a [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) setting that
+is read when JET is loaded, so it needs to be configured before JET is precompiled, e.g.
+with a `LocalPreferences.toml` file containing:
+```toml
+[JET]
+JET_DEV_MODE = true
+```
+
+Enabling it has the following effects:
+- Full JET functionality is loaded even on unsupported Julia versions, i.e.
+  [`JET_AVAILABLE`](@ref) becomes `true`. Note that JET may still not work correctly on
+  such versions.
+- Internal assertions that check JET's report caching and validate report interface
+  implementations are compiled in. They are omitted by default since they add overhead.
+- The `use_fixed_world` preference defaults to `false`, so JET's pre-defined analyzers and
+  interpreters run their analysis in the current world age instead of the world age fixed
+  at load time. This makes redefinitions of JET's own code take effect, at the cost of
+  losing robustness against invalidations caused by loading other packages.
+
+This mode is intended for developing JET itself and for experimenting on unsupported Julia
+versions, and is not recommended otherwise.
+"""
 const JET_DEV_MODE = Preferences.load_preference(UUID("c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"), "JET_DEV_MODE", false)
 
 const USE_FIXED_WORLD = Preferences.load_preference(UUID("c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"), "use_fixed_world", !JET_DEV_MODE)
@@ -18,13 +45,24 @@ _is_supported_julia(version::VersionNumber) =
 # PkgEval must exercise full JET functionality on pre-release Julia versions so that
 # compiler incompatibilities are detected instead of being hidden by empty stubs.
 """
-    JET_AVAILABLE::Bool
+    const JET_AVAILABLE::Bool
 
 Whether full JET functionality is available in the current process.
 
-This is `true` on supported Julia versions, when `JET_DEV_MODE` is enabled, or under
-PkgEval. When `false`, JET is loaded with empty stubs so test suites can skip JET-specific
-checks while keeping their test environments usable.
+This is `true` on supported Julia versions, when [`JET_DEV_MODE`](@ref) is enabled, or when
+running under PkgEval, i.e. with the `JULIA_PKGEVAL` environment variable set. Otherwise JET
+is loaded with empty stubs: loading it emits a warning, and calling any of its entry points
+throws an error.
+
+This lets a test suite stay instantiable on unsupported Julia versions while skipping its
+JET-specific checks at runtime:
+```julia
+using JET
+
+if JET.JET_AVAILABLE
+    include("jet_tests.jl")
+end
+```
 """
 const JET_AVAILABLE = JET_DEV_MODE || PKG_EVAL || _is_supported_julia(VERSION)
 export JET_AVAILABLE

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -542,6 +542,14 @@ iterator whose elements are any of the following matchers for a
 - a user-defined `T <: JET.ReportMatcher`: matches according to an extension
   of `JET.match_report(::T, report::InferenceErrorReport)`
 
+!!! note "Module containment stops at namespace roots"
+    The non-`Exact` matchers accept a module *and its submodules*, where
+    containment follows lexical nesting but stops at namespace roots: `Base`,
+    `Core`, and package root modules are not considered submodules of `Main`.
+    `target_modules = (Main,)` therefore matches only code defined
+    interactively in the REPL or in an analyzed script, without also matching
+    reports from `Base`.
+
 ---
 - `target_modules = nothing` \\
   Filters reports by the contexts in which problems should be reported.
@@ -569,7 +577,7 @@ iterator whose elements are any of the following matchers for a
 ```julia-repl
 julia> function foo(a)
            r1 = sum(a)       # => Base: MethodError(+(::Char, ::Char)), MethodError(zero(::Type{Char}))
-           r2 = undefsum(a)  # => @__MODULE__: UndefVarError(:undefsum)
+           r2 = undefsum(a)  # => Main: UndefVarError(:undefsum)
            return r1, r2
        end;
 
@@ -604,9 +612,9 @@ julia> @report_call foo("julia")
 │ `Main.undefsum` is not defined: undefsum
 └────────────────────
 
-# With `target_modules=(JET.LastFrameModuleExact(@__MODULE__),)`, JET reports only
-# problems detected in the `@__MODULE__` module itself:
-julia> @report_call target_modules=(JET.LastFrameModuleExact(@__MODULE__),) foo("julia")
+# With `target_modules=(Main,)`, JET reports only problems detected in code
+# defined interactively in the REPL:
+julia> @report_call target_modules=(Main,) foo("julia")
 ═════ 1 possible error found ═════
 ┌ foo(a::String) @ Main ./REPL[14]:3
 │ `Main.undefsum` is not defined: undefsum
@@ -664,8 +672,12 @@ struct AnyFrameMethod <: ReportMatcher
     meth::Union{Function,Method,Symbol}
 end
 
+# Module containment follows lexical nesting but stops at namespace roots
+# (`Base.moduleroot` semantics): in particular `Base` is not a submodule of `Main`,
+# so matchers given `Main` only cover interactively- or script-defined code.
 function issubmodule(child::Module, parent::Module)
     child === parent && return true
+    Base.is_root_module(child) && return false
     pm = parentmodule(child)
     pm === child && return false
     return issubmodule(pm, parent)
@@ -673,6 +685,7 @@ end
 
 function issubmoduleof(mod::Module, name::Symbol)
     nameof(mod) === name && return true
+    Base.is_root_module(mod) && return false
     pm = parentmodule(mod)
     pm === mod && return false
     return issubmoduleof(pm, name)

--- a/src/JETBase.jl
+++ b/src/JETBase.jl
@@ -5,8 +5,12 @@ let README = normpath(dirname(@__DIR__), "README.md")
         "> [!NOTE]" => "!!! note",
         "> [!WARNING]" => "!!! warning",
         "> [!IMPORTANT]" => "!!! note",
-        r"^\> (.+)$"m=>s"    \1",
-        r"^\>$"m=>s"")
+        r"^\> (.+)$"m => s"    \1",
+        r"^\>$"m => s"",
+        # drop HTML comments: Julia's Markdown parser has no notion of HTML blocks,
+        # so they would otherwise show up verbatim in `?JET` and in the manual
+        r"^<!-- @doc (.*?) -->$"ms => s"```@docs\n\1\n```\n",
+        r"^<!--.*?-->$"ms => "")
     @doc s JET
     include_dependency(README)
 end
@@ -69,7 +73,8 @@ function print_signature end
 """
     JETInterface
 
-This `baremodule` exports names that form the APIs of [`AbstractAnalyzer` Framework](@ref AbstractAnalyzer-Framework).
+This `baremodule` exports names that form the APIs of
+[`AbstractAnalyzer` framework](@ref AbstractAnalyzer-framework).
 `using JET.JETInterface` loads all names that are necessary to define a plugin analysis.
 """
 baremodule JETInterface end
@@ -416,14 +421,20 @@ include("toplevel/virtualprocess.jl")
 """
     res::JETToplevelResult
 
-Represents the result of JET's analysis on a top-level script.
-- `res.analyzer::AbstractAnalyzer`: [`AbstractAnalyzer`](@ref) used for this analysis
-- `res.res::VirtualProcessResult`: [`VirtualProcessResult`](@ref) collected from this analysis
-- `res.source::AbstractString`: the identity key of this analysis
-- `res.jetconfigs`: configurations used for this analysis
+Represents the result of analyzing top-level code, including files, packages, and text.
 
-`JETToplevelResult` implements `show` methods for each different frontend.
-An appropriate `show` method will be automatically chosen and render the analysis result.
+- `res.analyzer::AbstractAnalyzer`: the [`AbstractAnalyzer`](@ref) used for the
+  analysis
+- `res.res::VirtualProcessResult`: the [`VirtualProcessResult`](@ref) produced
+  by the analysis
+- `res.source::AbstractString`: a description of the analysis target that also
+  serves as the identity key of the analysis; e.g. the VS Code integration uses
+  it to replace superseded diagnostics
+- `res.jetconfigs`: the configurations associated with the analysis
+
+`JETToplevelResult` implements `Base.show` methods for JET's supported front ends.
+Julia's display system selects the appropriate method when rendering the
+analysis result.
 """
 struct JETToplevelResult{Analyzer<:AbstractAnalyzer,JETConfigs}
     analyzer::Analyzer
@@ -436,28 +447,22 @@ JETToplevelResult(analyzer::AbstractAnalyzer, res::VirtualProcessResult, source:
 @eval Base.iterate(res::JETToplevelResult, state=1) =
     return state > $(fieldcount(JETToplevelResult)) ? nothing : (getfield(res, state), state+1)
 
-function get_reports(result::JETToplevelResult)
-    res = result.res
-    if !isempty(res.toplevel_error_reports)
-        # non-empty `ret.toplevel_error_reports` means critical errors happened during
-        # the AST transformation, so they always have precedence over `ret.inference_error_reports`
-        return res.toplevel_error_reports
-    else
-        return configured_reports(res.inference_error_reports; result.jetconfigs...)
-    end
-end
-
 """
     res::JETCallResult
 
-Represents the result of JET's analysis on a function call.
-- `res.result::InferenceResult`: the result of this analysis
-- `res.analyzer::AbstractAnalyzer`: [`AbstractAnalyzer`](@ref) used for this analysis
-- `res.source::AbstractString`: the identity key of this analysis
-- `res.jetconfigs`: configurations used for this analysis
+Represents the result of analyzing a function call.
 
-`JETCallResult` implements `show` methods for each different frontend.
-An appropriate `show` method will be automatically chosen and render the analysis result.
+- `res.result::InferenceResult`: the `InferenceResult` produced by the analysis
+- `res.analyzer::AbstractAnalyzer`: the [`AbstractAnalyzer`](@ref) used for the
+  analysis
+- `res.source::AbstractString`: a description of the analysis target that also
+  serves as the identity key of the analysis; e.g. the VS Code integration uses
+  it to replace superseded diagnostics
+- `res.jetconfigs`: the configurations associated with the analysis
+
+`JETCallResult` implements `Base.show` methods for JET's supported front ends.
+Julia's display system selects the appropriate method when rendering the
+analysis result.
 """
 struct JETCallResult{Analyzer<:AbstractAnalyzer,JETConfigs}
     result::InferenceResult
@@ -479,62 +484,84 @@ function get_result(result::JETCallResult)
 end
 
 """
-    rpts = JET.get_reports(result::JETCallResult)
+    reports = JET.get_reports(result::JETCallResult)
+    reports = JET.get_reports(result::JETToplevelResult)
 
-Split `result` into a vector of reports, one per issue.
+Return the reports represented by `result`, one per detected issue.
+
+For a [`JETCallResult`](@ref), this returns the inference reports after applying
+report configuration. For a [`JETToplevelResult`](@ref), top-level errors take
+precedence: if any top-level errors were collected, only those errors are
+returned. Otherwise, this returns the configured inference reports.
 """
 function get_reports(result::JETCallResult)
     reports = get_reports(result.analyzer, result.result)
     return configured_reports(reports; result.jetconfigs...)
 end
+function get_reports(result::JETToplevelResult)
+    res = result.res
+    if !isempty(res.toplevel_error_reports)
+        # non-empty `ret.toplevel_error_reports` means critical errors happened during
+        # the AST transformation, so they always have precedence over `ret.inference_error_reports`
+        return res.toplevel_error_reports
+    else
+        return configured_reports(res.inference_error_reports; result.jetconfigs...)
+    end
+end
 
 """
 Configurations for [JET's analysis results](@ref analysis-result).
-These configurations are always active.
+
+The `target_modules` and `ignored_modules` values must be `nothing` or an
+iterator whose elements are any of the following matchers for a
+[`report::InferenceErrorReport`](@ref InferenceErrorReport):
+
+- `m::Module` or `JET.LastFrameModule(m::Module)`: matches when the module of
+  the report's innermost stack frame is `m` or one of its submodules
+- `name::Symbol` or `JET.LastFrameModule(name::Symbol)`: matches when the
+  module of the report's innermost stack frame, or one of that module's
+  parents, is named `name`
+- `JET.AnyFrameModule(m::Module)`: matches when the module of any stack frame
+  is `m` or one of its submodules
+- `JET.AnyFrameModule(name::Symbol)`: matches when the module of any stack
+  frame, or one of that module's parents, is named `name`
+- `JET.LastFrameModuleExact(m::Module)`: matches when the module of the
+  innermost stack frame is exactly `m`
+- `JET.LastFrameModuleExact(name::Symbol)`: matches when the module of the
+  innermost stack frame is named exactly `name`
+- `JET.AnyFrameModuleExact(m::Module)`: matches when the module of any stack
+  frame is exactly `m`
+- `JET.AnyFrameModuleExact(name::Symbol)`: matches when the module of any
+  stack frame is named exactly `name`
+- `JET.LastFrameMethod(meth)`, where `meth` is a `Function`, `Method`, or
+  `Symbol`: matches when the innermost stack frame belongs to the function,
+  is the exact method, or has the method name, respectively
+- `JET.AnyFrameMethod(meth)`, where `meth` is a `Function`, `Method`, or
+  `Symbol`: matches when any stack frame belongs to the function, is the exact
+  method, or has the method name, respectively
+- a user-defined `T <: JET.ReportMatcher`: matches according to an extension
+  of `JET.match_report(::T, report::InferenceErrorReport)`
 
 ---
 - `target_modules = nothing` \\
-  A configuration to filter out reports by specifying module contexts where problems should be reported.
-
-  By default (`target_modules = nothing`), JET reports all detected problems.
-  If specified, a problem is reported if its module context matches any of `target_modules`
-  settings and hidden otherwise. `target_modules` should be an iterator of whose element is
-  either of the data types below that match [`report::InferenceErrorReport`](@ref InferenceErrorReport)'s
-  context module as follows:
-  - `m::Module` or `JET.LastFrameModule(m::Module)`: matches if the module context of `report`'s innermost stack frame is `m` or any of its submodules
-  - `name::Symbol` or `JET.LastFrameModule(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is `name` or any of its parent modules is named `name`
-  - `JET.AnyFrameModule(m::Module)`: matches if the module context of any of `report`'s stack frames is `m` or any of its submodules
-  - `JET.AnyFrameModule(name::Symbol)`: matches if the module name of any of `report`'s stack frames is `name` or any of its parent modules is named `name`
-  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
-  - `JET.LastFrameModuleExact(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is exactly `name`
-  - `JET.AnyFrameModuleExact(m::Module)`: matches if the module context of any of `report`'s stack frames is exactly `m`, excluding submodules
-  - `JET.AnyFrameModuleExact(name::Symbol)`: matches if the module name of any of `report`'s stack frames is exactly `name`
-  - user-type `T <: JET.ReportMatcher`: matches according to user-definition overload `match_report(::T, report::InferenceErrorReport)`
+  Filters reports by the contexts in which problems should be reported.
+  By default, JET retains all detected problems. When an iterator is supplied,
+  JET retains a report only when at least one matcher matches it.
 ---
 - `ignored_modules = nothing` \\
-  A configuration to filter out reports by specifying module contexts where problems should be ignored.
-
-  By default (`ignored_modules = nothing`), JET reports all detected problems.
-  If specified, a problem is hidden if its module context matches any of `ignored_modules`
-  settings and reported otherwise. `ignored_modules` should be an iterator of whose element is
-  either of the data types below that match [`report::InferenceErrorReport`](@ref InferenceErrorReport)'s
-  context module as follows:
-  - `m::Module` or `JET.LastFrameModule(m::Module)`: matches if the module context of `report`'s innermost stack frame is `m` or any of its submodules
-  - `name::Symbol` or `JET.LastFrameModule(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is `name` or any of its parent modules is named `name`
-  - `JET.AnyFrameModule(m::Module)`: matches if the module context of any of `report`'s stack frames is `m` or any of its submodules
-  - `JET.AnyFrameModule(name::Symbol)`: matches if the module name of any of `report`'s stack frames is `name` or any of its parent modules is named `name`
-  - `JET.LastFrameModuleExact(m::Module)`: matches if the module context of `report`'s innermost stack frame is exactly `m`, excluding submodules
-  - `JET.LastFrameModuleExact(name::Symbol)`: matches if the module name of `report`'s innermost stack frame is exactly `name`
-  - `JET.AnyFrameModuleExact(m::Module)`: matches if the module context of any of `report`'s stack frames is exactly `m`, excluding submodules
-  - `JET.AnyFrameModuleExact(name::Symbol)`: matches if the module name of any of `report`'s stack frames is exactly `name`
-  - user-type `T <: JET.ReportMatcher`: matches according to user-definition overload `match_report(::T, report::InferenceErrorReport)`
+  Filters reports by the contexts in which problems should be ignored.
+  By default, JET ignores no detected problems. When an iterator is supplied,
+  JET removes a report when at least one matcher matches it. This filter is
+  applied after `target_modules`.
 ---
 - `report_config = nothing` \\
-  Additional configuration layer to filter out reports with user-specified strategies.
-  By default (`report_config = nothing`), JET will use the module context based configurations
-  elaborated above and below. If user-type `T` is given, then JET will report problems based
-  on the logic according to an user-overload `configured_reports(::T, reports::Vector{InferenceErrorReport})`,
-  and the `target_modules` and `ignored_modules` configurations are not really active.
+  Selects the report-filtering strategy. With the default `nothing`, JET builds
+  its standard configuration from `target_modules` and `ignored_modules`.
+  With any other value, JET instead calls
+  `JET.configured_reports(report_config, reports)` directly. This completely
+  bypasses `target_modules` and `ignored_modules`, even when they are supplied.
+  Custom configuration types must extend
+  `JET.configured_reports(::T, ::Vector{InferenceErrorReport})`.
 ---
 
 # Examples
@@ -546,7 +573,7 @@ julia> function foo(a)
            return r1, r2
        end;
 
-# by default, JET will print all the collected reports:
+# By default, JET prints all collected reports:
 julia> @report_call foo("julia")
 ═════ 3 possible errors found ═════
 ┌ foo(a::String) @ Main ./REPL[14]:2
@@ -574,28 +601,29 @@ julia> @report_call foo("julia")
 ││││││││││││││││ no matching method found `zero(::Type{Char})`: zero(T::Type{Char})
 │││││││││││││││└────────────────────
 ┌ foo(a::String) @ Main ./REPL[14]:3
-│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+│ `Main.undefsum` is not defined: undefsum
 └────────────────────
 
-# with `target_modules=(@__MODULE__,)`, JET will only report the problems detected within the `@__MODULE__` module:
-julia> @report_call target_modules=(@__MODULE__,) foo("julia")
+# With `target_modules=(JET.LastFrameModuleExact(@__MODULE__),)`, JET reports only
+# problems detected in the `@__MODULE__` module itself:
+julia> @report_call target_modules=(JET.LastFrameModuleExact(@__MODULE__),) foo("julia")
 ═════ 1 possible error found ═════
 ┌ foo(a::String) @ Main ./REPL[14]:3
-│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+│ `Main.undefsum` is not defined: undefsum
 └────────────────────
 
-# with `ignored_modules=(Base,)`, JET will ignore the errors detected within the `Base` module:
+# With `ignored_modules=(Base,)`, JET ignores errors detected in `Base`:
 julia> @report_call ignored_modules=(Base,) foo("julia")
 ═════ 1 possible error found ═════
 ┌ foo(a::String) @ Main ./REPL[14]:3
-│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+│ `Main.undefsum` is not defined: undefsum
 └────────────────────
 
-# alternatively, you can use Symbol to specify the module name without requiring it as a dependency:
+# Alternatively, use a Symbol to specify the module by name:
 julia> @report_call ignored_modules=(:Base,) foo("julia")
 ═════ 1 possible error found ═════
 ┌ foo(a::String) @ Main ./REPL[14]:3
-│ `Main.undefsum` is not defined: r2 = undefsum(a::String)
+│ `Main.undefsum` is not defined: undefsum
 └────────────────────
 ```
 ---
@@ -790,14 +818,20 @@ include("ui/vscode.jl")
 # -----------
 
 """
-    analyze_and_report_call!(analyzer::AbstractAnalyzer, f, [types]; jetconfigs...) -> JETCallResult
-    analyze_and_report_call!(analyzer::AbstractAnalyzer, tt::Type{<:Tuple}; jetconfigs...) -> JETCallResult
-    analyze_and_report_call!(analyzer::AbstractAnalyzer, mi::MethodInstance; jetconfigs...) -> JETCallResult
+    analyze_and_report_call!(analyzer::AbstractAnalyzer, f,
+                             types = Base.default_tt(f);
+                             jetconfigs...) -> JETCallResult
+    analyze_and_report_call!(analyzer::AbstractAnalyzer,
+                             tt::Type{<:Tuple};
+                             jetconfigs...) -> JETCallResult
+    analyze_and_report_call!(analyzer::AbstractAnalyzer,
+                             mi::MethodInstance;
+                             jetconfigs...) -> JETCallResult
 
-A generic entry point to analyze a function call with `AbstractAnalyzer`.
-Finally returns the analysis result as [`JETCallResult`](@ref).
-Note that this is intended to be used by developers of `AbstractAnalyzer` only.
-General users should use high-level entry points like [`report_call`](@ref) and [`report_opt`](@ref).
+Analyze a function call with `analyzer` and return the analysis result as a
+[`JETCallResult`](@ref). This generic entry point is intended only for
+developers of `AbstractAnalyzer`. General users should use high-level entry
+points such as [`report_call`](@ref) and [`report_opt`](@ref).
 """
 function analyze_and_report_call!(analyzer::AbstractAnalyzer, @nospecialize(f), @nospecialize(types = Base.default_tt(f));
                                   jetconfigs...)
@@ -909,13 +943,15 @@ is_entry(analyzer::AbstractAnalyzer, mi::MethodInstance) = get_entry(analyzer) =
 # ---------
 
 """
-    analyze_and_report_file!(interp::ConcreteInterpreter, filename::AbstractString; jetconfigs...) -> JETToplevelResult
+    analyze_and_report_file!(interp::ConcreteInterpreter,
+                             filename::AbstractString,
+                             pkgid::Union{Nothing,PkgId} = nothing;
+                             jetconfigs...) -> JETToplevelResult
 
-A generic entry point to analyze a file with `interp::ConcreteInterpreter`.
-Finally returns the analysis result as [`JETToplevelResult`](@ref).
-Note that this is intended to be used by developers of `AbstractAnalyzer` and
-`ConcreteInterpreter` only.
-General users should use high-level entry points like [`report_file`](@ref).
+Analyze a file with `interp` and return the analysis result as a
+[`JETToplevelResult`](@ref). This generic entry point is intended only for
+developers of `AbstractAnalyzer` and `ConcreteInterpreter`. General users
+should use high-level entry points such as [`report_file`](@ref).
 """
 function analyze_and_report_file!(interp::ConcreteInterpreter, filename::AbstractString,
                                   pkgid::Union{Nothing,PkgId} = nothing;
@@ -1037,12 +1073,13 @@ function (job::ReviseSignatureAnalysisJob)()
 end
 
 """
-    analyze_and_report_package!(analyzer::AbstractAnalyzer, package::Module; jetconfigs...) -> JETToplevelResult
+    analyze_and_report_package!(analyzer::AbstractAnalyzer, pkgmod::Module;
+                                jetconfigs...) -> JETToplevelResult
 
-A generic entry point to analyze a package with `analyzer::AbstractAnalyzer`.
-Finally returns the analysis result as [`JETToplevelResult`](@ref).
-Note that this is intended to be used by developers of `AbstractAnalyzer` only.
-General users should use high-level entry points like [`report_package`](@ref).
+Analyze the package module `pkgmod` with `analyzer` and return the analysis
+result as a [`JETToplevelResult`](@ref). This generic entry point is intended
+only for developers of `AbstractAnalyzer`. General users should use high-level
+entry points such as [`report_package`](@ref).
 """
 function analyze_and_report_package!(analyzer::AbstractAnalyzer, pkgmod::Module; jetconfigs...)
     pkgid = Base.PkgId(pkgmod)
@@ -1118,15 +1155,16 @@ function analyze_and_report_package!(analyzer::AbstractAnalyzer, pkgmod::Module;
 end
 
 """
-    analyze_and_report_text!(interp::ConcreteInterpreter, text::AbstractString,
-                             filename::AbstractString = "top-level";
+    analyze_and_report_text!(interp::ConcreteInterpreter,
+                             text::AbstractString,
+                             filename::AbstractString = "top-level",
+                             pkgid::Union{Nothing,PkgId} = nothing;
                              jetconfigs...) -> JETToplevelResult
 
-A generic entry point to analyze a top-level code with `interp::ConcreteInterpreter`.
-Finally returns the analysis result as [`JETToplevelResult`](@ref).
-Note that this is intended to be used by developers of `AbstractAnalyzer` and
-`ConcreteInterpreter` only.
-General users should use high-level entry points like [`report_text`](@ref).
+Analyze top-level `text` with `interp` and return the analysis result as a
+[`JETToplevelResult`](@ref). This generic entry point is intended only for
+developers of `AbstractAnalyzer` and `ConcreteInterpreter`. General users
+should use high-level entry points such as [`report_text`](@ref).
 """
 function analyze_and_report_text!(interp::ConcreteInterpreter, text::AbstractString,
                                   filename::AbstractString = "top-level",
@@ -1251,10 +1289,9 @@ function _call_test_ex(funcname::Symbol, testname::Symbol, ex0, __module__, __so
 end
 
 """
-    func_test(func, testname::Symbol, args...; jetconfigs...)
+    func_test(func, testname::Symbol, args...; broken::Bool = false, skip::Bool = false, jetconfigs...)
 
-An internal utility function to implement a `test_call`-like function.
-See the implementation of [`test_call`](@ref).
+An internal utility for implementing functions similar to [`test_call`](@ref).
 """
 function func_test(func, testname::Symbol, @nospecialize(args...);
     broken::Bool = false, skip::Bool = false,

--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -4,30 +4,36 @@
 """
     abstract type AbstractAnalyzer <: AbstractInterpreter end
 
-An interface type of analyzers that are built on top of [JET's analyzer framework](@ref AbstractAnalyzer-Framework).
+An interface type for analyzers built on
+[JET's `AbstractAnalyzer` framework](@ref AbstractAnalyzer-framework).
 
-When a new type `NewAnalyzer` implements the `AbstractAnalyzer` interface, it should be declared
-as subtype of `AbstractAnalyzer`, and is expected to implement the following interfaces:
+To implement the `AbstractAnalyzer` interface, declare `NewAnalyzer` as a
+subtype of `AbstractAnalyzer` and implement the following methods:
 
 ## Required interfaces
 
-1. **`JETInterface.AnalyzerState(analyzer::NewAnalyzer) -> AnalyzerState`**:
-   Returns the [`AnalyzerState`](@ref) for `analyzer::NewAnalyzer`.
+1. **`JETInterface.AnalyzerState(::NewAnalyzer) -> AnalyzerState`**
 
-2. **`JETInterface.AbstractAnalyzer(analyzer::NewAnalyzer, state::AnalyzerState) -> NewAnalyzer`**:
-   Constructs a new `NewAnalyzer` instance in the middle of JET's [top-level analysis](@ref toplevel)
-   or [abstract interpretation](@ref abstractinterpret), given the previous
-   `analyzer::NewAnalyzer` and [`state::AnalyzerState`](@ref AnalyzerState).
+   Return the [`AnalyzerState`](@ref) associated with the analyzer.
 
-3. **`JETInterface.AnalysisToken(analyzer::NewAnalyzer) -> AnalysisToken`**:
-   Returns a unique `AnalysisToken` object used for `analyzer::NewAnalyzer`.
+2. **`JETInterface.AbstractAnalyzer(::NewAnalyzer, ::AnalyzerState) -> NewAnalyzer`**
+
+   Construct a new `NewAnalyzer` from an existing analyzer and a replacement
+   state. JET calls this method when it recreates an analyzer during
+   [top-level analysis](@ref toplevel) or
+   [abstract interpretation](@ref abstractinterpret).
+
+3. **`JETInterface.AnalysisToken(::NewAnalyzer) -> AnalysisToken`**
+
+   Return the [`AnalysisToken`](@ref) that identifies analyzer instances whose
+   cached analysis results may be shared.
 
 See also [`AnalyzerState`](@ref) and [`AnalysisToken`](@ref).
 
 # Example
 
-JET.jl defines its default error analyzer `BasicJETAnalyzer <: AbstractAnalyzer` as the following
-(modified a bit for the sake of simplicity):
+JET.jl's default error analyzer, `BasicJETAnalyzer <: AbstractAnalyzer`, can be
+represented by the following simplified definition:
 ```julia
 # the default error analyzer for JET.jl
 struct BasicJETAnalyzer <: AbstractAnalyzer
@@ -38,8 +44,9 @@ end
 
 # AbstractAnalyzer API requirements
 JETInterface.AnalyzerState(analyzer::BasicJETAnalyzer) = analyzer.state
-JETInterface.AbstractAnalyzer(analyzer::BasicJETAnalyzer, state::AnalyzerState) =
-    BasicJETAnalyzer(state, analyzer.analysis_token, ...)
+JETInterface.AbstractAnalyzer(
+    analyzer::BasicJETAnalyzer, state::AnalyzerState) =
+        BasicJETAnalyzer(state, analyzer.analysis_token, ...)
 JETInterface.AnalysisToken(analyzer::BasicJETAnalyzer) = analyzer.analysis_token
 ```
 """
@@ -66,12 +73,14 @@ end
 """
     CachedAnalysisResult
 
-Cached version of [`AnalysisResult`](@ref) stored in the global analyzer cache.
+A cached collection of reports associated with an [`AnalysisResult`](@ref).
 
-When an [`AnalysisResult`](@ref) is cached into the global cache maintained by
-`AbstractAnalyzer`, it's transformed into this type. That is, when
-`codeinf::CodeInstance = $CC.code_cache(analyzer::AbstractAnalyzer)[mi::MethodInstance]`,
-the `codeinf.inferred` field will contain a `CachedAnalysisResult` instance.
+JET copies reports into this container and stacks it directly on the
+corresponding `InferenceResult` with `CC.stack_analysis_result!`. When that
+inference result is cached as a `CodeInstance`, the metadata is retained.
+Global cache lookup recovers the reports by traversing the `CodeInstance` with
+`CC.traverse_analysis_results`; local cache lookup can traverse the
+`InferenceResult` directly.
 """
 struct CachedAnalysisResult
     reports::Vector{InferenceErrorReport}
@@ -109,20 +118,20 @@ end
         ...
     end
 
-The mutable object that holds various states that are consumed by all [`AbstractAnalyzer`](@ref)s.
+Mutable storage for the state used by an [`AbstractAnalyzer`](@ref).
 
 ---
 
     JETInterface.AnalyzerState(analyzer::AbstractAnalyzer) -> AnalyzerState
 
-If `NewAnalyzer` implements the `AbstractAnalyzer` interface, `NewAnalyzer` should implement
-this `AnalyzerState(analyzer::NewAnalyzer) -> AnalyzerState` interface.
+Every `NewAnalyzer` subtype must implement this method to return its
+`AnalyzerState`.
 
-A new `AnalyzerState` is supposed to be constructed by the
-[`NewAnalyzer(; jetconfigs...)`](@ref AbstractAnalyzer) constructor, and the constructed
-`AnalyzerState` is usually kept within `NewAnalyzer` itself:
+A new `AnalyzerState` is normally constructed by the
+[`NewAnalyzer(; jetconfigs...)`](@ref AbstractAnalyzer) constructor and stored
+in the analyzer itself:
 ```julia
-function NewAnalyzer(world::UInt=Base.get_world_counter(); jetconfigs...)
+function NewAnalyzer(world::UInt = Base.get_world_counter(); jetconfigs...)
     ...
     state = AnalyzerState(world; jetconfigs...)
     return NewAnalyzer(..., state)
@@ -271,11 +280,11 @@ end
         AnalysisToken() = new()
     end
 
-A unique token object used to identify and separate caches of analysis results.
+An identity token used as the compiler cache owner for an [`AbstractAnalyzer`](@ref).
 
-Each `AbstractAnalyzer` implementation should use a consistent token to enable
-proper caching behavior. The identity of the token determines whether cached analysis
-results can be reused between analyzer instances.
+The token's object identity determines which analyzer instances can reuse
+cached inference and report results. Reuse the same token object only for
+analyzers with cache-compatible behavior; use distinct objects otherwise.
 """
 mutable struct AnalysisToken
     AnalysisToken() = new()
@@ -284,12 +293,12 @@ end
 """
     JETInterface.AnalysisToken(analyzer::AbstractAnalyzer) -> AnalysisToken
 
-Returns [`AnalysisToken`](@ref) for the given `analyzer::AbstractAnalyzer`.
-`AbstractAnalyzer` instances can share the same cache if they perform the same analysis,
-otherwise their cache should be separated.
+Return the [`AnalysisToken`](@ref) used as the cache owner for `analyzer`.
 
-If `NewAnalyzer` implements the `AbstractAnalyzer` interface, it must implement this
-function to return a consistent token for instances that should share the same cache.
+Every `NewAnalyzer` subtype must implement this method. Instances that can
+safely reuse cached inference and report results must return the same token
+object. Instances whose analysis behavior or configuration can produce
+incompatible results must return distinct token objects.
 """
 @noinline function AnalysisToken(analyzer::AbstractAnalyzer)
     AnalyzerType = nameof(typeof(analyzer))
@@ -323,9 +332,8 @@ typeinf_world(::AbstractAnalyzer) = nothing
 """
     JETInterface.valid_configurations(analyzer::AbstractAnalyzer) -> names or nothing
 
-Returns a set of names that are valid as a configuration for `analyzer`.
-`names` should be an iterator of `Symbol`.
-No validations are performed if `nothing` is returned.
+Return an iterable of `Symbol`s naming the configurations accepted by
+`analyzer`. Return `nothing` to skip configuration-name validation.
 """
 valid_configurations(::AbstractAnalyzer) = nothing
 
@@ -346,27 +354,25 @@ function validate_configs(valid_keys, jetconfigs)
 end
 
 """
-    JETInterface.aggregation_policy(analyzer::AbstractAnalyzer)
+    JETInterface.aggregation_policy(analyzer::AbstractAnalyzer) -> key_function
 
-Defines how `analyzer` aggregates [`InferenceErrorReport`](@ref)s.
-This policy determines how duplicate or similar reports are identified and grouped.
-Defaults to `default_aggregation_policy`.
+Return a callable that maps each [`InferenceErrorReport`](@ref) to the key used
+to deduplicate reports. The default is `default_aggregation_policy`.
 
 ---
 
     default_aggregation_policy(report::InferenceErrorReport) -> DefaultReportIdentity
 
-Returns the default identity of `report::InferenceErrorReport` using `DefaultReportIdentity`,
-which aggregates reports based on their "error location".
+Return the default deduplication key for a report. Two reports have the same
+key when they have:
 
-`DefaultReportIdentity` aggregates `InferenceErrorReport`s by creating an identity based on:
-1. The report type
-2. The signature of the method where the error was found
-3. The file and line number where the error occurred
+1. The same concrete report type
+2. Equal expression [`Signature`](@ref)s
+3. The same file and line in their final [`VirtualFrame`](@ref)s
 
-This approach ignores the specific `MethodInstance` identity, allowing errors to be
-aggregated if they occur at the same file and line, under the assumption that errors
-at the same location are likely duplicates even if in different method specializations.
+`Signature` equality compares only the `_sig` elements, using `===`, and ignores
+`tt`. The stack-trace component uses only the final frame's file and line; it
+omits that frame's `MethodInstance` and all preceding frames.
 """
 aggregation_policy(::AbstractAnalyzer) = default_aggregation_policy
 const default_aggregation_policy = function (report::InferenceErrorReport)
@@ -407,14 +413,9 @@ get_reports(analyzer::AbstractAnalyzer, result::InferenceResult) = (analyzer[res
 """
     add_new_report!(analyzer::AbstractAnalyzer, result::InferenceResult, report::InferenceErrorReport)
 
-Adds a new error report to the analyzer's collection for a specific inference result.
-
-This function associates an [`InferenceErrorReport`](@ref) with its corresponding
-`result::InferenceResult` in the analyzer's internal storage. The report becomes
-part of the analysis results that can be retrieved later using `get_reports(analyzer, result)`.
-
-Reports are stored in the order they are added, which can be important for maintaining
-the logical sequence of errors discovered during analysis.
+Append `report` to the reports associated with `result` in `analyzer`, then
+return `report`. Retrieve the collection with `get_reports(analyzer, result)`.
+Reports remain in insertion order.
 """
 function add_new_report!(analyzer::AbstractAnalyzer, result::InferenceResult, @nospecialize(report::InferenceErrorReport))
     push!(get_reports(analyzer, result), report)
@@ -444,57 +445,53 @@ CC.may_discard_trees(::AbstractAnalyzer) = false
 """
     abstract type ToplevelAbstractAnalyzer <: AbstractAnalyzer end
 
-A specialized interface type for analyzers that perform top-level analysis of Julia code.
+An interface type for analyzers that support top-level analysis of Julia code.
 
-`ToplevelAbstractAnalyzer` extends [`AbstractAnalyzer`](@ref) to provide clear separation
-between analyzers that support top-level analysis and those that don't, offering several
-key architectural benefits:
-- _Type Safety_: Only analyzers that explicitly extend `ToplevelAbstractAnalyzer` can be
-  used with JET's `virtual_process` system, making it clear at compile time which analyzers
-  support top-level analysis capabilities.
-- _Responsibility Separation_: Analyzers like `OptAnalyzer` that don't perform top-level
-  analysis are no longer required to handle top-level specific code paths, reducing
-  complexity and improving performance.
+`ToplevelAbstractAnalyzer` is a subtype of [`AbstractAnalyzer`](@ref).
+Methods specialized for this type provide top-level-specific inference behavior
+and distinguish these analyzers from analyzers such as `OptAnalyzer`, which do
+not support top-level analysis.
 
-## Top-Level Analysis Capabilities
+## Top-level analysis capabilities
 
-`ToplevelAbstractAnalyzer` provides specialized functionality for analyzing top-level
-Julia constructs such as:
+Together with a [`ConcreteInterpreter`](@ref), a `ToplevelAbstractAnalyzer`
+supports analysis of top-level constructs such as:
+
 - Global variable assignments
 - Constant declarations (`const` statements)
 - Module definitions and imports
 - Method definitions at the top level
 - Package-level code execution
 
-This analyzer type is used in [`virtual_process`](@ref) system to analyze Julia code
-as it would be executed at the top level, handling both concrete interpretation of some
-statements and abstract interpretation of others.
+The [`virtual_process`](@ref) system uses the concrete interpreter and analyzer
+to process Julia code as it would execute at the top level. Some statements are
+interpreted concretely, while others are analyzed abstractly.
 
 ## Usage
 
 `ToplevelAbstractAnalyzer` is typically used through JET's virtual process system:
 
 ```julia
-# Create a concrete interpreter with a toplevel analyzer
-interp = JETConcreteInterpreter(JETAnalyzer(...))
+# Create a concrete interpreter with a top-level analyzer
+interp = JETConcreteInterpreter(JETAnalyzer())
 analyzer = ToplevelAbstractAnalyzer(interp)
 
 # Analyze top-level code
 result = analyze_and_report_text!(interp, "x = 1; y = x + 1")
 ```
 
-## Implementation Requirements
+## Implementation requirements
 
-Concrete subtypes of `ToplevelAbstractAnalyzer` must implement all the interfaces required
-by [`AbstractAnalyzer`](@ref), and will automatically inherit the specialized top-level
-analysis behaviors provided by this type.
+Concrete subtypes of `ToplevelAbstractAnalyzer` must implement all interfaces
+required by [`AbstractAnalyzer`](@ref). Methods specialized for this interface
+then provide the top-level-specific abstract interpretation behavior.
 
-## See Also
+## See also
 
-- [`AbstractAnalyzer`](@ref): The base analyzer interface
-- [`JETAnalyzer`](@ref): JET's default error analyzer that implements this interface
-- [`virtual_process`](@ref): The main function that uses this analyzer type
-- [`ConcreteInterpreter`](@ref): The concrete interpreter that works with this analyzer
+- [`AbstractAnalyzer`](@ref): the base analyzer interface
+- [`JETAnalyzer`](@ref): JET's default error analyzer for this interface
+- [`virtual_process`](@ref): the top-level processing entry point
+- [`ConcreteInterpreter`](@ref): the corresponding concrete interpreter
 """
 abstract type ToplevelAbstractAnalyzer <: AbstractAnalyzer end
 

--- a/src/abstractinterpret/inferenceerrorreport.jl
+++ b/src/abstractinterpret/inferenceerrorreport.jl
@@ -7,8 +7,14 @@
 """
     Signature
 
-Represents an expression signature.
-`print_signature` implements a frontend functionality to show this type.
+Represents the expression signature associated with an error point.
+
+- `_sig::Vector{Any}`: components used to render the expression
+- `tt::Union{Type,Nothing}`: the call tuple type, when available
+
+Equality compares only the elements of `_sig`, using `===`, and ignores `tt`.
+Hashing likewise uses only `_sig`. [`print_signature`](@ref) renders a
+`Signature` for display.
 """
 struct Signature
     _sig::Vector{Any}
@@ -39,14 +45,14 @@ Base.lastindex(sig::Signature, args...) = lastindex(sig._sig, args...)
 """
     VirtualFrame
 
-Stack information representing virtual execution context:
-- `file::Symbol`: the path to the file containing the virtual execution context
-- `line::Int`: the line number in the file containing the virtual execution context
-- [`sig::Signature`](@ref Signature): a signature of this frame
-- `linfo::MethodInstance`: The `MethodInstance` containing the execution context
+Stack information representing a virtual execution context:
 
-This type is very similar to `Base.StackTraces.StackFrame`, but its execution context is
-collected during abstract interpration, not collected from actual execution.
+- `file::Symbol`: the source file containing the execution context
+- `line::Int`: the source line containing the execution context
+- `linfo::MethodInstance`: the `MethodInstance` containing the context
+
+This type is similar to `Base.StackTraces.StackFrame`, but its context is
+collected during abstract interpretation rather than runtime execution.
 """
 @withmixedhash struct VirtualFrame
     file::Symbol
@@ -57,10 +63,9 @@ end
 """
     VirtualStackTrace
 
-Represents a virtual stack trace in the form of a vector of `VirtualFrame`.
-The vector holds `VirtualFrame`s in order of "from entry call site to error point", i.e.
-the first element is the `VirtualFrame` of the entry call site, and the last element is that
-contains the error.
+A vector of [`VirtualFrame`](@ref)s ordered from the analysis entry point to the
+error point. The first element represents the entry frame, and the last element
+represents the frame where the error was detected.
 """
 const VirtualStackTrace = Vector{VirtualFrame}
 
@@ -443,53 +448,66 @@ end
 """
     abstract type InferenceErrorReport end
 
-An interface type of error reports collected by JET's abstract interpretation based analysis.
-All `InferenceErrorReport`s have the following fields,
-which explains _where_ and _how_ this error is reported:
-- [`vst::VirtualStackTrace`](@ref VirtualStackTrace): a virtual stack trace of the error
-- [`sig::Signature`](@ref Signature): a signature of the error point
+An interface type for error reports collected during JET's abstract interpretation.
 
-Note that some `InferenceErrorReport` may have additional fields other than `vst` and `sig`
-to explain _why_ they are reported.
+Every concrete subtype provides the following fields:
+
+- [`vst::VirtualStackTrace`](@ref VirtualStackTrace): the virtual stack trace
+  from the analysis entry point to the error point
+- [`sig::Signature`](@ref Signature): the expression signature at the error
+  point
+
+A subtype may provide additional fields to explain why the error was reported.
 """
 abstract type InferenceErrorReport end
 
 """
-    InferenceErrorReport
+    InferenceErrorReport()
 
-In order for `Report <: InferenceErrorReport` to implement the interface,
-it should satisfy the following requirements:
+A concrete `Report <: InferenceErrorReport` must satisfy the following
+requirements.
 
-- **Required fields** \\
-  `Report` should have the following fields,
-  which explains _where_ and _how_ this error is reported:
-  * `vst::VirtualStackTrace`: a virtual stack trace of the error
-  * [`sig::Signature`](@ref Signature): a signature of the error point
+## Required fields
 
-  Note that `Report` can have additional fields other than `vst` and `sig` to explain
-  _why_ this error is reported (mostly used for [`print_report_message`](@ref)).
+- `vst::VirtualStackTrace`: the virtual stack trace from the analysis entry
+  point to the error point
+- [`sig::Signature`](@ref Signature): the expression signature at the error point
 
-- **Required overloads** \\
+A report may have additional fields used by
+[`print_report_message`](@ref) to explain why it was emitted.
 
-  * [`JETInterface.copy_report(report::Report) -> new::Report`](@ref copy_report)
-  * [`JETInterface.print_report_message(io::IO, report::Report)`](@ref print_report_message)
+## Required methods
 
-- **Optional overloads** \\
+- [`JETInterface.copy_report(report::Report) -> new::Report`](@ref copy_report)
+- [`JETInterface.print_report_message(io::IO, report::Report)`](@ref print_report_message)
 
-  * [`JETInterface.print_signature(::Report) -> Bool`](@ref print_signature)
-  * [`JETInterface.report_color(::Report) -> Symbol`](@ref report_color)
+## Optional methods
 
-`Report <: InferenceErrorReport` is supposed to be constructed using the following constructor
+- [`JETInterface.print_signature(report::Report) -> Bool`](@ref print_signature)
+- [`JETInterface.report_color(report::Report) -> Symbol`](@ref report_color)
 
-    Report(::AbstractAnalyzer, state, spec_args...) -> Report
+## Construction
 
-where `state` can be either of:
-- `state::$StateAtPC`: a state with the current program counter specified
-- `state::InferenceState`: a state with the current program counter set to `state.currpc`
-- `state::InferenceResult`: a state with the current program counter unknown
-- `state::MethodInstance`: a state with the current program counter unknown
+JET provides the following generic constructor:
 
-See also: [`@jetreport`](@ref), [`VirtualStackTrace`](@ref), [`VirtualFrame`](@ref)
+    Report(state, spec_args...) -> Report
+
+`state` may be any of:
+
+- `state::StateAtPC`: a state with an explicitly specified program counter
+- `state::InferenceState`: a state using `state.currpc` as the program counter
+- `state::InferenceResult`: a state whose program counter is unknown
+- `state::MethodInstance`: a state whose program counter is unknown
+
+The generic constructor derives `vst` and `sig`, then calls this storage
+constructor:
+
+    Report(vst::VirtualStackTrace, sig::Signature, spec_args...) -> Report
+
+A manually defined report type must provide the storage constructor.
+[`@jetreport`](@ref) generates it automatically.
+
+See also [`VirtualStackTrace`](@ref) and [`VirtualFrame`](@ref).
 """
 function InferenceErrorReport() end
 
@@ -499,9 +517,9 @@ function InferenceErrorReport() end
 """
     JETInterface.copy_report(orig::Report) where Report<:InferenceErrorReport -> new::Report
 
-Returns new `new::Report`, that should be identical to the original `orig::Report`, except
-that `new.vst` is copied from `orig.vst` so that the further modification on `orig.vst`
-that may happen in later abstract interpretation doesn't affect `new.vst`.
+Return a new `Report` equivalent to `orig`. Preserve every field except `vst`,
+which must contain the same frames as `orig.vst` in a distinct vector. Mutating
+either stack trace must not affect the other report.
 """
 @noinline copy_report(report::InferenceErrorReport) = (@nospecialize;
     error(lazy"`copy_report(::$(typeof(report)))` is not implemented"))
@@ -509,7 +527,7 @@ that may happen in later abstract interpretation doesn't affect `new.vst`.
 """
     JETInterface.print_report_message(io::IO, report::Report) where Report<:InferenceErrorReport
 
-Prints to `io` and describes _why_ `report` is reported.
+Print to `io` a message explaining why `report` was emitted.
 """
 @noinline print_report_message(io::IO, report::InferenceErrorReport) = (@nospecialize;
     error(lazy"`print_report_message(::IO, ::$(typeof(report)))` is not implemented"))
@@ -517,14 +535,14 @@ Prints to `io` and describes _why_ `report` is reported.
 """
     JETInterface.print_signature(::Report) where Report<:InferenceErrorReport -> Bool
 
-Configures whether or not to print the report signature when printing `Report` (defaults to `true`).
+Return whether to print the report's signature. The default is `true`.
 """
 print_signature(::InferenceErrorReport) = true
 
 """
     JETInterface.report_color(::Report) where Report<:InferenceErrorReport -> Symbol
 
-Configures the color for `Report` (defaults to `:red`).
+Return the color used to print the report. The default is `ERROR_COLOR` (`:light_red`).
 """
 report_color(::InferenceErrorReport) = ERROR_COLOR
 
@@ -588,10 +606,13 @@ end
 """
     reportkey(report::InferenceErrorReport)
 
-Returns an identifier for the runtime-dispatched call site of `report`.
+Return `(report.sig.tt, last(report.vst).linfo)`. The first component is the
+reported call tuple type, or `nothing` when no call tuple type is available. The
+second component is the `MethodInstance` of the final virtual frame.
 
-If you have a long list of reports to analyze, `urpts = unique(reportkey, rpts)` may remove "duplicates"
-that arrive at the same runtime dispatch from different entry points.
+For a collection of reports, `unique(reportkey, reports)` deduplicates reports
+with the same two components, even when they were reached from different
+analysis entry points.
 """
 reportkey(report::InferenceErrorReport) = (report.sig.tt, report.vst[end].linfo)
 
@@ -602,22 +623,26 @@ reportkey(report::InferenceErrorReport) = (report.sig.tt, report.vst[end].linfo)
         ...
     end
 
-A utility macro to define [`InferenceErrorReport`](@ref).
-It can be very tedious to manually satisfy the `InferenceErrorReport` interfaces.
-JET internally uses this `@jetreport` utility macro, which takes a `struct` definition of
-`InferenceErrorReport` without the required fields specified, and automatically defines
-the `struct` as well as constructor definitions.
-If the report `NewReport <: InferenceErrorReport` is defined using `@jetreport`,
-then `NewReport` just needs to implement the `print_report_message` interface.
+Define an [`InferenceErrorReport`](@ref) subtype from its report-specific fields.
+The macro adds:
 
-For example, [`JETAnalyzer`](@ref)'s `MethodErrorReport` is defined as follows:
+- the required `vst::VirtualStackTrace` and `sig::Signature` fields
+- a storage constructor accepting `vst`, `sig`, and the report-specific fields
+- a [`copy_report`](@ref) method that copies `vst` and preserves the other fields
+
+The generic `NewReport(state, spec_args...)` constructor initializes `vst` and `sig`.
+A report defined with `@jetreport` only needs to implement the
+[`print_report_message`](@ref) interface; it may also override the optional report interfaces.
+
+The following is a simplified version of [`JETAnalyzer`](@ref)'s `MethodErrorReport`;
+the actual definition has additional behavior:
 ```julia
 @jetreport struct MethodErrorReport <: InferenceErrorReport
-    @nospecialize t # ::Union{Type, Vector{Type}}
+    @nospecialize t # ::Union{Type,Vector{Any}}
     union_split::Int
 end
 function print_report_message(io::IO, (; t, union_split)::MethodErrorReport)
-    print(io, "no matching method found for ")
+    print(io, "no matching method found ")
     if union_split == 0
         print_callsig(io, t)
     else
@@ -631,7 +656,9 @@ function print_report_message(io::IO, (; t, union_split)::MethodErrorReport)
     end
 end
 ```
-and constructed as like `MethodErrorReport(sv::InferenceState, atype::Any, 0)`.
+
+Given `sv::InferenceState` and `atype`, construct this simplified report with
+`MethodErrorReport(sv, atype, 0)`.
 """
 macro jetreport(ex)
     isexpected = @capture(ex, struct NewReport_ <: Super_; spec_sigs__; end)

--- a/src/analyzers/jetanalyzer.jl
+++ b/src/analyzers/jetanalyzer.jl
@@ -1,49 +1,47 @@
 
 """
-Every [entry point of error analysis](@ref jetanalysis-entry) can accept
-any of the [general configurations](@ref) as well as the following additional configurations
-that are specific to the error analysis.
+Every [entry point of error analysis](@ref jetanalysis-entry) accepts any of
+[the general configurations](@ref general-configurations), together with the
+following configurations specific to error analysis.
 
 ---
 - `mode::Symbol = :basic`:\\
-  Switches the error analysis pass. Each analysis pass reports errors according to their
-  own "error" definition.
-  JET by default offers the following modes:
-  - `mode = :basic`: the default error analysis pass.
-    This analysis pass is tuned to be useful for general Julia development by reporting common
-    problems, but also note that it is not enough strict to guarantee that your program never
-    throws runtime errors.\\
-  - `mode = :sound`: the sound error analysis pass.
-    If this pass doesn't report any errors, then your program is assured to run without
-    any runtime errors (unless JET's error definition is not accurate and/or there is an
-    implementation flaw).\\
-  - `mode = :typo`: a typo detection pass
-    A simple analysis pass to detect "typo"s in your program.
-    This analysis pass is essentially a subset of the default basic pass,
-    and it only reports undefined global reference and undefined field access.
-    This might be useful especially for a very complex code base, because even the basic pass
-    tends to be too noisy (spammed with too many errors) for such a case.
+  Selects the error-analysis mode. Each mode reports problems according to its
+  own definition of an error. JET provides the following modes:
+  - `mode = :basic`: the default error-analysis mode.
+    This mode reports common problems and is tuned for general Julia development,
+    but it is not strict enough to guarantee error-free execution.
+  - `mode = :sound`: the sound error-analysis mode.
+    If this mode reports no errors, the analyzed code is guaranteed not to encounter
+    a runtime error covered by JET's error model, assuming that the model and
+    implementation are actually sound.
+  - `mode = :typo`: the typo-detection mode.
+    This mode is a subset of the default basic mode and reports a focused set of
+    likely typo-related errors. These include undefined global, local, and
+    static-parameter references; incompatible global assignments; and invalid
+    field accesses or assignments. It can be useful for large or complex
+    codebases where even the basic mode produces too many reports.
 
   !!! note
-      You can also set up your own analysis using JET's [`AbstractAnalyzer`-Framework](@ref).
+      You can also set up your own analysis using JET's
+      [`AbstractAnalyzer` framework](@ref AbstractAnalyzer-framework).
 ---
 - `ignore_missing_comparison::Bool = false`:\\
-  If `true`, JET will ignores the possibility of a poorly-inferred comparison operator call
-  (e.g. `==`) returning `missing` in order to hide the error reports from branching on the
-  potential `missing` return value of such a comparison operator call.
-  This is turned off by default, because a comparison call results in a
-  `Union{Bool,Missing}` possibility, it likely signifies an inferrability issue or the
-  `missing` possibility should be handled someway. But this is useful to reduce the noisy
-  error reports in the situations where specific input arguments type is not available at
-  the beginning of the analysis like [`report_package`](@ref).
+  If `true`, JET widens any inferred call result that is exactly
+  `Union{Bool,Missing}` to `Any`. This suppresses reports caused by branching on
+  a possible `missing` result from a poorly inferred comparison operator such
+  as `==`. This is disabled by default because `Union{Bool,Missing}` can indicate
+  imprecise inference or a case where `missing` should be handled explicitly.
+  It can nevertheless reduce noise when precise input argument types are
+  unavailable at the analysis entry point, as with [`report_package`](@ref).
 ---
 - `ignore_throws::Bool = false`:\\
-  If `true`, JET will not report errors from `throw` calls and exceptions that may propagate
-  to callers. This is turned off by default, but is useful when analyzing package-level
-  definitions where `throw` calls are often intentional (e.g., interface function definitions
-  that throw errors by default) and not indicative of actual problems.
-  This configuration is enabled by default in [`report_package`](@ref)
-  to reduce noise from such intentional throws.
+  If `true`, JET does not report errors from `throw` calls or exceptions that
+  may propagate to callers. This is disabled by default, but is useful when
+  analyzing package-level definitions where `throw` calls are often
+  intentional, such as interface functions that throw errors by default.
+  [`report_package`](@ref) enables this configuration by default to reduce
+  noise from such intentional throws.
 ---
 """
 struct JETAnalyzerConfig
@@ -59,6 +57,44 @@ struct JETAnalyzerConfig
     end
 end
 
+"""
+    abstract type JETAnalyzer <: ToplevelAbstractAnalyzer end
+
+JET's default error analyzer, which powers the
+[error analysis](@ref jetanalysis) entry points such as [`report_call`](@ref)
+and [`report_file`](@ref). The analyzer runs Julia's type inference on the
+given code and, while walking the inferred call graph, collects places that
+may raise runtime errors, such as `MethodError`s and undefined name
+references.
+
+There is no single correct definition of what should count as an "error" in
+this kind of static analysis: a stricter definition catches more potential
+problems, but also produces more false positives. `JETAnalyzer` therefore
+offers multiple analysis modes, each with its own error definition.
+`JETAnalyzer` itself is an abstract type; each mode is implemented as a
+concrete subtype, and the `JETAnalyzer(; jetconfigs...)` constructor selects
+one according to [the `mode` configuration](@ref jetanalysis-config):
+
+- `mode = :basic` (default) constructs `BasicJETAnalyzer`, which reports
+  problems that are likely to be actual errors, and is tuned to be useful for
+  general Julia development. It is not strict enough to guarantee that the
+  analyzed code is free from runtime errors.
+- `mode = :sound` constructs `SoundJETAnalyzer`, which reports any possibility
+  of a runtime error covered by JET's error model, at the cost of more false
+  positives. If it reports no errors, the analyzed code should not raise a
+  runtime error covered by the model.
+- `mode = :typo` constructs `TypoJETAnalyzer`, which reports only a focused
+  subset of likely typos, such as undefined name references and invalid field
+  accesses. It is useful for large codebases where even the basic mode is too
+  noisy.
+
+Each subtype implements its own definition of an "error" by overloading the
+report hooks (`report_method_error!`, `report_undef_global_var!`, and so on),
+while sharing the traversal implemented for `JETAnalyzer`. `JETAnalyzer` is
+built on JET's [`AbstractAnalyzer` framework](@ref AbstractAnalyzer-framework),
+which third-party analyzers can also use to implement different analyses on
+the same infrastructure.
+"""
 abstract type JETAnalyzer <: ToplevelAbstractAnalyzer end
 
 struct BasicJETAnalyzer <: JETAnalyzer
@@ -614,7 +650,7 @@ function _report_uncaught_exception!(analyzer::JETAnalyzer, frame::InferenceStat
 end
 
 @jetreport struct MethodErrorReport <: InferenceErrorReport
-    @nospecialize t # ::Union{Type, Vector{Type}}
+    @nospecialize t # ::Union{Type,Vector{Any}}
     union_split::Int
     uncovered::Bool
 end
@@ -989,7 +1025,7 @@ function _report_global_assignment!(analyzer::JETAnalyzer, sv::InferenceState, r
 end
 
 @jetreport struct NonBooleanCondErrorReport <: InferenceErrorReport
-    @nospecialize t # ::Union{Type, Vector{Type}}
+    @nospecialize t # ::Union{Type,Vector{Any}}
     union_split::Int
     uncovered::Bool
 end
@@ -1481,13 +1517,14 @@ JETInterface.valid_configurations(::JETAnalyzer) = JET_ANALYZER_VALID_CONFIGURAT
     report_call(tt::Type{<:Tuple}; jetconfigs...) -> JETCallResult
     report_call(mi::Core.MethodInstance; jetconfigs...) -> JETCallResult
 
-Analyzes a function call with the given type signature to find type-level errors
-and returns back detected problems.
+Analyzes a function call with the given type signature and returns a
+[`JETCallResult`](@ref) containing the detected type-level problems.
 
-The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as a keyword argument.
+The [general configurations](@ref general-configurations) and
+[error-analysis-specific configurations](@ref jetanalysis-config) can be
+supplied as keyword arguments.
 
-See [the documentation of the error analysis](@ref jetanalysis) for more details.
+See [the documentation of the error analysis](@ref jetanalysis) for details.
 """
 function report_call(args...; jetconfigs...)
     analyzer = JETAnalyzer(; jetconfigs...)
@@ -1497,12 +1534,13 @@ end
 """
     @report_call [jetconfigs...] f(args...)
 
-Evaluates the arguments to a function call, determines their types, and then calls
-[`report_call`](@ref) on the resulting expression.
-This macro works in a similar way as the `@code_typed` macro.
+Evaluates the function and its arguments, determines their types, and calls
+[`report_call`](@ref) with the resulting function and argument-type signature.
+This macro works similarly to the `@code_typed` macro.
 
-The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as an optional argument.
+The [general configurations](@ref general-configurations) and
+[error-analysis-specific configurations](@ref jetanalysis-config) can be
+supplied as optional leading configuration arguments.
 """
 macro report_call(ex0...)
     return InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :report_call, ex0)
@@ -1514,20 +1552,21 @@ end
 """
     @test_call [jetconfigs...] [broken=false] [skip=false] f(args...)
 
-Runs [`@report_call jetconfigs... f(args...)`](@ref @report_call) and tests that the function
-call `f(args...)` is free from problems that `@report_call` can detect.
-Returns a `Pass` result if the test is successful, a `Fail` result if any problems are detected,
-or an `Error` result if the test encounters an unexpected error.
-When the test `Fail`s, abstract call stack to each problem location will be printed to `stdout`.
+Runs [`@report_call jetconfigs... f(args...)`](@ref @report_call) and records
+its result in the current test set. It records a `Test.Pass` when the call is
+free from detectable problems, a `JET.JETTestFailure` (a `Test.Result` that is
+tallied as a failure) when problems are detected, and a `Test.Error` when
+analysis throws an unexpected error. A `JETTestFailure` displays an abstract
+call stack for each reported problem.
 ```julia-repl
 julia> @test_call sincos(10)
 Test Passed
   Expression: #= none:1 =# JET.@test_call sincos(10)
 ```
 
-As with [`@report_call`](@ref), the [general configurations](@ref) and
-[the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as an optional argument:
+As with [`@report_call`](@ref), the [general configurations](@ref general-configurations)
+and [error-analysis-specific configurations](@ref jetanalysis-config) can be
+supplied as optional leading configuration arguments:
 ```julia-repl
 julia> cond = false
 
@@ -1535,9 +1574,9 @@ julia> function f(n)
            # `cond` is untyped, and will be reported by the sound analysis pass,
            # while JET's default analysis pass will ignore it
            if cond
-               return sin(n)
+               return n
            else
-               return cos(n)
+               return -n
            end
        end;
 
@@ -1549,30 +1588,32 @@ julia> @test_call mode=:sound f(10)
 JET-test failed at none:1
   Expression: #= none:1 =# JET.@test_call mode = :sound f(10)
   ═════ 1 possible error found ═════
-  ┌ @ none:2 goto %4 if not cond
-  │ non-boolean (Any) used in boolean context: goto %4 if not cond
-  └──────────
+  ┌ f(n::Int64) @ Main ./none:2
+  │ non-boolean `Any` may be used in boolean context: goto %5 if not cond
+  └────────────────────
 
 ERROR: There was an error during testing
 ```
 
-`@test_call` is fully integrated with [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/)'s unit-testing infrastructure.
-This means that the result of `@test_call` will be included in a final `@testset` summary
-and it supports `skip` and `broken` annotations, just like the `@test` macro:
+`@test_call` integrates with the unit-testing infrastructure of the
+[`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
+Its result is included in the enclosing `@testset` summary, and it supports
+`skip` and `broken` annotations like the `@test` macro:
 ```julia-repl
 julia> using JET, Test
 
-# Julia can't propagate the type constraint `ref[]::Number` to `sin(ref[])`, JET will report `NoMethodError`
+# Julia can't propagate the type constraint `ref[]::Number` to `sin(ref[])`,
+# so JET reports a possible `MethodError`.
 julia> f(ref) = isa(ref[], Number) ? sin(ref[]) : nothing;
 
-# we can make it type-stable if we extract `ref[]` into a local variable `x`
+# Extracting `ref[]` into a local variable `x` makes the call type-stable.
 julia> g(ref) = (x = ref[]; isa(x, Number) ? sin(x) : nothing);
 
 julia> @testset "check errors" begin
            ref = Ref{Union{Nothing,Int}}(0)
            @test_call f(ref)             # fail
-           @test_call g(ref)             # fail
-           @test_call broken=true f(ref) # annotated as broken, thus still "pass"
+           @test_call g(ref)             # pass
+           @test_call broken=true f(ref) # broken; does not fail the test set
        end
 check errors: JET-test failed at REPL[21]:3
   Expression: #= REPL[21]:3 =# JET.@test_call f(ref)
@@ -1594,10 +1635,10 @@ end
     test_call(f, [types]; broken::Bool = false, skip::Bool = false, jetconfigs...)
     test_call(tt::Type{<:Tuple}; broken::Bool = false, skip::Bool = false, jetconfigs...)
 
-Runs [`report_call`](@ref) on a function call with the given type signature and tests that
-it is free from problems that `report_call` can detect.
-Except that it takes a type signature rather than a call expression, this function works
-in the same way as [`@test_call`](@ref).
+Runs [`report_call`](@ref) on a function call with the given type signature and
+tests that it is free from problems that `report_call` can detect. It behaves
+like [`@test_call`](@ref), but accepts a type signature rather than a call
+expression.
 """
 function test_call(args...; jetconfigs...)
     return func_test(report_call, :test_call, args...; jetconfigs...)
@@ -1609,26 +1650,28 @@ end
 """
     report_file(file::AbstractString; jetconfigs...) -> JETToplevelResult
 
-Analyzes `file` to find type-level errors and returns back detected problems.
+Analyzes `file` and returns a [`JETToplevelResult`](@ref) containing the
+detected type-level problems.
 
-The [general configurations](@ref) and [the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as a keyword argument.
+The [general configurations](@ref general-configurations) and
+[error-analysis-specific configurations](@ref jetanalysis-config) can be
+supplied as keyword arguments.
 
 !!! tip
-    When you want to analyze your package but no files that actually use its functions are
-    available, [the `analyze_from_definitions` option](@ref toplevel-config) may be useful
-    since it allows JET to analyze methods based on their declared signatures.
-    For example, JET can analyze JET itself in this way:
+    When no files that call your package's functions are available,
+    [the `analyze_from_definitions` option](@ref toplevel-config) can be useful
+    because it lets JET analyze methods from their declared signatures.
+    For example, JET can analyze itself this way:
     ```julia-repl
-    # from the root directory of JET.jl
+    # From the root directory of JET.jl
     julia> report_file("src/JET.jl";
                        analyze_from_definitions = true)
     ```
     See also [`report_package`](@ref).
 
 !!! note
-    This function enables the `toplevel_logger` configuration with the default logging level
-    by default. You can still explicitly specify and configure it:
+    This function enables `toplevel_logger` at the default logging level.
+    You can override or disable it explicitly:
     ```julia
     report_file(args...;
                 toplevel_logger = nothing, # suppress the toplevel logger
@@ -1642,17 +1685,17 @@ function report_file(args...; jetconfigs...)
 end
 
 """
-    test_file(file::AbstractString; jetconfigs...)
+    test_file(file::AbstractString; broken::Bool = false, skip::Bool = false, jetconfigs...)
 
 Runs [`report_file`](@ref) and tests that there are no problems detected.
 
-As with [`report_file`](@ref), the [general configurations](@ref) and
-[the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as an optional argument.
+As with [`report_file`](@ref), the [general configurations](@ref general-configurations)
+and [error-analysis-specific configurations](@ref jetanalysis-config) can be supplied as
+keyword arguments.
 
-Like [`@test_call`](@ref), `test_file` is fully integrated with the
+Like [`@test_call`](@ref), `test_file` integrates with the
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
-See [`@test_call`](@ref) for the details.
+See [`@test_call`](@ref) for details.
 """
 function test_file(args...; jetconfigs...)
     return func_test(report_file, :test_file, args...; jetconfigs...)
@@ -1661,35 +1704,32 @@ end
 """
     report_package(package::Module; jetconfigs...) -> JETToplevelResult
 
-Analyzes `package` and returns back type-level errors.
+Analyzes `package` and returns a [`JETToplevelResult`](@ref) containing the
+detected type-level problems.
 
 This function uses [Revise.jl](https://github.com/timholy/Revise.jl) to collect method
-signatures defined in the package and analyzes each method based on its signature.
-This approach allows JET to analyze a package without requiring top-level call sites or
-actual usage examples.
+signatures defined in the package and analyzes each method from its signature. This
+allows JET to analyze a package without requiring top-level call sites or usage examples.
 
-This analysis is performed incrementally. This means that when the same package is analyzed
-multiple times, changes that Revise can handle are dynamically reflected and change the
-analysis results, while unaffected results from the initial analysis are reused as-is.
-Therefore, subsequent analyses often finish very quickly
-(depending on the scale of invalidations that occur).
+The analysis is incremental. When the same package is analyzed multiple times,
+changes that Revise can handle are reflected in the results, while unaffected
+results from the initial analysis are reused. Subsequent analyses therefore
+often finish quickly, depending on the extent of invalidation.
 
-Any [general configurations](@ref) and [`JETAnalyzer` specific configurations](@ref jetanalysis-config)
-can be specified as a keyword argument, and if given, they are preferred over the default
-configurations. By default, `report_package` enables the following configurations:
-- `ignore_missing_comparison = true`: JET ignores the possibility of a poorly-inferred
-  comparison operator call (e.g. `==`) returning `missing`. This is useful because
-  `report_package` often relies on poor input argument type information at the beginning of
-  analysis, leading to noisy error reports from branching on the potential `missing` return
-  value of such a comparison operator call. If a target package needs to handle `missing`,
-  this configuration should be turned off since it hides the possibility of errors that
-  may actually occur at runtime.
-- `ignore_throws = true`: JET will not report errors from `throw` calls and exceptions
-  that may propagate to callers. This is useful because package-level definitions often
-  include intentional error-throwing interface functions (e.g.,
-  `@noinline interface_func(::T) = error("Interface not implemented")`), which are not
-  indicative of actual problems. If you want to analyze exception handling in your package,
-  this configuration should be turned off.
+The [general configurations](@ref general-configurations) and
+[`JETAnalyzer`-specific configurations](@ref jetanalysis-config) can be
+supplied as keyword arguments. Supplied values override the defaults below:
+- `ignore_missing_comparison = true`: JET widens any inferred call result that
+  is exactly `Union{Bool,Missing}` to `Any`. This reduces noise because
+  `report_package` often begins analysis with imprecise argument types. Disable
+  this configuration when the package intentionally handles `missing`, because
+  it can hide errors that may occur at runtime.
+- `ignore_throws = true`: JET does not report errors from `throw` calls or
+  exceptions that may propagate to callers. Package-level definitions often
+  include intentional error-throwing interface functions, such as
+  `@noinline interface_func(::T) = error("Interface not implemented")`, that do
+  not indicate actual problems. Disable this configuration to analyze exception
+  handling in the package.
 
 !!! tip "About `target_modules` configuration"
     One of the most common issues of this analysis is that the results of `report_package(pkg)`
@@ -1725,13 +1765,13 @@ end
 
 Runs [`report_package`](@ref) and tests that there are no problems detected.
 
-As with [`report_package`](@ref), the [general configurations](@ref) and
-[the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as an optional argument.
+As with [`report_package`](@ref), the [general configurations](@ref general-configurations)
+and [error-analysis-specific configurations](@ref jetanalysis-config) can be supplied as
+keyword arguments.
 
-Like [`@test_call`](@ref), `test_package` is fully integrated with the
+Like [`@test_call`](@ref), `test_package` integrates with the
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
-See [`@test_call`](@ref) for the details.
+See [`@test_call`](@ref) for details.
 
 ```julia-repl
 julia> using Example
@@ -1749,9 +1789,11 @@ end
 
 """
     report_text(text::AbstractString; jetconfigs...) -> JETToplevelResult
-    report_text(text::AbstractString, filename::AbstractString; jetconfigs...) -> JETToplevelResult
+    report_text(text::AbstractString, filename::AbstractString;
+                jetconfigs...) -> JETToplevelResult
 
-Analyzes top-level `text` and returns back type-level errors.
+Analyzes the top-level code in `text` and returns a
+[`JETToplevelResult`](@ref) containing the detected type-level problems.
 """
 function report_text(args...; jetconfigs...)
     interp = JETConcreteInterpreter(JETAnalyzer(; jetconfigs...))
@@ -1759,18 +1801,20 @@ function report_text(args...; jetconfigs...)
 end
 
 """
-    test_text(text::AbstractString; jetconfigs...)
-    test_text(text::AbstractString, filename::AbstractString; jetconfigs...)
+    test_text(text::AbstractString;
+              broken::Bool = false, skip::Bool = false, jetconfigs...)
+    test_text(text::AbstractString, filename::AbstractString;
+              broken::Bool = false, skip::Bool = false, jetconfigs...)
 
 Runs [`report_text`](@ref) and tests that there are no problems detected.
 
-As with [`report_text`](@ref), the [general configurations](@ref) and
-[the error analysis specific configurations](@ref jetanalysis-config)
-can be specified as an optional argument.
+As with [`report_text`](@ref), the [general configurations](@ref general-configurations) and
+[error-analysis-specific configurations](@ref jetanalysis-config) can be supplied as
+keyword arguments.
 
-Like [`@test_call`](@ref), `test_text` is fully integrated with the
+Like [`@test_call`](@ref), `test_text` integrates with the
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
-See [`@test_call`](@ref) for the details.
+See [`@test_call`](@ref) for details.
 """
 function test_text(args...; jetconfigs...)
     return func_test(report_text, :test_text, args...; jetconfigs...)

--- a/src/analyzers/optanalyzer.jl
+++ b/src/analyzers/optanalyzer.jl
@@ -1,62 +1,77 @@
 """
-Every [entry point of optimization analysis](@ref optanalysis-entry) can accept
-any of the [general configurations](@ref) as well as the following additional configurations
-that are specific to the optimization analysis.
+Every [entry point of optimization analysis](@ref optanalysis-entry) accepts
+any of the [general configurations](@ref general-configurations), together with
+the following configurations specific to optimization analysis.
 
 ---
 - `skip_noncompileable_calls::Bool = true`:\\
-  Julia's runtime dispatch is "powerful" because it can always compile code with concrete
-  runtime arguments so that [a "kernel" function](https://docs.julialang.org/en/v1/manual/performance-tips/#kernel-functions)
-  runs very effectively even if it's called from a type-instable call site.
-  This means, we (really) often accept that some parts of our code are not inferred statically,
-  and rather we want to just rely on information that is only available at runtime.
-  To model this programming style, the optimization analyzer by default does NOT report any
-  optimization failures or runtime dispatches detected within non-concrete calls
-  (more correctly, "non-compileable" calls are ignored: see also the note below).
-  We can turn off this `skip_noncompileable_calls` configuration to get type-instabilities
-  within those calls.
+  A call with an abstract inferred signature may not be compileable as-is, but
+  this does not necessarily make its downstream code inefficient. At runtime,
+  Julia dispatches using concrete argument types and can compile specialized
+  code for a
+  ["kernel" function](https://docs.julialang.org/en/v1/manual/performance-tips/#kernel-functions).
+  The kernel can therefore run efficiently even when reached from a
+  type-unstable call site. Idiomatic Julia code may intentionally use such
+  boundaries, relying on information available only at runtime rather than
+  requiring inference to continue through them.
+
+  To model this programming style, `OptAnalyzer` does not, by default, report
+  optimization failures or runtime dispatches found inside calls that Julia
+  would not compile for their inferred signatures. Such calls are often
+  non-concrete, although the more precise criterion is whether a call is
+  compileable; see the note below. The entry call itself is always analyzed.
+  Set `skip_noncompileable_calls=false` to include reports from inside those
+  calls.
+
+  The following example is adapted from Julia's
+  [kernel-function documentation](https://docs.julialang.org/en/v1/manual/performance-tips/#kernel-functions):
   ```julia-repl
-  # the following examples are adapted from https://docs.julialang.org/en/v1/manual/performance-tips/#kernel-functions
   julia> function fill_twos!(a)
              for i = eachindex(a)
                  a[i] = 2
              end
          end;
 
-  julia> function strange_twos(n)
-             a = Vector{rand(Bool) ? Int64 : Float64}(undef, n)
+  julia> function strange_twos(a::Vector)
              fill_twos!(a)
              return a
          end;
 
-  # by default, only type-instabilities within concrete call (i.e. `strange_twos(3)`) are reported
-  # and those within non-concrete calls (`fill_twos!(a)`) are not reported
-  julia> @report_opt strange_twos(3)
-  ═════ 2 possible errors found ═════
-  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:2
-  │ runtime dispatch detected: %33::Type{Vector{_A}} where _A(undef, n::Int64)::Vector
-  └────────────────────
-  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
-  │ runtime dispatch detected: fill_twos!(%34::Vector)::Any
+  # Analyze `strange_twos` with the abstract `Vector` entry signature.
+  julia> report_opt(strange_twos, (Vector,))
+  ═════ 1 possible error found ═════
+  ┌ strange_twos(a::Vector) @ Main ./REPL[2]:2
+  │ runtime dispatch detected: fill_twos!(a::Vector)::Any
   └────────────────────
 
-  # we can get reports from non-concrete calls with `skip_noncompileable_calls=false`
-  julia> @report_opt skip_noncompileable_calls=false strange_twos(3)
-  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
-  │┌ fill_twos!(a::Vector) @ Main ./REPL[22]:3
-  ││┌ setindex!(A::Vector, x::Int64, i1::Int64) @ Base ./array.jl:1014
+  # Also include reports from inside non-compileable calls.
+  julia> report_opt(strange_twos, (Vector,);
+                    skip_noncompileable_calls=false)
+  ═════ 5 possible errors found ═════
+  ┌ strange_twos(a::Vector) @ Main ./REPL[2]:2
+  │┌ fill_twos!(a::Vector) @ Main ./REPL[1]:3
+  ││┌ setindex!(A::Vector, x::Int64, i::Int64) @ Base ./array.jl:986
+  │││┌ _setindex!(A::Vector{T}, x::Any, i::Int64) where T @ Base ./array.jl:990
+  ││││ runtime dispatch detected: Base.throw_boundserror(A::Vector, %12::Tuple{Int64})
+  │││└────────────────────
+  ││┌ setindex!(A::Vector, x::Int64, i::Int64) @ Base ./array.jl:985
   │││ runtime dispatch detected: convert(%5::Any, x::Int64)::Any
   ││└────────────────────
-  │┌ fill_twos!(a::Vector) @ Main ./REPL[22]:3
+  ││┌ setindex!(A::Vector, x::Int64, i::Int64) @ Base ./array.jl:986
+  │││ runtime dispatch detected: Base._setindex!(A::Vector, %9::Any, i::Int64)::Vector
+  ││└────────────────────
+  │┌ fill_twos!(a::Vector) @ Main ./REPL[1]:3
   ││ runtime dispatch detected: ((a::Vector)[%13::Int64] = 2::Any)
   │└────────────────────
-  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:2
-  │ runtime dispatch detected: %33::Type{Vector{_A}} where _A(undef, n::Int64)::Vector
-  └────────────────────
-  ┌ strange_twos(n::Int64) @ Main ./REPL[23]:3
-  │ runtime dispatch detected: fill_twos!(%34::Vector)::Any
+  ┌ strange_twos(a::Vector) @ Main ./REPL[2]:2
+  │ runtime dispatch detected: fill_twos!(a::Vector)::Any
   └────────────────────
   ```
+
+  With the default setting, JET reports the runtime dispatch from the entry
+  call to `fill_twos!(::Vector)` but omits reports from inside `fill_twos!`.
+  With `skip_noncompileable_calls=false`, JET also reports runtime dispatches
+  encountered while analyzing the body of `fill_twos!(::Vector)`.
 
   !!! note "Non-compileable calls"
       Julia runtime system sometimes generate and execute native code of an abstract call.
@@ -120,8 +135,8 @@ that are specific to the optimization analysis.
   program uses a function that is intentionally designed to use runtime dispatch.
 
   ```julia-repl
-  # ignore `$CC.widenconst` calls (since it's designed to be runtime-dispatched):
-  julia> function_filter(@nospecialize f) = f !== $CC.widenconst;
+  # Ignore `Compiler.widenconst`, which intentionally uses runtime dispatch.
+  julia> function_filter(@nospecialize f) = f !== Compiler.widenconst;
 
   julia> @test_opt function_filter=function_filter f(args...)
   ...
@@ -392,13 +407,15 @@ JETInterface.valid_configurations(::OptAnalyzer) = OPT_ANALYZER_VALID_CONFIGURAT
     report_opt(tt::Type{<:Tuple}; jetconfigs...) -> JETCallResult
     report_opt(mi::Core.MethodInstance; jetconfigs...) -> JETCallResult
 
-Analyzes a function call with the given type signature to detect optimization failures and
+Analyzes a function call with the given type signature and returns a
+[`JETCallResult`](@ref) containing detected optimization failures and
 unresolved method dispatches.
 
-The [general configurations](@ref) and [the optimization analysis specific configurations](@ref optanalysis-config)
-can be specified as a keyword argument.
+The [general configurations](@ref general-configurations) and
+[optimization-analysis-specific configurations](@ref optanalysis-config) can be
+supplied as keyword arguments.
 
-See [the documentation of the optimization analysis](@ref optanalysis) for more details.
+See [the documentation of the optimization analysis](@ref optanalysis) for details.
 """
 function report_opt(args...; jetconfigs...)
     analyzer = OptAnalyzer(; jetconfigs...)
@@ -408,11 +425,12 @@ end
 """
     @report_opt [jetconfigs...] f(args...)
 
-Evaluates the arguments to a function call, determines their types, and then calls
-[`report_opt`](@ref) on the resulting expression.
+Evaluates the function and its arguments, determines their types, and calls
+[`report_opt`](@ref) with the resulting function and argument-type signature.
 
-The [general configurations](@ref) and [the optimization analysis specific configurations](@ref optanalysis-config)
-can be specified as an optional argument.
+The [general configurations](@ref general-configurations) and
+[optimization-analysis-specific configurations](@ref optanalysis-config) can be
+supplied as optional leading configuration arguments.
 """
 macro report_opt(ex0...)
     return InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :report_opt, ex0)
@@ -421,31 +439,29 @@ end
 """
     @test_opt [jetconfigs...] [broken=false] [skip=false] f(args...)
 
-Runs [`@report_opt jetconfigs... f(args...)`](@ref @report_opt) and tests that the function
-call `f(args...)` is free from optimization failures and unresolved method dispatches that
-`@report_opt` can detect.
+Runs [`@report_opt jetconfigs... f(args...)`](@ref @report_opt) and records a
+test that passes when the call is free from optimization failures and
+unresolved method dispatches that `@report_opt` can detect.
 
-As with [`@report_opt`](@ref), the [general configurations](@ref) and
-[optimization analysis specific configurations](@ref optanalysis-config)
-can be specified as an optional argument:
+As with [`@report_opt`](@ref), the [general configurations](@ref general-configurations) and
+[optimization-analysis-specific configurations](@ref optanalysis-config) can be supplied as
+optional leading configuration arguments:
 ```julia-repl
 julia> function f(n)
-            r = sincos(n)
-            # `println` is full of runtime dispatches,
-            # but we can ignore the corresponding reports from `Base`
-            # with the `target_modules` configuration
-            println(r)
-            return r
+           r = sincos(n)
+           # Ignore runtime dispatch reports from the `println` implementation.
+           println(r)
+           return r
        end;
 
-julia> @test_opt target_modules=(@__MODULE__,) f(10)
+julia> @test_opt ignored_modules=(Base,) f(10)
 Test Passed
-  Expression: #= REPL[3]:1 =# JET.@test_call analyzer = JET.OptAnalyzer target_modules = (#= REPL[3]:1 =# @__MODULE__(),) f(10)
+  Expression: #= REPL[3]:1 =# JET.@test_opt ignored_modules = (Base,) f(10)
 ```
 
-Like [`@test_call`](@ref), `@test_opt` is fully integrated with the
+Like [`@test_call`](@ref), `@test_opt` integrates with the
 [`Test` standard library](https://docs.julialang.org/en/v1/stdlib/Test/).
-See [`@test_call`](@ref) for the details.
+See [`@test_call`](@ref) for details.
 """
 macro test_opt(ex0...)
     return call_test_ex(:report_opt, Symbol("@test_opt"), ex0, __module__, __source__)
@@ -455,10 +471,10 @@ end
     test_opt(f, [types]; broken::Bool = false, skip::Bool = false, jetconfigs...)
     test_opt(tt::Type{<:Tuple}; broken::Bool = false, skip::Bool = false, jetconfigs...)
 
-Runs [`report_opt`](@ref) on a function call with the given type signature and tests that
-it is free from optimization failures and unresolved method dispatches that `report_opt` can detect.
-Except that it takes a type signature rather than a call expression, this function works
-in the same way as [`@test_opt`](@ref).
+Runs [`report_opt`](@ref) on a function call with the given type signature and
+tests that it is free from optimization failures and unresolved method
+dispatches that `report_opt` can detect. It behaves like [`@test_opt`](@ref),
+but accepts a type signature rather than a call expression.
 """
 function test_opt(@nospecialize(args...); jetconfigs...)
     return func_test(report_opt, :test_opt, args...; jetconfigs...)

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -1,10 +1,11 @@
 """
-    ToplevelErrorReport
+    abstract type ToplevelErrorReport end
 
-An interface type of error reports that JET collects while top-level concrete interpration.
-All `ToplevelErrorReport` should have the following fields:
-- `file::String`: the path to the file containing the interpretation context
-- `line::Int`: the line number in the file containing the interpretation context
+An interface type for reports that JET collects during top-level processing,
+including parsing and partial concrete interpretation.
+All concrete subtypes of `ToplevelErrorReport` must have the following fields:
+- `file::String`: the path to the source file associated with the report
+- `line::Int`: the source line associated with the report
 
 See also: [`virtual_process`](@ref), [`ConcreteInterpreter`](@ref)
 """
@@ -167,117 +168,99 @@ function print_report(io::IO, report::MissingConcretizationErrorReport)
 end
 
 """
-Configurations for top-level analysis.
-These configurations will be active for all the top-level entries explained in the
+Configuration options for top-level analysis.
+These options apply to all entry points described in the
 [top-level analysis entry points](@ref jetanalysis-toplevel-entry) section.
 
 ---
 - `context::Module = Main` \\
-  The module context in which the top-level execution will be simulated.
+  The module context in which JET simulates top-level execution.
 
-  This configuration can be useful when you just want to analyze a submodule, without
-  starting entire analysis from the root module.
-  For example, we can analyze `Base.Math` like below:
+  This option is useful for analyzing a submodule's source file without
+  starting analysis from the root module. For example, analyze `Base.Math`
+  with `Base` as its parent module:
   ```julia-repl
   julia> report_file(JET.fullbasepath("math.jl");
-                     context = Base,                  # `Base.Math`'s root module
-                     analyze_from_definitions = true, # there're only definitions in `Base`
-                     )
+                     context = Base,
+                     analyze_from_definitions = true)
   ```
 
-  Note that this module context will be virtualized by default so that JET can repeat analysis
-  in the same session without having "invalid redefinition of constant ..." error etc.
-  In other word, JET virtualizes the module context of `context` and make sure the original
-  module context isn't polluted by JET.
----
-- `target_defined_modules::Bool = false` \\
-  If `true`, automatically set the [`target_modules`](@ref result-config) configuration so that
-  JET filters out errors that are reported within modules that JET doesn't analyze directly.
-
-  !!! warning "Deprecated"
-      This configuration is deprecated since JET v0.11.
-      In particular, if you were using this configuration with [`report_package`](@ref),
-      you should load your package in advance and use the
-      [`target_modules` configuration](@ref result-config)
-      to achieve the same filtering behavior
-      ```julia-repl
-      julia> report_package("MyPkg"; target_defined_modules=true) # deprecated
-
-      julia> using MyPkg; report_package(MyPkg; target_modules=(MyPkg,)) # preferred
-      ```
+  By default, JET virtualizes `context`. This allows repeated analysis in the
+  same session without errors such as `invalid redefinition of constant ...`
+  and prevents analyzed definitions from being written directly into the
+  original module. See [`virtualize_module_context`](@ref) for details.
 ---
 - `analyze_from_definitions::Union{Bool,Symbol} = false` \\
-  If `true`, JET will start analysis using signatures of top-level definitions (e.g. method signatures),
-  after the top-level interpretation has been done (unless no serious top-level error has
-  happened, like errors involved within a macro expansion).
-  This can be handy when you want to analyze a package, which usually contains only definitions
-  but not their usages (i.e. top-level callsites).
-  With this option, JET can enter analysis just with method or type definitions, and we don't
-  need to pass a file that uses the target package.
+  If `true`, after top-level processing completes, JET starts analysis from
+  collected signatures of top-level definitions, such as method signatures.
+  It does so only when no serious top-level error occurred, such as an error
+  during macro expansion.
 
-  When `analyze_from_definitions` is specified as `name::Symbol`, JET starts its analysis
-  using the interpreted method signature whose name is equal to `name` as the analysis entry
-  point. For example, when analyzing a script that uses `@main` to specify the entry point,
-  it would be convenient to specify `analyze_from_definitions = :main`.
+  This is useful for packages that contain definitions but no top-level call
+  sites that exercise them. It allows JET to begin analysis from method or
+  type definitions without requiring a separate driver file that calls the
+  package.
+
+  When set to `name::Symbol`, JET uses the interpreted signatures of methods
+  named `name` as analysis entry points. For example, a script that uses
+  `@main` can set `analyze_from_definitions = :main`.
 
   !!! warning
-      This feature is very experimental at this point, and you may face lots of false positive
-      errors, especially when trying to analyze a big package with lots of dependencies.
-      If a file that contains top-level callsites (e.g. `test/runtests.jl`) is available,
-      JET analysis using the file is generally preferred, since analysis entered from
-      concrete call sites will produce more accurate results than analysis entered from
-      (maybe not concrete-typed) method signatures.
+      This feature is experimental and may produce many false-positive errors,
+      especially for large packages with many dependencies. When a file containing
+      top-level call sites is available, such as `test/runtests.jl`, analyzing that
+      file is generally preferable.
+      Concrete call sites usually produce more accurate results than potentially
+      abstract method signatures.
 
   Also see: [`report_file`](@ref), [`report_package`](@ref)
 ---
-- `concretization_patterns::Vector{Any} = Any[]` \\
-  Specifies a customized top-level code concretization strategy.
+- `concretization_patterns = Any[]` \\
+  Accepts an iterable of surface-syntax expression patterns that customize
+  which top-level code blocks JET concretely executes. JET normalizes each
+  supplied pattern, collects the patterns in a `Vector{Any}`, and combines
+  them with built-in patterns that concretize type-alias assignments.
 
-  When analyzing a top-level code, JET first splits the entire code into appropriate units
-  of code (i.e. "code blocks"), and then iterate a virtual top-level code execution process
-  on each code block in order to simulate Julia's top-level code execution.
-  In the virtual code execution, JET will selectively interpret "top-level definitions"
-  (like a function definition), while it tries to avoid executing any other parts of code
-  including function calls that typically do a main computational task, leaving them to be
-  analyzed by the succeeding abstract interpretation based analysis.
+  JET splits top-level input into code blocks and processes them sequentially
+  to simulate Julia's top-level execution. Within each block, JET concretely
+  interprets statements required to establish top-level definitions and their
+  dependencies. It analyzes the remaining statements abstractly rather than
+  executing application code and its possible side effects.
 
-  However, currently, JET doesn't track "inter-block" level code dependencies, and therefore
-  the selective interpretation of top-level definitions may fail when it needs to use global
-  bindings defined in the other code blocks that have not been selected and actually
-  interpreted (i.e. "concretized") but left for abstract interpretation (i.e. "abstracted").
+  JET does not currently track concrete-value dependencies between separately
+  processed blocks. Concretization can therefore fail when a selected
+  statement needs a global value assigned in another block that JET left for
+  abstract interpretation instead of concretely executing.
 
-  For example, the issue would happen if the expansion of a macro uses a global variable, e.g.:
+  This can occur when macro expansion accesses a global variable, as in:
   > test/fixtures/concretization_patterns.jl
-  $(let
-      text = read(normpath(@__DIR__, "..", "..", "test", "fixtures", "concretization_patterns.jl"), String)
+  $(let path = normpath(
+        @__DIR__, "..", "..", "test", "fixtures", "concretization_patterns.jl")
+      text = read(path, String)
       lines = split(text, '\n')
       pushfirst!(lines, "```julia"); push!(lines, "```")
       join(lines, "\n  ")
   end)
 
-  To circumvent this issue, JET offers this `concretization_patterns::Vector{<:Any}` configuration,
-  which allows us to customize JET's top-level code concretization strategy.
-  `concretization_patterns` specifies the _patterns of code_ that should be concretized.
-  To put in other word, when JET sees a code that matches any of code patterns specified by
-  this configuration, JET will try to interpret and concretize the code, regardless of
-  whether or not JET's default code selection logic decides to concretize it.
+  To work around this limitation, list surface-syntax expression patterns in
+  `concretization_patterns`. Before macro expansion and lowering, JET matches
+  each top-level block against these patterns. When a pattern matches, JET
+  concretely executes the entire block, overriding its default per-statement
+  selection.
 
-  JET uses [MacroTools.jl's expression pattern match](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/),
-  and we can specify whatever code pattern expected by `MacroTools.@capture` macro.
-  For example, in order to solve the issue explained above, we can have:
+  JET uses MacroTools.jl [expression patterns](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/),
+  so any pattern accepted by `MacroTools.@capture` can be used. For example:
   ```julia
   concretization_patterns = [:(const GLOBAL_CODE_STORE = Dict())]
   ```
-  Then `GLOBAL_CODE_STORE` will just be concretized and so any top-level error won't happen
-  at the macro expansion.
+  This ensures that the assignment to `GLOBAL_CODE_STORE` is concretely
+  executed before later macro expansion needs its value.
 
-  Since configuring `concretization_patterns` properly can be tricky, JET offers a logging
-  system that allows us to debug 's top-level code concretization plan. With the
-  `toplevel_logger` configuration with specifying the logging level to be above than
-  `$JET_LOGGER_LEVEL_DEBUG` ("debug") level, we can see:
-  - which code is matched with `concretization_patterns` and forcibly concretized
-  - which code is selected to be concretized by JET's default code selection logic:
-    where `t`-annotated statements are concretized while `f`-annotated statements are abstracted
+  To inspect JET's concretization plan, set the `$(repr(JET_LOGGER_LEVEL))` property of
+  `toplevel_logger` to `$JET_LOGGER_LEVEL_DEBUG` ("debug"). Debug output shows:
+  - which blocks match `concretization_patterns` and are concretely executed
+  - which statements JET selects by default, where `t` marks concretely
+    interpreted statements and `f` marks abstractly analyzed statements
   ```julia-repl
   julia> report_file("test/fixtures/concretization_patterns.jl";
                      concretization_patterns = [:(const GLOBAL_CODE_STORE = Dict())],
@@ -328,35 +311,33 @@ These configurations will be active for all the top-level entries explained in t
   [toplevel-debug]  exited from test/fixtures/concretization_patterns.jl (took 0.032 sec)
   ```
 
-  Also see: the `toplevel_logger` section below, [`virtual_process`](@ref).
-
-  !!! note
-      [`report_package`](@ref) automatically sets this configuration as
-      ```julia
-      concretization_patterns = [:(x_)]
-      ```
-      meaning that it will concretize all top-level code included in a package being analyzed.
+  Also see: the `toplevel_logger` section below and [`virtual_process`](@ref).
 ---
 - `toplevel_logger::Union{Nothing,IO} = nothing` \\
-  If `IO` object is given, it will track JET's toplevel analysis.
-  Logging level can be specified with `$(repr(JET_LOGGER_LEVEL))` `IO` property.
-  Currently supported logging levels are either of $(JET_LOGGER_LEVELS_DESC).
+  If an `IO` object is provided, JET writes top-level analysis logs to it.
+  Set the logging level with the `$(repr(JET_LOGGER_LEVEL))` `IO` property.
+  Supported logging levels are $(JET_LOGGER_LEVELS_DESC).
 
   Examples:
-  * logs into `stdout`
-  ```julia-repl
-  julia> report_file(filename; toplevel_logger = stdout)
-  ```
-  * logs into `io::IOBuffer` with "debug" logger level
-  ```julia-repl
-  julia> report_file(filename; toplevel_logger = IOContext(io, $(repr(JET_LOGGER_LEVEL)) => $JET_LOGGER_LEVEL_DEBUG));
-  ```
+  - Write logs to `stdout` at the default level:
+    ```julia-repl
+    julia> report_file(filename; toplevel_logger = stdout)
+    ```
+  - Write logs to `io::IOBuffer` at the "debug" level:
+    ```julia-repl
+    julia> logger = IOContext(
+               io, $(repr(JET_LOGGER_LEVEL)) => $JET_LOGGER_LEVEL_DEBUG)
+
+    julia> report_file(filename; toplevel_logger = logger)
+    ```
 ---
 - `virtualize::Bool = true` \\
-  When `true`, JET will virtualize the given root module context.
+  When `true`, JET processes input in a virtualized version of the root module context.
 
-  This configuration is supposed to be used only for testing or debugging.
-  See [`virtualize_module_context`](@ref) for the internal.
+  Disabling virtualization is intended mainly for testing or debugging,
+  because top-level processing can mutate `context` and repeated analysis can
+  trigger redefinition errors.
+  See [`virtualize_module_context`](@ref) for implementation details.
 ---
 """
 struct ToplevelConfig
@@ -458,15 +439,19 @@ end
 """
     res::VirtualProcessResult
 
-- `res.analyzed_files::Dict{String,AnalyzedFileInfo}`: files that have been analyzed with
-    their corresponding module analyzed_files attached.
-- `res.toplevel_error_reports::Vector{ToplevelErrorReport}`: toplevel errors found during the
-    text parsing or partial (actual) interpretation; these reports are "critical" and should
-    have precedence over `inference_error_reports`
-- `res.inference_error_reports::Vector{InferenceErrorReport}`: possible error reports found
-    by `ToplevelAbstractAnalyzer`
-- `res.signature_infos`: signatures of methods defined within the analyzed files
-- `res.actual2virtual::$Actual2Virtual`: keeps actual and virtual module
+- `res.analyzed_files::Dict{String,AnalyzedFileInfo}`: analyzed files and the
+  source ranges associated with each module in those files.
+- `res.toplevel_error_reports::Vector{ToplevelErrorReport}`: reports produced
+  during top-level processing, including parsing, macro expansion, lowering,
+  and partial concrete interpretation. These critical reports take precedence
+  over `inference_error_reports`.
+- `res.inference_error_reports::Vector{InferenceErrorReport}`: reports of
+  potential errors found by `ToplevelAbstractAnalyzer`.
+- `res.signature_infos::Vector{SignatureInfo}`: method signatures collected
+  for analysis from top-level definitions.
+- `res.actual2virtual::Union{Actual2Virtual,Nothing}`: maps the actual root
+  module to its virtual counterpart, or is `nothing` when module
+  virtualization is disabled.
 """
 struct VirtualProcessResult
     analyzed_files::Dict{String,AnalyzedFileInfo}
@@ -540,12 +525,16 @@ end
 """
     abstract type ConcreteInterpreter <: JuliaInterpreter.Interpreter end
 
-An interface to inject code into JET's virtual process via JuliaInterpreter's interpretation.
+An interface for concretely interpreting selected top-level statements during
+[`virtual_process`](@ref) using JuliaInterpreter.
 
-Subtypes are expected to implement:
-- `InterpretationState(interp::T) -> InterpretationState` - return the interpreter state
-- `ConcreteInterpreter(interp::T, state::InterpretationState) -> T` - create new interpreter with state
-- `ToplevelAbstractAnalyzer(interp::T) -> analyzer::ToplevelAbstractAnalyzer` - return the analyzer for this interpreter
+Subtypes must implement:
+- `InterpretationState(interp::T) -> InterpretationState`:
+  return the interpreter state.
+- `ConcreteInterpreter(interp::T, state::InterpretationState) -> T`:
+  return an interpreter of type `T` associated with `state`.
+- `ToplevelAbstractAnalyzer(interp::T) -> ToplevelAbstractAnalyzer`:
+  return the top-level analyzer associated with the interpreter.
 """
 :(ConcreteInterpreter)
 
@@ -600,28 +589,38 @@ interpret_world(::JETConcreteInterpreter) = JET_INTERPRET_WORLD[]
                     config::ToplevelConfig;
                     overrideex::Union{Nothing,Expr}=nothing) -> res::VirtualProcessResult
 
-Simulates Julia's toplevel execution and collects error points, and finally returns `VirtualProcessResult`.
+Simulates Julia's top-level execution, collects error reports, and returns a
+`VirtualProcessResult`.
 
-This function first parses `s::AbstractString` into `toplevelnode::JS.SyntaxNode` and then
-iterate the following steps on each code block (`blk`) of `toplevelnode`:
-1. if `blk` is a `:module` expression, recursively enters analysis into an newly defined
-   virtual module
-2. `lower`s `blk` into `:thunk` expression `lwr` (macros are also expanded in this step)
-3. if the context module is virtualized, replaces self-references of the original context
-   module with virtualized one: see `fix_self_references`
-4. `ConcreteInterpreter` partially interprets some statements in `lwr` that should not be
-   abstracted away (e.g. a `:method` definition); see also [`partially_interpret!`](@ref)
-5. finally, `ToplevelAbstractAnalyzer` analyzes the remaining statements by abstract interpretation
+If `x` is an `AbstractString`, this function first parses it into a `JS.SyntaxNode`.
+The internal `overrideex` keyword may be used only when `x` is a `JS.SyntaxNode`,
+and its value must be an `Expr` with head `:toplevel`.
+The expression is analyzed in place of the syntax represented by `x`.
+`AbstractString` input does not accept this override.
+
+The function processes each top-level code block (`blk`) in the resulting or
+supplied syntax tree as follows:
+1. If `blk` is or expands to a `:module` expression, define the module and
+   recursively analyze its body in that new module.
+2. Otherwise, expand macros and lower `blk`. Skip literal results; a `:thunk`
+   result supplies the lowered `CodeInfo`.
+3. If the context module was virtualized, rewrite self-references from the
+   original module to the virtual module; see `fix_self_references!`.
+4. Use `ConcreteInterpreter` to concretely interpret statements that must not
+   be abstracted, such as `:method` definitions; see
+   [`partially_interpret!`](@ref).
+5. Use `ToplevelAbstractAnalyzer` to analyze the remaining statements
+   abstractly.
 
 !!! warning
-    In order to process the toplevel code sequentially as Julia runtime does, `virtual_process`
-    splits the entire code, and then iterate a simulation process on each code block.
-    With this approach, we can't track the inter-code-block level dependencies, and so a
-    partial interpretation of toplevle definitions will fail if it needs an access to global
-    variables defined in other code blocks that are not interpreted but just abstracted.
-    We can circumvent this issue using JET's `concretization_patterns` configuration, which
-    allows us to customize JET's concretization strategy.
-    See [`ToplevelConfig`](@ref) for more details.
+    To process top-level code sequentially, as the Julia runtime does,
+    `virtual_process` splits the input into code blocks and simulates them one
+    at a time. This approach does not track concrete-value dependencies
+    between separately processed blocks. Consequently, partial interpretation
+    of a top-level definition can fail when it needs a global value defined in
+    another block that was abstractly rather than concretely interpreted. Use
+    `concretization_patterns` to force the relevant blocks to be concretely
+    interpreted. See [`ToplevelConfig`](@ref) for details.
 """
 function virtual_process(interp::ConcreteInterpreter,
                          x::Union{AbstractString,JS.SyntaxNode},
@@ -697,20 +696,23 @@ end
 """
     virtualize_module_context(actual::Module)
 
-HACK to return a module where the context of `actual` is virtualized.
+Return a fresh virtual module that provides access to the bindings of `actual`.
 
-The virtualization will be done by 2 steps below:
-1. loads the module context of `actual` into a sandbox module, and export the whole context from there
-2. then uses names exported from the sandbox
+Virtualization proceeds in two steps:
+1. Use `using` to make the defined names of `actual` available in a sandbox
+   module, then export those names from the sandbox.
+2. Use `using` in the virtual module to make the sandbox's exported names
+   available.
 
-This way, JET's runtime simulation in the virtual module context will be able to define
-a name that is already defined in `actual` without causing
-"cannot assign a value to variable ... from module ..." error, etc.
-It allows JET to virtualize the context of already-existing module other than `Main`.
+This allows JET to define names in the virtual module even when the same names
+already exist in `actual`, without triggering errors such as `cannot assign a
+value to variable ... from module ...`. It also allows JET to analyze an
+existing module other than `Main` without defining analyzed code directly in
+that module.
 
 !!! warning "TODO"
-    Currently this function relies on `Base.names`, and thus it can't restore the `using`ed
-    names.
+    Because this function relies on `Base.names`, it cannot reproduce names
+    made available through `using`.
 """
 function virtualize_module_context(actual::Module)
     modpath = split_module_path(actual)
@@ -1387,15 +1389,21 @@ function walk_and_transform!(@nospecialize(x), inner, outer, scope::Vector{Symbo
 end
 
 """
-    partially_interpret!(interp::ConcreteInterpreter, concretize::BitVector, mod::Module, src::CodeInfo)
+    partially_interpret!(interp::ConcreteInterpreter, concretize::BitVector,
+                         mod::Module, src::CodeInfo) -> concretize::BitVector
 
-Partially interprets statements in `src` using JuliaInterpreter.jl:
-- concretizes "toplevel definitions", i.e. `:method`, `:struct_type`, `:abstract_type` and
-  `:primitive_type` expressions and their dependencies
-- concretizes user-specified toplevel code (see [`ToplevelConfig`](@ref))
-- directly evaluates module usage expressions and report error of invalid module usages
-  (TODO: enter into the loaded module and keep JET analysis)
-- special-cases `include` calls so that top-level analysis recursively enters the included file
+Resize and fill `concretize` with one entry for each statement in `src`; `true`
+marks a statement selected for concrete interpretation. Evaluate the selected
+statements using JuliaInterpreter.jl and return the same selection mask.
+
+The selection includes:
+- Top-level definitions, including `:method`, `:struct_type`, `:abstract_type`,
+  and `:primitive_type` expressions, together with their dependencies.
+- Module-usage expressions, which are directly evaluated so that invalid
+  usages can be reported. Modules loaded by `import` or `using` are not
+  recursively analyzed.
+- `include` calls, which cause top-level analysis to recursively enter the
+  included file.
 """
 function partially_interpret!(interp::ConcreteInterpreter, concretize::BitVector, mod::Module, src::CodeInfo)
     state = InterpretationState(interp)

--- a/src/ui/print.jl
+++ b/src/ui/print.jl
@@ -23,7 +23,8 @@ end
 
 """
 Configurations for report printing.
-The configurations below will be active whenever `show`ing [JET's analysis result](@ref analysis-result) within REPL.
+These configurations apply when [JET's analysis results](@ref analysis-result)
+are displayed in the REPL.
 
 ---
 - `sourceinfo::Symbol = :default` \\
@@ -31,20 +32,24 @@ The configurations below will be active whenever `show`ing [JET's analysis resul
   - `:full` - Expand all file paths to absolute paths
   - `:default` - Show paths as-is, prefixing `./` only for relative paths
   - `:compact` - Show basename only for absolute paths, relative paths unchanged
-  - `:minimal` - Show only module information, omit file paths (no `path:line`)
-  - `:none` - Omit location information entirely (no `@ Module path:line`).
-     For toplevel errors, treated as `:compact` since location is essential.
+  - `:minimal` - For inference reports, show only `@ Module`, without a file
+    path or line number. For top-level reports, treat this as `:compact`.
+  - `:none` - For inference reports, omit the entire `@ Module path:line`
+    location. For top-level reports, treat this as `:compact` because the source
+    location is essential.
 ---
 - `print_toplevel_success::Bool = false` \\
-  If `true`, prints a message when there is no toplevel errors found.
+  If `true`, print a message when no top-level errors are found.
 ---
 - `print_inference_success::Bool = true` \\
-  If `true`, print a message when there is no errors found in abstract interpretation based analysis pass.
+  If `true`, print a message when no errors are found by an
+  abstract-interpretation-based analysis pass.
 ---
 - `stacktrace_types_limit::Union{Nothing, Int} = nothing` \\
-  If `nothing`, limit type-depth printing of argument types in stack traces based on the display size.
-  If a positive `Int`, limit type-depth printing to given depth.
-  If a non-positive `Int`, do not limit type-depth printing.
+  If `nothing`, limit the type depth of argument types in stack traces based on
+  the display size.
+  If a positive `Int`, limit the type depth to the given depth.
+  If a non-positive `Int`, do not limit the type depth.
 ---
 """
 struct PrintConfig

--- a/src/ui/vscode.jl
+++ b/src/ui/vscode.jl
@@ -32,15 +32,16 @@ vscode_diagnostics_order(analyzer::AbstractAnalyzer) = true
 # =============
 
 """
-Configurations for the VSCode integration.
-These configurations are active only when used in [the integrated Julia REPL](https://www.julia-vscode.org/docs/dev/userguide/runningcode/).
+Configurations for the VS Code integration.
+These configurations are active only when used in
+[the integrated Julia REPL](https://www.julia-vscode.org/docs/dev/userguide/runningcode/).
 
 ---
-- `vscode_console_output::Union{Nothing,IO} = stdout` \\
-  JET will show analysis result in VSCode's "PROBLEMS" pane and inline annotations.
-  If `vscode_console_output::IO` is specified, JET will also print the result into the
-  specified output stream in addition to showing the result in the integrated views.
-  When `nothing`, the result will be only shown in the integrated views.
+- `vscode_console_output::Union{Nothing,IO} = nothing` \\
+  JET shows the analysis result in VS Code's "PROBLEMS" pane and inline
+  annotations. If an `IO` object is supplied, JET also prints the result to that
+  stream. When this option is `nothing`, the result appears only in the
+  integrated views.
 ---
 """
 struct VSCodeConfig end

--- a/test/abstractinterpret/test_typeinfer.jl
+++ b/test/abstractinterpret/test_typeinfer.jl
@@ -704,6 +704,22 @@ end
         end
     end
 
+    @testset "namespace root filtering" begin
+        # `target_modules = (Main,)` should cover interactively-defined code
+        # without letting reports from `Base` through
+        m = Core.eval(Main, :(module $(gensym(:NamespaceRootFiltering))
+            foo(a) = (sum(a), undefsum(a))
+        end))
+        let result = report_call(m.foo, (String,); target_modules=(Main,))
+            r = only(get_reports_with_test(result))
+            @test is_global_undef_var(r, :undefsum)
+        end
+        let result = report_call(m.foo, (String,); ignored_modules=(Main,))
+            test_sum_over_string(result)
+            @test !any(r->is_global_undef_var(r, :undefsum), get_reports_with_test(result))
+        end
+    end
+
     @testset "Symbol-based filtering" begin
         let result = @report_call target_modules=(:BasicFiltering,) BasicFiltering.foo([1,2,3])
             reports = get_reports_with_test(result)


### PR DESCRIPTION
JET's API docstrings contained stale signatures, incorrect defaults, and behavior descriptions that no longer matched the implementation. The manual pages and examples were similarly outdated, with uneven English prose and Markdown formatting.

This change revises the analyzer, report, and user-facing API docstrings to match the current implementation, updates examples to the current output format, and polishes the prose throughout. It also normalizes Markdown formatting, the generated framework page links, and the Documenter setup.