### PR TITLE
toplevel: Derive concretization patterns from the actual assignment

### DIFF
--- a/src/abstractinterpret/abstractanalyzer.jl
+++ b/src/abstractinterpret/abstractanalyzer.jl
@@ -86,12 +86,42 @@ struct CachedAnalysisResult
     reports::Vector{InferenceErrorReport}
 end
 
+"""
+Records the top-level statement that gives a global binding its value, together with a
+ready-to-use `concretization_patterns` entry matching it when one can be derived (see
+`concretization_pattern`).
+
+`pattern` is `nothing` when no entry could be derived, e.g. when the assignment is nested
+within a `let` block; `file` and `line` still point at the statement, which is what the
+user needs in order to write the entry by hand.
+
+Only the reduced pattern is kept, not the statement it was derived from: right-hand sides
+can be arbitrarily large, and `AbstractBindingState` (which embeds this) is evaluated as a
+constant into the analyzed module, so it stays alive for that module's lifetime.
+"""
+struct ToplevelAssignment
+    pattern::Union{Nothing,Expr}
+    file::String
+    line::Int
+end
+
 struct AbstractBindingState
     isconst::Bool
     maybeundef::Bool
+    assignment::Union{Nothing,ToplevelAssignment}
     typ
-    AbstractBindingState(isconst::Bool, maybeundef::Bool, @nospecialize typ) = new(isconst, maybeundef, typ)
-    AbstractBindingState(isconst::Bool, maybeundef::Bool) = new(isconst, maybeundef)
+    function AbstractBindingState(
+            isconst::Bool, maybeundef::Bool, @nospecialize(typ);
+            assignment::Union{Nothing,ToplevelAssignment} = nothing
+        )
+        return new(isconst, maybeundef, assignment, typ)
+    end
+    function AbstractBindingState(
+            isconst::Bool, maybeundef::Bool;
+            assignment::Union{Nothing,ToplevelAssignment} = nothing
+        )
+        return new(isconst, maybeundef, assignment)
+    end
 end
 
 # `report_package` analyzes signatures concurrently while all task analyzers share a single
@@ -164,6 +194,7 @@ mutable struct AnalyzerState
     # will be used in toplevel analysis (skip inference on actually interpreted statements)
     const concretized::BitVector
 
+    const current_toplevel_assignment::Union{Nothing,ToplevelAssignment}
     const binding_states::AbstractBindings # TODO Make this globally maintained?
 
     # some `AbstractAnalyzer` may want to use this
@@ -192,6 +223,7 @@ function AnalyzerState(world::UInt = get_world_counter();
                          #=report_stash::Vector{InferenceErrorReport}=# InferenceErrorReport[],
                          #=cache_target::Union{Nothing,Pair{Symbol,InferenceState}}=# nothing,
                          #=concretized::BitVector=# non_toplevel_concretized,
+                         #=current_toplevel_assignment=# nothing,
                          #=binding_states::AbstractBindings=# AbstractBindings(),
                          #=entry::Union{Nothing,MethodInstance}=# nothing)
 end
@@ -202,6 +234,7 @@ function AnalyzerState(state::AnalyzerState, refresh_local_cache::Bool=true;
                        inf_params::InferenceParams = state.inf_params,
                        opt_params::OptimizationParams = state.opt_params,
                        concretized::BitVector = state.concretized,
+                       current_toplevel_assignment::Union{Nothing,ToplevelAssignment} = state.current_toplevel_assignment,
                        binding_states::AbstractBindings = state.binding_states,
                        entry::Union{Nothing,MethodInstance} = state.entry)
     if refresh_local_cache
@@ -218,6 +251,7 @@ function AnalyzerState(state::AnalyzerState, refresh_local_cache::Bool=true;
                          #=report_stash=# InferenceErrorReport[],
                          #=cache_target=# nothing,
                          concretized,
+                         current_toplevel_assignment,
                          binding_states,
                          entry)
 end
@@ -496,11 +530,14 @@ then provide the top-level-specific abstract interpretation behavior.
 abstract type ToplevelAbstractAnalyzer <: AbstractAnalyzer end
 
 # constructor for sequential toplevel JET analysis
-function ToplevelAbstractAnalyzer(interp::ConcreteInterpreter, concretized::BitVector)
+function ToplevelAbstractAnalyzer(
+        interp::ConcreteInterpreter, concretized::BitVector;
+        current_toplevel_assignment::Union{Nothing,ToplevelAssignment} = nothing
+    )
     # use the latest world age to take in newly added methods defined by `ConcreteInterpreter`
     world = get_world_counter()
     analyzer = ToplevelAbstractAnalyzer(interp)
     state = AnalyzerState(analyzer)
-    newstate = AnalyzerState(state; world, concretized)
+    newstate = AnalyzerState(state; world, concretized, current_toplevel_assignment)
     return AbstractAnalyzer(analyzer, newstate)
 end

--- a/src/abstractinterpret/typeinfer.jl
+++ b/src/abstractinterpret/typeinfer.jl
@@ -499,7 +499,9 @@ function CC.global_assignment_rt_exct(analyzer::ToplevelAbstractAnalyzer, sv::In
     end
     isconcretized = JET.isconcretized(analyzer, sv) # this statement has been analyzed by `ConcreteInterpreter`
     newty′ = Ref{Any}(newty)
-    isconditional = istoplevelframe(sv) ? let postdomtree = CC.construct_postdomtree(sv.cfg)
+    istoplevel = istoplevelframe(sv)
+    assignment = istoplevel ? get_current_toplevel_assignment(analyzer) : nothing
+    isconditional = istoplevel ? let postdomtree = CC.construct_postdomtree(sv.cfg)
         !CC.postdominates(postdomtree, sv.currbb, 1)
     end : true
     (valid_worlds, ret) = CC.scan_partitions(analyzer, g, sv.world) do analyzer::AbstractAnalyzer, ::Core.Binding, partition::Core.BindingPartition
@@ -511,7 +513,7 @@ function CC.global_assignment_rt_exct(analyzer::ToplevelAbstractAnalyzer, sv::In
             # to track their types precisely.
             # However, by accurately determining whether a top-level assignment is conditional,
             # it is possible to track such bindings’ `isdefined` status precisely.
-            get_binding_states(analyzer)[partition] = AbstractBindingState(false, isconditional)
+            get_binding_states(analyzer)[partition] = AbstractBindingState(false, isconditional; assignment)
         end
         return rte
     end
@@ -609,6 +611,7 @@ end # @static if isdefinedglobal(Core, :declare_const)
 
 function const_assignment_rt_exct(analyzer::ToplevelAbstractAnalyzer, sv::InferenceState, saw_latestworld::Bool, gr::GlobalRef,
                                   @nospecialize(new_binding_typ))
+    @assert istoplevelframe(sv)
     if saw_latestworld
         return Pair{Any,Any}(Nothing, ErrorException)
     end
@@ -616,6 +619,7 @@ function const_assignment_rt_exct(analyzer::ToplevelAbstractAnalyzer, sv::Infere
     new_binding_typ′ = Ref{Any}(new_binding_typ)
     postdomtree = CC.construct_postdomtree(sv.cfg)
     isconditional = !CC.postdominates(postdomtree, sv.currbb, 1)
+    assignment = get_current_toplevel_assignment(analyzer)
     (valid_worlds, ret) = CC.scan_partitions(analyzer, gr, sv.world) do analyzer::ToplevelAbstractAnalyzer, _binding::Core.Binding, partition::Core.BindingPartition
         rte = const_assignment_binding_rt_exct(analyzer, partition)
         rt, _exct = rte
@@ -627,15 +631,20 @@ function const_assignment_rt_exct(analyzer::ToplevelAbstractAnalyzer, sv::Infere
                 binding_states = get_binding_states(analyzer)
                 binding_state = @lock binding_states.lock begin
                     if !isconditional
-                        new_state = AbstractBindingState(true, false, new_binding_typ′[])
+                        new_state = AbstractBindingState(true, false, new_binding_typ′[]; assignment)
                     elseif haskey(binding_states, partition)
                         old_binding_state = binding_states[partition]
                         @assert old_binding_state.isconst && isdefined(old_binding_state, :typ)
                         newmaybeundef = old_binding_state.maybeundef & isconditional
                         newtyp = old_binding_state.typ ⊔ new_binding_typ′[]
-                        new_state = AbstractBindingState(true, newmaybeundef, newtyp)
+                        # each top-level statement builds its own `ToplevelAssignment`, so
+                        # `===` here means "the same statement"; keep it only then, since
+                        # no single pattern can stand for two conflicting statements
+                        same_statement = old_binding_state.assignment === assignment
+                        merged_assignment = same_statement ? assignment : nothing
+                        new_state = AbstractBindingState(true, newmaybeundef, newtyp; assignment=merged_assignment)
                     else
-                        new_state = AbstractBindingState(true, true, new_binding_typ′[])
+                        new_state = AbstractBindingState(true, true, new_binding_typ′[]; assignment)
                     end
                     binding_states[partition] = new_state
                     new_state

--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -132,24 +132,29 @@ end
 struct MissingConcretizationError <: Exception
     isconst::Bool
     var::GlobalRef
+    assignment::Union{Nothing,ToplevelAssignment}
 end
 
 struct MissingConcretizationErrorReport <: ToplevelErrorReport
     isconst::Bool
     var::GlobalRef
+    assignment::Union{Nothing,ToplevelAssignment}
     file::String
     line::Int
 end
 function print_report(io::IO, report::MissingConcretizationErrorReport)
-    (; isconst, var) = report
+    (; isconst, var, assignment) = report
     (; mod, name) = var
-    pattern = isconst ? ":(const $name = x_)" : ":($name = x_)"
-    example = "`report_file(\"path/to/file.jl\"; concretization_patterns = [$pattern])`"
     println(io, "`$mod.$name` is used while JET is processing top-level definitions,")
     println(io, "so JET needs its concrete value (the actual runtime value).")
     println(io)
     println(io, "JET tracked that the binding exists, but it did not actually evaluate")
-    println(io, "the assignment that gives this binding its value.")
+    if assignment === nothing
+        println(io, "the assignment that gives this binding its value.")
+    else
+        println(io, "the assignment at $(assignment.file):$(assignment.line) that gives")
+        println(io, "this binding its value.")
+    end
     println(io)
     if !isconst
         println(io, "- If `$name` is intended to be a stable configuration value,")
@@ -162,9 +167,23 @@ function print_report(io::IO, report::MissingConcretizationErrorReport)
         println(io, "- Add a `concretization_patterns` entry for the assignment.")
     end
     println(io, "  This tells JET to actually evaluate top-level code that matches the")
-    println(io, "  pattern. For example:")
-    println(io, "  ", example)
-    println(io, "  Use a specific pattern when possible, because matching code is executed.")
+    patternex = assignment === nothing ? nothing : assignment.pattern
+    if patternex !== nothing
+        pattern = sprint(Base.show_unquoted, patternex)
+        println(io, "  pattern. For example:")
+        println(io, "  `report_file(\"path/to/file.jl\"; concretization_patterns = [:($pattern)])`")
+        println(io, "  Use a specific pattern when possible, because matching code is executed.")
+    elseif assignment !== nothing
+        println(io, "  pattern. Patterns are matched against whole top-level statements,")
+        println(io, "  and JET could not derive one from the statement holding that")
+        println(io, "  assignment, so the pattern has to be written by hand to match the")
+        println(io, "  statement as it appears in the source.")
+    else
+        println(io, "  pattern. Patterns are matched against whole top-level statements,")
+        println(io, "  and JET could not identify the statement that assigns this binding,")
+        println(io, "  so the pattern has to be written by hand to match that statement as")
+        println(io, "  it appears in the source.")
+    end
     println(io, "- As a last resort, use `concretization_patterns = [:(x_)]` to evaluate")
     println(io, "  all top-level code in the module. This may run side effects and can")
     print(io, "  make analysis slower.")
@@ -919,6 +938,34 @@ function bail_out_concretized(concretized::BitVector, src::CodeInfo)
     return false
 end
 
+"""
+    concretization_pattern(@nospecialize x) -> pattern::Union{Nothing,Expr}
+
+Build a `concretization_patterns` entry matching the top-level assignment statement `x`,
+by replacing its innermost right-hand side with the `MacroTools` wildcard `x_`.
+Only the assignment spine is copied, so the right-hand side, which can be arbitrarily
+large, is neither copied nor retained.
+
+Returns `nothing` when `x` is not itself a top-level assignment, e.g. when the assignment
+is nested within a `let` block. Since patterns are matched against whole top-level
+statements, no useful pattern can be derived from the assignment alone in that case.
+Short-form function definitions are rejected too: they never give a global binding its
+value, and `:(f(x) = x_)` would concretize every definition of `f`.
+"""
+function concretization_pattern(@nospecialize(x))
+    if isexpr(x, (:global, :const), 1)
+        inner = concretization_pattern(only((x::Expr).args))
+        return inner === nothing ? nothing : Expr((x::Expr).head, inner)
+    elseif isexpr(x, :(=), 2) && !Base.is_short_function_def(x)
+        lhs, rhs = (x::Expr).args
+        return Expr(:(=), deepcopy(lhs), @something concretization_pattern(rhs) :x_)
+    end
+    return nothing
+end
+
+toplevel_assignment(@nospecialize(x), file::String, line::Int) =
+    ToplevelAssignment(concretization_pattern(x), file, line)
+
 struct VNode
     force_concretize::Bool
     node::JS.SyntaxNode
@@ -1203,6 +1250,7 @@ function _virtual_process!(interp::ConcreteInterpreter,
             continue
         end
 
+        current_toplevel_assignment = toplevel_assignment(x, state.filename, state.curline)
         blk = Expr(:block, lnn, x) # attach current line number info
         lwr = lower_with_err_handling(interp, node, blk)
 
@@ -1227,7 +1275,7 @@ function _virtual_process!(interp::ConcreteInterpreter,
             continue
         end
 
-        analyzer = ToplevelAbstractAnalyzer(interp, concretized)
+        analyzer = ToplevelAbstractAnalyzer(interp, concretized; current_toplevel_assignment)
 
         result = analyze_toplevel!(analyzer, src, state.context)
 
@@ -1691,7 +1739,7 @@ function JuliaInterpreter.lookup(interp::ConcreteInterpreter, frame::Frame, @nos
                         return typ.val
                     end
                 end
-                throw(MissingConcretizationError(val.isconst, node))
+                throw(MissingConcretizationError(val.isconst, node, val.assignment))
             end
             return val
         else
@@ -1704,7 +1752,6 @@ function JuliaInterpreter.lookup(interp::ConcreteInterpreter, frame::Frame, @nos
                 else
                     # allow ConcreteInterpreter to use actual concrete values that have been
                     # figured out by the abstract analyzer
-                    raise = true
                     if isdefined(binding_state, :typ)
                         typ = binding_state.typ
                         if typ isa Const
@@ -1713,7 +1760,7 @@ function JuliaInterpreter.lookup(interp::ConcreteInterpreter, frame::Frame, @nos
                     end
                     # if this binding is not concrete, then propagate this error type so that
                     # it can be handled by `handle_err`
-                    raise && throw(MissingConcretizationError(binding_state.isconst, node))
+                    throw(MissingConcretizationError(binding_state.isconst, node, binding_state.assignment))
                 end
             end
         end
@@ -2069,7 +2116,7 @@ function JuliaInterpreter.handle_err(
 
     state = InterpretationState(interp)
     if err isa MissingConcretizationError
-        report = MissingConcretizationErrorReport(err.isconst, err.var, state.filename, state.curline)
+        report = MissingConcretizationErrorReport(err.isconst, err.var, err.assignment, state.filename, state.curline)
     else
         report = ActualErrorWrapped(err, st, state.filename, state.curline)
     end

--- a/test/toplevel/test_toplevel_inference.jl
+++ b/test/toplevel/test_toplevel_inference.jl
@@ -347,6 +347,31 @@ end
     @test isempty(res.res.inference_error_reports)
 end
 
+@testset "`concretization_pattern`" begin
+    @test JET.concretization_pattern(:(A = rand(Int))) == :(A = x_)
+    @test JET.concretization_pattern(:(A::DataType = rand(Int))) == :(A::DataType = x_)
+    @test JET.concretization_pattern(:(global A = rand(Int))) == :(global A = x_)
+    @test JET.concretization_pattern(:(const A = rand(Int))) == :(const A = x_)
+    @test JET.concretization_pattern(:(A = B = rand(Int))) == :(A = B = x_)
+    @test JET.concretization_pattern(:((A, B) = rand(Int, 2))) == :((A, B) = x_)
+    # short-form function definitions never give a global binding its value
+    @test JET.concretization_pattern(:(f(x) = 2x)) === nothing
+    @test JET.concretization_pattern(:(f(x::T) where T = 2x)) === nothing
+    @test JET.concretization_pattern(:(A + B)) === nothing
+    @test JET.concretization_pattern(:A) === nothing
+    # a nested assignment would need a pattern covering the whole top-level statement,
+    # which is left to the user to write
+    @test JET.concretization_pattern(:(let; global A = rand(Int); end)) === nothing
+    @test JET.concretization_pattern(:(if c; A = 1; else; A = 2; end)) === nothing
+
+    # the statement is located regardless of whether a pattern could be derived
+    let assignment = JET.toplevel_assignment(:(let; global A = rand(Int); end), "f.jl", 2)
+        @test assignment.pattern === nothing
+        @test assignment.file == "f.jl"
+        @test assignment.line == 2
+    end
+end
+
 @testset "MissingConcretizationErrorReport" begin
     let res = @analyze_toplevel begin
             RandomType = rand((Bool,Int))
@@ -361,6 +386,8 @@ end
             @test isa(report, MissingConcretizationErrorReport)
             @test report.var.name === :RandomType
             @test !report.isconst
+            @test report.assignment isa JET.ToplevelAssignment
+            @test report.assignment.pattern == :(RandomType = x_)
 
             msg = sprint(JET.print_report, report)
             @test occursin("JET needs its concrete value", msg)
@@ -370,7 +397,93 @@ end
             @test occursin("if JET still cannot determine the value", msg)
             @test occursin("concretization_patterns = [:(RandomType = x_)]", msg)
             @test occursin("because matching code is executed", msg)
+            @test occursin("the assignment at $(report.assignment.file):$(report.assignment.line)", msg)
         end
+    end
+
+    let res = @analyze_toplevel begin
+            TypedRandomType::DataType = rand((Bool, Int))
+            struct TypedStruct
+                field::TypedRandomType
+            end
+        end
+        report = only(res.res.toplevel_error_reports)
+        @test report isa MissingConcretizationErrorReport
+        @test report.assignment isa JET.ToplevelAssignment
+        @test report.assignment.pattern == :(TypedRandomType::DataType = x_)
+    end
+
+    let res = @analyze_toplevel concretization_patterns = [:(TypedRandomType::DataType = x_)] begin
+            TypedRandomType::DataType = rand((Bool, Int))
+            struct TypedStruct
+                field::TypedRandomType
+            end
+        end
+        @test isempty(res.res.toplevel_error_reports)
+    end
+
+    let res = @analyze_toplevel begin
+            global GlobalRandomType = rand((Bool, Int))
+            struct GlobalStruct
+                field::GlobalRandomType
+            end
+        end
+        report = only(res.res.toplevel_error_reports)
+        @test report isa MissingConcretizationErrorReport
+        @test report.assignment isa JET.ToplevelAssignment
+        @test report.assignment.pattern == :(global GlobalRandomType = x_)
+    end
+
+    let res = @analyze_toplevel concretization_patterns = [:(global GlobalRandomType = x_)] begin
+            global GlobalRandomType = rand((Bool, Int))
+            struct GlobalStruct
+                field::GlobalRandomType
+            end
+        end
+        @test isempty(res.res.toplevel_error_reports)
+    end
+
+    mktempdir() do dir
+        main_file = joinpath(dir, "main.jl")
+        assignment_file = joinpath(dir, "config.jl")
+        use_file = joinpath(dir, "use.jl")
+        write(main_file, "include(\"config.jl\")\ninclude(\"use.jl\")\n")
+        write(assignment_file, "IncludedRandomType::DataType = rand((Bool, Int))\n")
+        write(use_file, "struct IncludedStruct\n    field::IncludedRandomType\nend\n")
+
+        res = report_file2(main_file)
+        report = only(res.res.toplevel_error_reports)
+        @test report isa MissingConcretizationErrorReport
+        @test report.file == use_file
+        @test report.assignment isa JET.ToplevelAssignment
+        @test report.assignment.file == assignment_file
+        @test report.assignment.pattern == :(IncludedRandomType::DataType = x_)
+        # the report is anchored at the use site, so the message needs to point elsewhere
+        @test occursin("the assignment at $assignment_file:1", sprint(JET.print_report, report))
+    end
+
+    # a pattern covering the enclosing statement is left to the user to write, so JET must
+    # not suggest one; `:(NestedRandomType = x_)` in particular would never match here.
+    # The statement is still located, which is what the user needs to write the pattern.
+    @testset "nested assignment statement" begin
+        res = JET.report_text("""
+            let
+                global NestedRandomType = rand((Bool, Int))
+            end
+            struct NestedStruct
+                field::NestedRandomType
+            end
+            """)
+        report = only(res.res.toplevel_error_reports)
+        @test report isa MissingConcretizationErrorReport
+        @test report.assignment isa JET.ToplevelAssignment
+        @test report.assignment.pattern === nothing
+        @test report.assignment.line == 1 # the `let` statement, not the use site
+        @test report.line == 4
+        msg = sprint(JET.print_report, report)
+        @test occursin("the assignment at $(report.assignment.file):1", msg)
+        @test occursin("could not derive one from the statement holding that", msg)
+        @test !occursin("concretization_patterns = [:(NestedRandomType = x_)]", msg)
     end
 end
 


### PR DESCRIPTION
`MissingConcretizationErrorReport` only knew the name of the binding it complained about, so the `concretization_patterns` entry it suggested was rebuilt from that name alone. For code like
```julia
XY::DataType = rand((Bool, Int))
struct S
    field::XY
end
```
the report suggested `:(XY = x_)`, which does not match the statement as written and therefore has no effect when configured. The report is anchored at the use site as well, so nothing pointed at where the assignment actually is, which matters when it lives in an `include`d file.

This commit introduces `ToplevelAssignment`, recording the file and line of the top-level statement that gives a binding its value along with a ready-to-use `concretization_patterns` entry for it. `_virtual_process!` builds one per top-level statement, deriving the entry through the new `concretization_pattern`, which replaces the innermost right-hand side with the `MacroTools` wildcard `x_` while keeping the assignment as written, so `::` annotations, `global`/`const` wrappers and assignment chains all survive. The result travels through `AnalyzerState.current_toplevel_assignment` into the `AbstractBindingState` recorded for the binding, and from there into the report, which now names the file and line of the assignment and suggests the derived entry.

Patterns are matched against whole top-level statements, so no entry can be derived when the assignment is nested within e.g. a `let` block. `concretization_pattern` returns `nothing` for those and `print_report` says that no pattern could be derived, rather than suggesting one that would never match; the statement is still located, which is what the reader needs in order to write the entry by hand. Short-form function definitions are likewise not treated as assignments, since `:(f(x) = x_)` would concretize every definition of `f`. Only the reduced pattern is retained, not the statement it came from: `AbstractBindingState` is evaluated as a constant into the analyzed module and so stays alive for that module's lifetime, while right-hand sides can be arbitrarily large.

This change also asserts the top-level-frame invariant that `const_assignment_rt_exct` already relies on for its postdominance check.