### PR TITLE
toplevel: Simplify Test.jl macros during virtual processing

### DIFF
--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -1102,6 +1102,184 @@ function lower_with_err_handling(interp::ConcreteInterpreter, ::JS.SyntaxNode, x
     end
 end
 
+const TEST_MACRO_NAMES = Set{Symbol}((
+    Symbol("@test"),
+    Symbol("@test_broken"),
+    Symbol("@test_skip"),
+    Symbol("@test_throws"),
+    Symbol("@test_logs"),
+    Symbol("@test_warn"),
+    Symbol("@test_nowarn"),
+    Symbol("@test_deprecated"),
+    Symbol("@inferred"),
+    Symbol("@testset"),
+))
+
+function test_macro_name(mod::Module, @nospecialize(mac))
+    if mac isa GlobalRef
+        mac.mod === Test || return nothing
+        return mac.name
+    elseif mac isa Symbol
+        @invokelatest(isdefinedglobal(mod, mac)) || return nothing
+        isdefinedglobal(Test, mac) || return nothing
+        @invokelatest(getglobal(mod, mac)) === getglobal(Test, mac) || return nothing
+        return mac
+    elseif isexpr(mac, :., 2)
+        modname, name = mac.args
+        name isa QuoteNode || return nothing
+        name = name.value
+        name isa Symbol || return nothing
+        modname isa Symbol || return nothing
+        @invokelatest(isdefinedglobal(mod, modname)) || return nothing
+        @invokelatest(getglobal(mod, modname)) === Test || return nothing
+        return name
+    end
+    return nothing
+end
+
+# Prevent the synthetic result of a Test macro replacement from affecting the
+# surrounding inference result while preserving its runtime value.
+hide_test_replacement_value(@nospecialize(value)) =
+    Expr(:call, GlobalRef(Base, :inferencebarrier), value)
+
+function discard_test_expression_value(@nospecialize(ex))
+    ret = quote
+        try
+            $ex
+        catch
+        end
+        $(hide_test_replacement_value(nothing))
+    end
+    return Base.remove_linenums!(ret)
+end
+
+function preserve_test_expression_value(@nospecialize(exs...))
+    value = gensym(:test_value)
+    ret = quote
+        let $value = nothing
+            try
+                $(exs[1:end-1]...)
+                $value = $(last(exs))
+            catch
+            end
+            $(hide_test_replacement_value(value))
+        end
+    end
+    return Base.remove_linenums!(ret)
+end
+
+macro_argument_value(@nospecialize(ex)) = isexpr(ex, :(=), 2) ? last(ex.args) : ex
+
+function replace_test(@nospecialize(ex), kws::Vector{Any})
+    broken = Any[kw.args[2] for kw in kws if isexpr(kw, :(=), 2) && kw.args[1] === :broken]
+    skip = Any[kw.args[2] for kw in kws if isexpr(kw, :(=), 2) && kw.args[1] === :skip]
+    kws = Any[kw for kw in kws if !(isexpr(kw, :(=), 2) && kw.args[1] ∈ (:skip, :broken))]
+    length(broken) ≤ 1 || return nothing
+    length(skip) ≤ 1 || return nothing
+    isempty(skip) || isempty(broken) || return nothing
+    try
+        Test.test_expr!("@test", ex, kws...)
+    catch
+        return nothing
+    end
+    test_expr = discard_test_expression_value(ex)
+    if !isempty(skip)
+        ret = quote
+            if $(only(skip))
+                $(hide_test_replacement_value(nothing))
+            else
+                $test_expr
+            end
+        end
+        return Base.remove_linenums!(ret)
+    elseif !isempty(broken)
+        return Expr(:block, only(broken), test_expr)
+    end
+    return test_expr
+end
+
+function replace_test_macrocall(name::Symbol, args::Vector{Any})
+    exs = args[3:end]
+    if name === Symbol("@test")
+        isempty(exs) && return nothing
+        return replace_test(first(exs), Any[exs[2:end]...])
+    elseif name === Symbol("@test_broken")
+        isempty(exs) && return nothing
+        ex, kws = first(exs), exs[2:end]
+        try
+            Test.test_expr!("@test_broken", ex, kws...)
+        catch
+            return nothing
+        end
+        return discard_test_expression_value(ex)
+    elseif name === Symbol("@test_skip")
+        isempty(exs) && return nothing
+        ex, kws = first(exs), exs[2:end]
+        try
+            Test.test_expr!("@test_skip", ex, kws...)
+        catch
+            return nothing
+        end
+        return hide_test_replacement_value(nothing)
+    elseif name === Symbol("@test_throws")
+        length(exs) == 2 || return nothing
+        return discard_test_expression_value(Expr(:block, exs...))
+    elseif name === Symbol("@test_logs")
+        isempty(exs) && return nothing
+        values = Any[macro_argument_value(ex) for ex in exs[1:end-1]]
+        push!(values, last(exs))
+        return preserve_test_expression_value(values...)
+    elseif name === Symbol("@test_warn")
+        length(exs) == 2 || return nothing
+        return preserve_test_expression_value(exs...)
+    elseif name === Symbol("@test_nowarn")
+        length(exs) == 1 || return nothing
+        return preserve_test_expression_value(exs...)
+    elseif name === Symbol("@test_deprecated")
+        1 ≤ length(exs) ≤ 2 || return nothing
+        return preserve_test_expression_value(exs...)
+    elseif name === Symbol("@inferred")
+        1 ≤ length(exs) ≤ 2 || return nothing
+        return preserve_test_expression_value(exs...)
+    elseif name === Symbol("@testset")
+        isempty(exs) && return nothing
+        values = Any[macro_argument_value(ex) for ex in exs[1:end-1]]
+        body = last(exs)
+        if isexpr(body, :for, 2)
+            body = copy(body)
+            body.args[2] = Expr(:block, values..., body.args[2])
+            empty!(values)
+        end
+        ret = quote
+            let
+                try
+                    $(values...)
+                    $body
+                catch
+                end
+                $(hide_test_replacement_value(nothing))
+            end
+        end
+        return Base.remove_linenums!(ret)
+    end
+    return nothing
+end
+
+function replace_test_macrocalls(@nospecialize(x), mod::Module)
+    x isa Expr || return x
+    isexpr(x, (:quote, :inert)) && return x
+    if isexpr(x, :macrocall)
+        name = test_macro_name(mod, first(x.args))
+        name ∈ TEST_MACRO_NAMES || return x
+        replaced = Expr(:macrocall, x.args[1], x.args[2],
+            map(@nospecialize(arg) -> replace_test_macrocalls(arg, mod), x.args[3:end])...)
+        replacement = replace_test_macrocall(name, replaced.args)
+        return @something replacement replaced
+    end
+    return Expr(x.head,
+        map(@nospecialize(arg) -> replace_test_macrocalls(arg, mod), x.args)...)
+end
+
 function _virtual_process!(interp::ConcreteInterpreter,
                            toplevelnode::JS.SyntaxNode;
                            force_concretize::Bool = false,
@@ -1183,14 +1361,16 @@ function _virtual_process!(interp::ConcreteInterpreter,
         end
 
         x = desugar_main_macrocall(x)
+        x = replace_test_macrocalls(x, state.context)
 
         # although we will lower `x` after special-handling `:toplevel` and `:module` expressions,
         # expand `macrocall`s here because macro can arbitrarily generate those expressions
-        if isexpr(x, :macrocall) ||
+        if (isexpr(x, :macrocall) ||
             # This kind of code occurs when a macro returns a `:toplevel` expression.
             # This expression contains information about the macro expansion position and module context,
             # but for now we just ignore that.
-            isexpr(x, :var"hygienic-scope")
+            isexpr(x, :var"hygienic-scope"))
+
             newx = macroexpand_with_err_handling(state, x)
 
             # if any error happened during macro expansion, bail out now and continue

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1945,6 +1945,16 @@ end
     end
 end
 
+function eval_replaced_test_macro(mod::Module, ex::Expr)
+    return Core.eval(mod, JET.replace_test_macrocalls(ex, mod))
+end
+
+function has_globalref(@nospecialize(x), mod::Module, name::Symbol)
+    x isa GlobalRef && return x.mod === mod && x.name === name
+    x isa Expr || return false
+    return any(arg -> has_globalref(arg, mod, name), x.args)
+end
+
 # in this e2e test suite, we just check usage of test macros doesn't lead to (false positive)
 # top-level errors (e.g. world age, etc.)
 # TODO
@@ -1953,6 +1963,121 @@ end
 @testset "@test macros" begin
     vmod = Module()
     Core.eval(vmod, :(using Test))
+
+    @testset "lightweight replacements" begin
+        let mod = Module()
+            Core.eval(mod, :(using Test))
+
+            @test eval_replaced_test_macro(mod, :(@test true)) === nothing
+            @test eval_replaced_test_macro(mod, :(@test false)) === nothing
+            @test eval_replaced_test_macro(mod, :(@test error("x"))) === nothing
+            @test eval_replaced_test_macro(mod, :(Test.@test true)) === nothing
+
+            @test eval_replaced_test_macro(mod, :(@test 1 ≈ 1 atol=0.1)) === nothing
+            @test eval_replaced_test_macro(mod, :(@test true broken=true)) === nothing
+            @test eval_replaced_test_macro(mod, :(@test false broken=true)) === nothing
+
+            Core.eval(mod, :(const test_ran = Ref(false)))
+            skipped = eval_replaced_test_macro(mod, :(@test (test_ran[] = true) skip=true))
+            @test skipped === nothing
+            test_ran = @invokelatest getglobal(mod, :test_ran)
+            @test !test_ran[]
+
+            @test eval_replaced_test_macro(mod, :(@test_broken false)) === nothing
+            @test eval_replaced_test_macro(mod, :(@test_skip error("not evaluated"))) === nothing
+            @test eval_replaced_test_macro(mod, :(@test_throws ErrorException error("x"))) === nothing
+            @test eval_replaced_test_macro(mod, :(@test_throws "x" error("x"))) === nothing
+            @test eval_replaced_test_macro(mod, :(@test_throws ArgumentError error("x"))) === nothing
+            @test eval_replaced_test_macro(mod, :(@test_throws ErrorException 42)) === nothing
+
+            @test eval_replaced_test_macro(mod, :(@test_logs (:info, "message") 42)) == 42
+            Core.eval(mod, :(const logged_value = Ref(0)))
+            @test eval_replaced_test_macro(mod, :(@test_logs logged_value[] = 42)) == 42
+            logged_value = @invokelatest getglobal(mod, :logged_value)
+            @test logged_value[] == 42
+            @test eval_replaced_test_macro(mod, :(@test_warn "warning" 42)) == 42
+            @test eval_replaced_test_macro(mod, :(@test_nowarn 42)) == 42
+            @test eval_replaced_test_macro(mod, :(@test_deprecated 42)) == 42
+            @test eval_replaced_test_macro(mod, :(@inferred identity(42))) == 42
+
+            testset = eval_replaced_test_macro(mod, quote
+                @testset "scope" begin
+                    local_only = 1
+                    @test local_only == 1
+                    @testset "nested" begin
+                        @test local_only == 1
+                    end
+                end
+            end)
+            @test testset === nothing
+            @test !isdefinedglobal(mod, :local_only)
+
+            Core.eval(mod, :(const description_ran = Ref(false)))
+            eval_replaced_test_macro(mod, quote
+                @testset "scope $(description_ran[] = true)" begin
+                    @test true
+                end
+            end)
+            description_ran = @invokelatest getglobal(mod, :description_ran)
+            @test description_ran[]
+
+            Core.eval(mod, :(const loop_values = Int[]))
+            eval_replaced_test_macro(mod, quote
+                @testset "i=$i" for i in 1:2
+                    push!(loop_values, i)
+                    @test i > 0
+                end
+            end)
+            loop_values = @invokelatest getglobal(mod, :loop_values)
+            @test loop_values == [1, 2]
+        end
+
+        let mod = Module()
+            Core.eval(mod, :(using Test))
+            ex = JET.replace_test_macrocalls(quote
+                @testset "nested replacement" begin
+                    @test true
+                    @test_throws ErrorException error("x")
+                end
+            end, mod)
+            expanded = macroexpand(mod, ex)
+            @test has_globalref(expanded, Base, :inferencebarrier)
+            @test !has_globalref(expanded, Test, :do_test)
+            @test !has_globalref(expanded, Test, :do_test_throws)
+        end
+
+        let mod = Module()
+            Core.eval(mod, :(macro test(ex); :(99); end))
+            ex = JET.replace_test_macrocalls(:(@test true), mod)
+            @test Core.eval(mod, ex) == 99
+        end
+
+        let mod = Module()
+            Core.eval(mod, :(using Test))
+            Core.eval(mod, :(macro preserve(ex); QuoteNode(ex); end))
+            ex = JET.replace_test_macrocalls(:(@preserve @test true), mod)
+            preserved = Core.eval(mod, ex)
+            @test preserved isa Expr
+            @test preserved.head === :macrocall
+        end
+    end
+
+    @testset "testset statement order" begin
+        let res = @analyze_toplevel context = vmod virtualize = false begin
+                consume_test_closure(f::Function) = nothing
+                @testset "local type annotation" begin
+                    Typ = Any
+                    for _ = 1:2
+                        Typ = Tuple{Typ}
+                    end
+                    consume_test_closure() do x::Typ
+                        x
+                    end
+                end
+            end
+            @test isempty(res.res.toplevel_error_reports)
+        end
+    end
 
     let # @test
         res = @analyze_toplevel context = vmod virtualize = false begin
@@ -2053,6 +2178,14 @@ end
             @testset "JET example" begin
                 @test sum("julia") == "julia" # actual errors
             end
+        end
+        @test isempty(res.res.toplevel_error_reports)
+        test_sum_over_string(res)
+    end
+
+    let # nested @test in a value position
+        res = @analyze_toplevel context = vmod virtualize = false begin
+            result = @test sum("julia") == "julia"
         end
         @test isempty(res.res.toplevel_error_reports)
         test_sum_over_string(res)


### PR DESCRIPTION
`report_file` spent much of its time on test files expanding and inferring Test.jl reporting machinery instead of user expressions.

The virtual process now recognizes Test.jl macro calls before macro expansion and replaces them with lightweight AST. The replacements preserve relevant argument evaluation and testset ordering while omitting Test.jl result construction and recording.

The replacements intentionally approximate Test.jl semantics. Result-like macros return an opaque synthetic value, while wrapper macros preserve the underlying runtime value. Recognized nested Test macros are rewritten recursively, and unrelated macros remain untouched.

On `Struct2JSONSchema/test/runtests.jl`
(on abap34/Struct2JSONSchema.jl#31), warm `report_file` time with the Struct2JSONSchema environment fell from 6.83 seconds to 4.59 seconds, a 33% reduction. Inference reports increased from 18 to 20 because more user code became visible.

A synthetic warm benchmark on Julia 1.12.6 with one thread compared this change with its parent revision over seven post-warm-up runs per input. Median `report_file` times fell from 4.124 to 0.0175 seconds for 100 standalone `@test` calls (235.6x), from 4.471 to 0.0251 seconds for 100 testsets with one test each (177.9x), and from 0.120 to 0.0103 seconds for one testset with 100 tests (11.7x). For 300 mixed tolerance, `@test_throws`, and `@test_skip` calls, time fell from 4.336 to 0.0563 seconds (77.0x).

Focused tests cover supported macros, nested and value-position calls, binding resolution, and testset scope and statement ordering.