### PR TITLE
toplevel: Isolate conditional closures in Test expressions

### DIFF
--- a/src/toplevel/virtualprocess.jl
+++ b/src/toplevel/virtualprocess.jl
@@ -1142,6 +1142,112 @@ end
 hide_test_replacement_value(@nospecialize(value)) =
     Expr(:call, GlobalRef(Base, :inferencebarrier), value)
 
+function is_anonymous_test_function(@nospecialize(ex))
+    isexpr(ex, :->, 2) && return true
+    isexpr(ex, :function, 2) || return false
+    sig = first(ex.args)
+    while isexpr(sig, (:(::), :where)) && !isempty(sig.args)
+        sig = first(sig.args)
+    end
+    return isexpr(sig, :tuple)
+end
+
+# Calls and access syntax preserve their operands through ordinary closure capture.
+const THUNK_SAFE_TEST_CALL_HEADS = (:call, :ref, :., :parameters, :kw, :...)
+
+# These heads do not introduce bindings by themselves and are safe when all children are safe.
+const THUNK_SAFE_TEST_CONTROL_HEADS = (:block, :&&, :||, :if, :comparison)
+
+# Literal construction does not observe or modify the enclosing lexical scope.
+const THUNK_SAFE_TEST_LITERAL_HEADS = (
+    :tuple, :vect, :vcat, :hcat, :ncat, :typed_vcat, :typed_hcat, :typed_ncat,
+    :row, :nrow, :string,
+)
+
+# `where` binds type variables only within its type expression; these heads do not define
+# names in the surrounding scope.
+const THUNK_SAFE_TEST_TYPE_HEADS = (:curly, :(::), :where)
+
+# Virtual processing concretizes top-level closure definitions so that later inference can
+# use their methods. When a closure is defined in a conditional branch of a test expression,
+# realizing that definition also selects the preceding condition for concrete execution.
+# Outlining the test expression into a zero-argument function instead leaves its nested
+# closures inside an ordinary method body, where inference can analyze the control flow
+# without concretely executing the condition.
+#
+# Introducing a function scope is only safe for expression forms whose enclosing-scope
+# behavior is implemented by closure capture. In particular, bindings, named definitions,
+# control transfers, and unknown macro syntax must remain inline, so this is intentionally a
+# positive list of reads, calls, expression-level control flow, and anonymous functions.
+function is_test_expression_thunk_safe(@nospecialize(ex))
+    ex isa Expr || return true
+    isexpr(ex, (:quote, :inert)) && return true
+    is_anonymous_test_function(ex) && return true
+    if isexpr(ex, :do, 2)
+        call, closure = ex.args
+        return is_test_expression_thunk_safe(call) &&
+            is_anonymous_test_function(closure)
+    end
+    (ex.head ∈ THUNK_SAFE_TEST_CALL_HEADS ||
+     ex.head ∈ THUNK_SAFE_TEST_CONTROL_HEADS ||
+     ex.head ∈ THUNK_SAFE_TEST_LITERAL_HEADS ||
+     ex.head ∈ THUNK_SAFE_TEST_TYPE_HEADS) || return false
+    return all(is_test_expression_thunk_safe, ex.args)
+end
+
+# Unconditional anonymous functions do not force unrelated control flow to be concretized,
+# so only detect definitions nested under short-circuit or branch semantics.
+function has_conditionally_defined_test_function(
+        @nospecialize(ex), conditional::Bool = false)
+    ex isa Expr || return false
+    isexpr(ex, (:quote, :inert)) && return false
+    is_anonymous_test_function(ex) && return conditional
+    if isexpr(ex, :do, 2)
+        call, closure = ex.args
+        return has_conditionally_defined_test_function(call, conditional) ||
+            conditional && is_anonymous_test_function(closure)
+    elseif isexpr(ex, (:&&, :||), 2)
+        return has_conditionally_defined_test_function(first(ex.args), conditional) ||
+            has_conditionally_defined_test_function(last(ex.args), true)
+    elseif isexpr(ex, :if)
+        isempty(ex.args) && return false
+        has_conditionally_defined_test_function(first(ex.args), conditional) && return true
+        return any(ex.args[2:end]) do @nospecialize(branch)
+            has_conditionally_defined_test_function(branch, true)
+        end
+    elseif isexpr(ex, :comparison)
+        for (i, arg) in enumerate(ex.args)
+            has_conditionally_defined_test_function(arg, conditional || i ≥ 5) &&
+                return true
+        end
+        return false
+    end
+    return any(arg -> has_conditionally_defined_test_function(arg, conditional), ex.args)
+end
+
+# `conditionally_evaluated` accounts for control flow introduced by the replacement itself,
+# such as the `if skip` surrounding the tested expression for `@test skip=...`.
+function should_wrap_test_expression_in_thunk(
+        @nospecialize(ex); conditionally_evaluated::Bool = false)
+    return is_test_expression_thunk_safe(ex) &&
+        has_conditionally_defined_test_function(ex, conditionally_evaluated)
+end
+
+function wrap_test_expression_in_thunk(@nospecialize(ex))
+    thunk = gensym(:test_expression)
+    ret = quote
+        let $thunk = () -> $ex
+            $thunk()
+        end
+    end
+    return Base.remove_linenums!(ret)
+end
+
+function maybe_wrap_test_expression_in_thunk(@nospecialize(ex))
+    should_wrap_test_expression_in_thunk(ex) || return ex
+    return wrap_test_expression_in_thunk(ex)
+end
+
 function discard_test_expression_value(@nospecialize(ex))
     ret = quote
         try
@@ -1182,17 +1288,34 @@ function replace_test(@nospecialize(ex), kws::Vector{Any})
     catch
         return nothing
     end
-    test_expr = discard_test_expression_value(ex)
     if !isempty(skip)
-        ret = quote
-            if $(only(skip))
-                $(hide_test_replacement_value(nothing))
-            else
-                $test_expr
+        skip = only(skip)
+        if should_wrap_test_expression_in_thunk(ex; conditionally_evaluated = true)
+            thunk = gensym(:test_expression)
+            test_expr = discard_test_expression_value(Expr(:call, thunk))
+            ret = quote
+                let $thunk = () -> $ex
+                    if $skip
+                        $(hide_test_replacement_value(nothing))
+                    else
+                        $test_expr
+                    end
+                end
+            end
+        else
+            test_expr = discard_test_expression_value(ex)
+            ret = quote
+                if $skip
+                    $(hide_test_replacement_value(nothing))
+                else
+                    $test_expr
+                end
             end
         end
         return Base.remove_linenums!(ret)
-    elseif !isempty(broken)
+    end
+    test_expr = discard_test_expression_value(maybe_wrap_test_expression_in_thunk(ex))
+    if !isempty(broken)
         return Expr(:block, only(broken), test_expr)
     end
     return test_expr
@@ -1211,7 +1334,7 @@ function replace_test_macrocall(name::Symbol, args::Vector{Any})
         catch
             return nothing
         end
-        return discard_test_expression_value(ex)
+        return discard_test_expression_value(maybe_wrap_test_expression_in_thunk(ex))
     elseif name === Symbol("@test_skip")
         isempty(exs) && return nothing
         ex, kws = first(exs), exs[2:end]
@@ -1223,23 +1346,31 @@ function replace_test_macrocall(name::Symbol, args::Vector{Any})
         return hide_test_replacement_value(nothing)
     elseif name === Symbol("@test_throws")
         length(exs) == 2 || return nothing
-        return discard_test_expression_value(Expr(:block, exs...))
+        ex = maybe_wrap_test_expression_in_thunk(Expr(:block, exs...))
+        return discard_test_expression_value(ex)
     elseif name === Symbol("@test_logs")
         isempty(exs) && return nothing
         values = Any[macro_argument_value(ex) for ex in exs[1:end-1]]
-        push!(values, last(exs))
+        push!(values, maybe_wrap_test_expression_in_thunk(last(exs)))
         return preserve_test_expression_value(values...)
     elseif name === Symbol("@test_warn")
         length(exs) == 2 || return nothing
+        exs = Any[exs...]
+        exs[end] = maybe_wrap_test_expression_in_thunk(last(exs))
         return preserve_test_expression_value(exs...)
     elseif name === Symbol("@test_nowarn")
         length(exs) == 1 || return nothing
-        return preserve_test_expression_value(exs...)
+        return preserve_test_expression_value(
+            maybe_wrap_test_expression_in_thunk(only(exs)))
     elseif name === Symbol("@test_deprecated")
         1 ≤ length(exs) ≤ 2 || return nothing
+        exs = Any[exs...]
+        exs[end] = maybe_wrap_test_expression_in_thunk(last(exs))
         return preserve_test_expression_value(exs...)
     elseif name === Symbol("@inferred")
         1 ≤ length(exs) ≤ 2 || return nothing
+        exs = Any[exs...]
+        exs[end] = maybe_wrap_test_expression_in_thunk(last(exs))
         return preserve_test_expression_value(exs...)
     elseif name === Symbol("@testset")
         isempty(exs) && return nothing
@@ -1749,6 +1880,13 @@ function select_statements(mod::Module, src::CodeInfo, idxs::Int...)
     return concretize
 end
 
+# TODO: Compiler-generated closure setup is selected here like user-visible definitions.
+# For a branch-local closure, control-dependency selection can therefore execute preceding
+# user conditions merely to materialize its type and method for inference. A general fix
+# should distinguish definition-only materialization from runtime concretization: materialize
+# closure setup without selecting enclosing control flow when its signature and setup have no
+# runtime-value dependencies, and retain the current control-sensitive behavior otherwise.
+# `maybe_wrap_test_expression_in_thunk` is a Test-specific mitigation until then.
 function select_direct_requirement!(concretize, stmts, edges)
     for (idx, stmt) in enumerate(stmts)
         if (LoweredCodeUtils.ismethod(stmt) ||    # don't abstract away method definitions

--- a/test/toplevel/test_virtualprocess.jl
+++ b/test/toplevel/test_virtualprocess.jl
@@ -1977,6 +1977,46 @@ end
             @test eval_replaced_test_macro(mod, :(@test true broken=true)) === nothing
             @test eval_replaced_test_macro(mod, :(@test false broken=true)) === nothing
 
+            Core.eval(mod, :(const conditional_closure_calls = Ref(0)))
+            conditional_closure_calls = @invokelatest getglobal(mod, :conditional_closure_calls)
+            conditional_closure = quote
+                @test true && any((1,)) do _
+                    conditional_closure_calls[] += 1
+                    true
+                end
+            end
+            @test eval_replaced_test_macro(mod, conditional_closure) === nothing
+            @test conditional_closure_calls[] == 1
+
+            for (skip, expected_calls) in ((true, 0), (false, 1))
+                conditional_closure_calls[] = 0
+                conditional_closure = quote
+                    @test any((1,)) do _
+                        conditional_closure_calls[] += 1
+                        true
+                    end skip=$skip
+                end
+                @test eval_replaced_test_macro(mod, conditional_closure) === nothing
+                @test conditional_closure_calls[] == expected_calls
+            end
+
+            # Keep this expression inline so `return` still targets the enclosing function,
+            # even though its conditional closure would otherwise make it a thunk candidate.
+            control_transfer = quote
+                function return_from_test()
+                    @test begin
+                        true && any((1,)) do _
+                            true
+                        end
+                        return 42
+                    end
+                    return 0
+                end
+            end
+            Core.eval(mod, JET.replace_test_macrocalls(control_transfer, mod))
+            return_from_test = @invokelatest getglobal(mod, :return_from_test)
+            @test @invokelatest(return_from_test()) == 42
+
             Core.eval(mod, :(const test_ran = Ref(false)))
             skipped = eval_replaced_test_macro(mod, :(@test (test_ran[] = true) skip=true))
             @test skipped === nothing
@@ -2032,6 +2072,74 @@ end
             @test loop_values == [1, 2]
         end
 
+        let ex = :(pred(x) && any(items) do item
+                    check(item, x)
+                end)
+            @test JET.is_test_expression_thunk_safe(ex)
+            @test JET.should_wrap_test_expression_in_thunk(ex)
+        end
+
+        let ex = :(any(items) do item
+                    check(item)
+                end)
+            @test JET.is_test_expression_thunk_safe(ex)
+            @test !JET.should_wrap_test_expression_in_thunk(ex)
+        end
+
+        let ex = :(pred() && function (value)
+                    assigned_in_function = compute_value(value)
+                    return assigned_in_function
+                end)
+            @test JET.is_test_expression_thunk_safe(ex)
+            @test JET.should_wrap_test_expression_in_thunk(ex)
+        end
+
+        for ex in (:(pred() || any(items) do item
+                            check(item)
+                        end),
+                   :(if pred()
+                        any(items) do item
+                            check(item)
+                        end
+                    else
+                        false
+                    end),
+                   :(lower() < middle() < (any(items) do item
+                            check(item)
+                        end)),
+                   :(pred(Tuple{T} where T) && any(items) do item
+                            check(item)
+                        end))
+            @test JET.is_test_expression_thunk_safe(ex)
+            @test JET.has_conditionally_defined_test_function(ex)
+            @test JET.should_wrap_test_expression_in_thunk(ex)
+        end
+
+        for ex in (:(begin
+                        value = compute_value()
+                        pred() && any(items) do item
+                            check(item, value)
+                        end
+                    end),
+                   :(begin
+                        @unknown_test_helper check(value)
+                        pred() && any(items) do item
+                            check(item)
+                        end
+                    end),
+                   :(begin
+                        function check(value)
+                            return value
+                        end
+                        pred() && any(items) do item
+                            check(item)
+                        end
+                    end))
+            @test JET.has_conditionally_defined_test_function(ex)
+            @test !JET.is_test_expression_thunk_safe(ex)
+            @test !JET.should_wrap_test_expression_in_thunk(ex)
+        end
+
         let mod = Module()
             Core.eval(mod, :(using Test))
             ex = JET.replace_test_macrocalls(quote
@@ -2059,6 +2167,22 @@ end
             preserved = Core.eval(mod, ex)
             @test preserved isa Expr
             @test preserved.head === :macrocall
+        end
+    end
+
+    @testset "conditional closures" begin
+        let res = @analyze_toplevel context = vmod virtualize = false begin
+                test_macro_items = [1]
+                @test_broken any(test_macro_items) do _
+                    undefined_in_broken_test
+                end && any(test_macro_items) do _
+                    false
+                end
+            end
+            @test isempty(res.res.toplevel_error_reports)
+            @test any(res.res.inference_error_reports) do report
+                is_global_undef_var(report, :undefined_in_broken_test)
+            end
         end
     end
 


### PR DESCRIPTION
Test.jl macro replacements left anonymous functions in top-level lowered code. For example:

    @test_broken any(items) do item
        first_check(item)
    end && any(items) do item
        second_check(item)
    end

The closure in the right-hand branch became a concrete definition requirement. Reaching it could concretely execute the first `any` call, causing side effects or top-level errors instead of inference reports.

This change outlines only thunk-safe tested expressions containing conditionally defined anonymous functions into zero-argument functions. Calls, expression-level control flow, literals, and type expressions are accepted by an explicit whitelist. Bindings, named definitions, control transfers, and unknown macros remain inline. The `skip=` path defines the thunk outside its generated branch and invokes it only when enabled.

A minimal reproducer now reports an undefined global in the first closure through inference instead of concrete top-level execution. The focused `@test macros` tests pass 96/96.

This is a Test-specific mitigation for a general virtual-process limitation. A future fix should distinguish compiler-generated closure materialization from runtime concretization during statement selection. It can avoid selecting enclosing control flow when closure setup has no runtime-value dependencies, while retaining current behavior otherwise.

Warm median timings were neutral versus disabling the wrapping: 4.44 seconds versus 4.57 seconds for Struct2JSONSchema, which had no eligible expressions, and 20.83 seconds versus 21.18 seconds for JET's test file, which had two.